### PR TITLE
feat: add default metadata to councils

### DIFF
--- a/src/app/flow-councils/[chainId]/[councilId]/flow-council.tsx
+++ b/src/app/flow-councils/[chainId]/[councilId]/flow-council.tsx
@@ -207,8 +207,8 @@ export default function FlowCouncil({
         }}
       >
         <RoundBanner
-          name={councilMetadata.name}
-          description={councilMetadata.description}
+          name={councilMetadata.name ?? "Flow Council"}
+          description={councilMetadata.description ?? "N/A"}
           chainId={chainId}
           distributionTokenInfo={token}
           gdaPool={gdaPool}

--- a/src/app/flow-councils/components/Sidebar.tsx
+++ b/src/app/flow-councils/components/Sidebar.tsx
@@ -64,20 +64,28 @@ function Sidebar() {
         });
 
         for (const council of councilsQueryRes.councils) {
-          promises.push(
-            (async () => {
-              const metadataRes = await verifiedFetch(
-                `ipfs://${council.metadata}`,
-              );
-              const metadata = await metadataRes.json();
+          if (council.metadata) {
+            promises.push(
+              (async () => {
+                const metadataRes = await verifiedFetch(
+                  `ipfs://${council.metadata}`,
+                );
+                const metadata = await metadataRes.json();
 
-              councils.push({
-                id: council.id,
-                name: metadata.name,
-                description: metadata.description,
-              });
-            })(),
-          );
+                councils.push({
+                  id: council.id,
+                  name: metadata.name,
+                  description: metadata.description,
+                });
+              })(),
+            );
+          } else {
+            councils.push({
+              id: council.id,
+              name: "Flow Council",
+              description: "N/A",
+            });
+          }
         }
 
         await Promise.all(promises);

--- a/src/app/flow-councils/flow-councils.tsx
+++ b/src/app/flow-councils/flow-councils.tsx
@@ -233,7 +233,7 @@ export default function FlowCouncils(props: FlowCouncilsProps) {
           pool: council.pool,
           isConnected: poolMembership?.isConnected ?? false,
           units: BigInt(poolMembership?.units ?? 0),
-          metadata,
+          metadata: metadata ?? { name: "Flow Council", description: "N/A" },
         });
       };
 
@@ -306,7 +306,7 @@ export default function FlowCouncils(props: FlowCouncilsProps) {
     token?: Token;
   }) => {
     const [nameRef, { clampedText }] = useClampText({
-      text: council.metadata.name,
+      text: council.metadata?.name,
       ellipsis: "...",
       lines: 3,
     });

--- a/src/app/flow-councils/grantee/grantee.tsx
+++ b/src/app/flow-councils/grantee/grantee.tsx
@@ -204,8 +204,8 @@ export default function Grantee(props: GranteeProps) {
         const metadata = await metadataRes.json();
 
         setCouncilMetadata({
-          name: metadata.name,
-          description: metadata.description,
+          name: metadata?.name ?? "Flow Council",
+          description: metadata?.description ?? "N/A",
         });
       } catch (err) {
         console.error(err);

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -13,7 +13,7 @@ export const SUPERVISUAL_BASE_URL = "https://graph.flowstate.network";
 export const OG_DEFAULT_IMAGE_URL =
   "https://opengraph.b-cdn.net/production/images/46f99288-6ea8-4768-af0c-4b716bc1bf02.png?token=_GzabZBVzFhqh2_MDikORxOyaHHx9NygbVgatN7KFHY&height=630&width=1200&expires=33264419569";
 export const IPFS_GATEWAYS = [
-  "https://gateway.pinata.cloud",
+  "https://silver-definite-penguin-424.mypinata.cloud",
   "https://nftstorage.link",
   "https://storry.tv",
   "https://4everland.io",


### PR DESCRIPTION
Adds default name and description to Flow Councils to show when they don't have metadata