### PR TITLE
fix: flow splitters current flow rate input field update

### DIFF
--- a/src/app/flow-splitters/components/OpenFlow.tsx
+++ b/src/app/flow-splitters/components/OpenFlow.tsx
@@ -311,7 +311,7 @@ export default function OpenFlow(props: OpenFlowProps) {
   ]);
 
   useEffect(() => {
-    if (address && flowRateToReceiver && !areTransactionsLoading) {
+    if (address && flowRateToReceiver) {
       const currentStreamValue = roundWeiAmount(
         BigInt(flowRateToReceiver) *
           BigInt(fromTimeUnitsToSeconds(1, unitOfTime[TimeInterval.MONTH])),
@@ -321,7 +321,7 @@ export default function OpenFlow(props: OpenFlowProps) {
       setAmountPerTimeInterval(currentStreamValue);
       setNewFlowRate(BigInt(flowRateToReceiver));
     }
-  }, [address, flowRateToReceiver, areTransactionsLoading]);
+  }, [address, flowRateToReceiver]);
 
   useEffect(() => {
     const liquidationEstimate = calcLiquidationEstimate(newFlowRate);


### PR DESCRIPTION
Waits for the new flow rate value from the subgraph before updating the amount input field in the flow distribution view of flow splitters

fixes #57 