### PR TITLE
feat: add pool connection modal for unconnected grantees in flow councils

### DIFF
--- a/src/app/flow-councils/hooks/gdaPoolQuery.ts
+++ b/src/app/flow-councils/hooks/gdaPoolQuery.ts
@@ -5,6 +5,7 @@ import { getApolloClient } from "@/lib/apollo";
 const SUPERFLUID_QUERY = gql`
   query GDAPoolQuery($gdaPool: String) {
     pool(id: $gdaPool) {
+      id
       flowRate
       adjustmentFlowRate
       totalAmountFlowedDistributedUntilUpdatedAt
@@ -17,6 +18,7 @@ const SUPERFLUID_QUERY = gql`
         units
         updatedAtTimestamp
         totalAmountReceivedUntilUpdatedAt
+        isConnected
       }
       poolDistributors {
         account {


### PR DESCRIPTION
Adds a modal shown when the user is a grantee unconnected to the distribution pool prompting to connect