### PR TITLE
fix: flow splitters checkout balance validation color

### DIFF
--- a/src/app/flow-guilds/components/OpenFlow.tsx
+++ b/src/app/flow-guilds/components/OpenFlow.tsx
@@ -768,13 +768,16 @@ export default function OpenFlow(props: OpenFlowProps) {
             className="position-relative justify-content-center mt-1"
           >
             <Card.Text
-              className={`m-0 ${!hasSufficientSuperTokenBalance ? "text-danger" : "text-info"}`}
+              className={`m-0 ${!hasSufficientSuperTokenBalance && newFlowRate ? "text-danger" : "text-info"}`}
               style={{
                 fontSize: "0.8rem",
               }}
             >
               {token.symbol}:{" "}
-              {formatNumber(Number(formatEther(superTokenBalance)))}
+              {formatNumber(Number(formatEther(superTokenBalance)))}{" "}
+              {!hasSufficientSuperTokenBalance && newFlowRate && (
+                <>(Wrap below)</>
+              )}
             </Card.Text>
             {!isSuperTokenPure &&
               !showWrappingStep &&
@@ -931,10 +934,8 @@ export default function OpenFlow(props: OpenFlowProps) {
                 height={16}
               />
             </OverlayTrigger>
-            <Card.Text className="m-0 fs-6">Wrap more by</Card.Text>
-            <Card.Text
-              className={`m-0 ms-1 fs-6 ${isLiquidationClose ? "text-danger" : ""}`}
-            >
+            <Card.Text className="m-0 fs-6 fw-bold">
+              Wrap more by{" "}
               {dayjs.unix(liquidationEstimate).format("MMMM D, YYYY")}
             </Card.Text>
           </Stack>

--- a/src/app/flow-splitters/components/OpenFlow.tsx
+++ b/src/app/flow-splitters/components/OpenFlow.tsx
@@ -647,7 +647,7 @@ export default function OpenFlow(props: OpenFlowProps) {
               className="position-relative justify-content-center mt-1"
             >
               <Card.Text
-                className={`m-0 ${!hasSufficientSuperTokenBalance ? "text-danger" : "text-info"}`}
+                className={`m-0 ${!hasSufficientSuperTokenBalance && Number(amountPerTimeInterval) > 0 ? "text-danger" : "text-info"}`}
                 style={{
                   fontSize: "0.8rem",
                 }}
@@ -839,10 +839,8 @@ export default function OpenFlow(props: OpenFlowProps) {
                     height={16}
                   />
                 </OverlayTrigger>
-                <Card.Text className="m-0 fs-6">Wrap more by</Card.Text>
-                <Card.Text
-                  className={`m-0 ms-1 fs-6 ${isLiquidationClose ? "text-danger" : ""}`}
-                >
+                <Card.Text className="m-0 fs-6 fw-bold">
+                  Wrap more by{" "}
                   {dayjs.unix(liquidationEstimate).format("MMMM D, YYYY")}
                 </Card.Text>
               </Stack>


### PR DESCRIPTION
Keeps the color of the balance until an amount is entered in the Flow Splitters checkout