### PR TITLE
fix: flow splitter not found

### DIFF
--- a/src/app/flow-splitters/[chainId]/[poolId]/flow-splitter.tsx
+++ b/src/app/flow-splitters/[chainId]/[poolId]/flow-splitter.tsx
@@ -318,8 +318,8 @@ export default function FlowSplitter(props: FlowSplitterProps) {
           <span className="position-absolute top-50 start-50 translate-middle">
             <Spinner />
           </span>
-        ) : !network ? (
-          <p className="w-100 mt-5 fs-4 text-center">Pool Not Found</p>
+        ) : !network || !pool ? (
+          <p className="w-100 mt-5 fs-4 text-center">Flow Splitter Not Found</p>
         ) : (
           <>
             <h1 className="d-flex flex-column flex-sm-row align-items-sm-center overflow-hidden gap-sm-1 mt-5 mb-1">

--- a/src/app/flow-splitters/launch/launch.tsx
+++ b/src/app/flow-splitters/launch/launch.tsx
@@ -183,7 +183,7 @@ export default function Launch(props: LaunchProps) {
 
       const receipt = await publicClient.waitForTransactionReceipt({
         hash,
-        confirmations: 3,
+        confirmations: 5,
       });
       const poolId = parseEventLogs({
         abi: flowSplitterAbi,


### PR DESCRIPTION
Shows a "Flow Splitter Not Found" message when the subgraph responds with a null `pools`