### PR TITLE
fix: build transactions array before effect in flow councils pool distribution funding

### DIFF
--- a/src/app/flow-councils/components/DistributionPoolDetails.tsx
+++ b/src/app/flow-councils/components/DistributionPoolDetails.tsx
@@ -160,7 +160,11 @@ export default function DistributionPoolDetails(
                     : totalMonthlyStream - monthlyStreamToReceiver < 100
                       ? 2
                       : 1,
-            }).format(totalMonthlyStream - monthlyStreamToReceiver)}
+            }).format(
+              totalMonthlyStream - monthlyStreamToReceiver > 0
+                ? totalMonthlyStream - monthlyStreamToReceiver
+                : 0,
+            )}
           </Badge>
         </Stack>
         <Stack direction="vertical" gap={1} className="w-25">


### PR DESCRIPTION
Builds the transactions array before the effects run in Flow Councils pool distribution funding so that if the wrapping step is skipped the submit button doesn't show a transaction too much for a bit