### PR TITLE
feat: zero out units of flow splitter members not present in csv

### DIFF
--- a/src/app/flow-splitters/[chainId]/[poolId]/admin/admin.tsx
+++ b/src/app/flow-splitters/[chainId]/[poolId]/admin/admin.tsx
@@ -372,12 +372,7 @@ export default function Admin(props: AdminProps) {
 
       const validAdmins = adminsEntry.filter(
         (adminEntry) =>
-          adminEntry.validationError === "" &&
-          adminEntry.address !== "" &&
-          !poolAdmins.some(
-            (admin: { address: string }) =>
-              admin.address === adminEntry.address,
-          ),
+          adminEntry.validationError === "" && adminEntry.address !== "",
       );
       const validMembers = membersEntry.filter(
         (memberEntry) =>

--- a/src/app/flow-splitters/flow-splitters.tsx
+++ b/src/app/flow-splitters/flow-splitters.tsx
@@ -126,16 +126,16 @@ export default function FlowSplitters(props: FlowSplittersProps) {
 
   useEffect(() => {
     (async () => {
-      if (!flowSplitterAdminQueryRes?.pools || !superfluidQueryRes?.account) {
+      if (!flowSplitterAdminQueryRes?.pools) {
         return;
       }
 
       const pools = [];
-      const sfPoolMemberships = superfluidQueryRes.account.poolMemberships;
+      const sfPoolMemberships = superfluidQueryRes?.account?.poolMemberships;
       const flowSplitterPoolMemberships = (
         await getFlowSplitterMemberships({
           variables: {
-            poolAddresses: sfPoolMemberships.map(
+            poolAddresses: sfPoolMemberships?.map(
               (m: { pool: { id: string } }) => m.pool.id,
             ),
           },
@@ -147,7 +147,7 @@ export default function FlowSplitters(props: FlowSplittersProps) {
           (pool: { poolAddress: string }) =>
             pool.poolAddress === poolAdmin.poolAddress,
         );
-        const poolMembership = sfPoolMemberships.find(
+        const poolMembership = sfPoolMemberships?.find(
           (membership: { pool: { id: string } }) =>
             membership.pool.id === flowSplitterMember?.poolAddress,
         );
@@ -188,7 +188,7 @@ export default function FlowSplitters(props: FlowSplittersProps) {
             continue;
           }
 
-          const poolMembership = sfPoolMemberships.find(
+          const poolMembership = sfPoolMemberships?.find(
             (membership: { pool: { id: string } }) =>
               membership.pool.id === flowSplitterPool?.poolAddress,
           );


### PR DESCRIPTION
When a user uploads a .csv on the flow splitter admin page compare the diff between the new list and the existing pool members and zero out the ones not present