### PR TITLE
fix: update SUP prompt with $ minimum

### DIFF
--- a/src/app/flow-guilds/components/OpenFlow.tsx
+++ b/src/app/flow-guilds/components/OpenFlow.tsx
@@ -702,7 +702,7 @@ export default function OpenFlow(props: OpenFlowProps) {
           <Card.Link href="https://claim.superfluid.org/claim" target="_blank">
             earn $SUP
           </Card.Link>
-          ? Claim your reward stream increase daily.
+          ? Claim your reward stream increase daily. (min. $1 cumulative volume per token to qualify)
         </Card.Text>
       </Stack>
       <Stack direction="vertical" gap={2} className="my-4">


### PR DESCRIPTION
Updates the user prompt for SUP rewards to include the $1 minimum volume threshold