### PR TITLE
fix: transaction success check

### DIFF
--- a/src/app/flow-councils/flow-councils.tsx
+++ b/src/app/flow-councils/flow-councils.tsx
@@ -306,7 +306,7 @@ export default function FlowCouncils(props: FlowCouncilsProps) {
     token?: Token;
   }) => {
     const [nameRef, { clampedText }] = useClampText({
-      text: council.metadata.name,
+      text: council.metadata?.name,
       ellipsis: "...",
       lines: 3,
     });


### PR DESCRIPTION
Checks the transaction receipt for a success status before writing to the database in Flow Council applications review page