### PR TITLE
fix: grantee card monthly flow spacing

### DIFF
--- a/src/app/explore/explore.tsx
+++ b/src/app/explore/explore.tsx
@@ -64,7 +64,8 @@ const SQF_ADDRESSES = {
 };
 
 export default function Explore(props: ExploreProps) {
-  const { coreInflow, greenpillInflow, guildGuildInflow, chonesGuildInflow } = props;
+  const { coreInflow, greenpillInflow, guildGuildInflow, chonesGuildInflow } =
+    props;
 
   const { isMobile, isTablet, isSmallScreen, isMediumScreen, isBigScreen } =
     useMediaQuery();
@@ -251,7 +252,7 @@ export default function Explore(props: ExploreProps) {
               tokenSymbol="ETHx"
               link="/flow-guilds/guild-guild"
             />
-              <RoundCard
+            <RoundCard
               name="Chones Guild"
               image="/chones-guild.svg"
               roundType="Flow Guild"

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -36,7 +36,7 @@ const FLOW_GUILD_ADDRESSES = {
     safeAddress: "0x29f4c46e04b9d35724af08f314d936f44f52527c",
     token: "0xe6c8d111337d0052b9d88bf5d7d55b7f8385acd3",
   },
-    ["chonesguild"]: {
+  ["chonesguild"]: {
     safeAddress: "0xc40f7733f0ea30bb6f797c88444769e00775d021",
     token: "0xe6c8d111337d0052b9d88bf5d7d55b7f8385acd3",
   },
@@ -67,7 +67,7 @@ export default async function Page() {
       token: FLOW_GUILD_ADDRESSES["guild-guild"].token,
     },
   );
-    const chonesGuildQueryRes = await request<{ account: Account }>(
+  const chonesGuildQueryRes = await request<{ account: Account }>(
     networks.find((network) => network.id === arbitrum.id)!.superfluidSubgraph,
     FLOW_GUILD_QUERY,
     {

--- a/src/app/pool/components/Grantee.tsx
+++ b/src/app/pool/components/Grantee.tsx
@@ -155,12 +155,18 @@ export default function Grantee(props: GranteeProps) {
             <Card.Text as="small" className="m-0">
               {monthlyAllocation}
             </Card.Text>
-            <Card.Text as="small" className="m-0">
-              {allocationTokenInfo.symbol}
-            </Card.Text>
-            <Card.Text as="small" className="m-0">
-              /mo
-            </Card.Text>
+            <Stack
+              direction="horizontal"
+              gap={1}
+              className="flex-wrap justify-content-center"
+            >
+              <Card.Text as="small" className="m-0">
+                {allocationTokenInfo.symbol}
+              </Card.Text>
+              <Card.Text as="small" className="m-0">
+                /mo
+              </Card.Text>
+            </Stack>
           </Stack>
           <Stack direction="vertical" className="align-items-center w-33">
             <Card.Text as="small" className="m-0 fw-bold">
@@ -169,12 +175,18 @@ export default function Grantee(props: GranteeProps) {
             <Card.Text as="small" className="m-0">
               {monthlyMatching}
             </Card.Text>
-            <Card.Text as="small" className="m-0">
-              {matchingTokenInfo.symbol}
-            </Card.Text>
-            <Card.Text as="small" className="m-0">
-              /mo
-            </Card.Text>
+            <Stack
+              direction="horizontal"
+              gap={1}
+              className="flex-wrap justify-content-center"
+            >
+              <Card.Text as="small" className="m-0">
+                {matchingTokenInfo.symbol}
+              </Card.Text>
+              <Card.Text as="small" className="m-0">
+                /mo
+              </Card.Text>
+            </Stack>
           </Stack>
         </Stack>
       </Card.Body>


### PR DESCRIPTION
Wraps text of monthly flow in grantee card only for long token symbols