### PR TITLE
fix: eligibility button color in wallet panel

### DIFF
--- a/src/components/WalletBalance.tsx
+++ b/src/components/WalletBalance.tsx
@@ -343,8 +343,7 @@ export default function WalletBalance() {
                     variant="link"
                     href={nftMintUrl}
                     target="_blank"
-                    disabled={!!nftBalance && nftBalance > 0 ? true : false}
-                    className="bg-info text-light text-decoration-none"
+                    className="bg-primary text-light text-decoration-none"
                   >
                     Get the NFT
                   </Button>


### PR DESCRIPTION
Keeps the eligibility button in the wallet panel enabled with the primary color as background