### PR TITLE
feat: updates project info nav methods

### DIFF
--- a/src/app/flow-councils/components/GranteeCard.tsx
+++ b/src/app/flow-councils/components/GranteeCard.tsx
@@ -130,7 +130,7 @@ export default function Grantee(props: GranteeProps) {
   return (
     <>
       <Card
-        className="rounded-5 border border-4 border-dark overflow-hidden cursor-pointer shadow"
+        className="grantee-card rounded-5 border border-4 border-dark overflow-hidden cursor-pointer shadow"
         onClick={showGranteeDetails}
         style={{
           height: 430,

--- a/src/app/flow-councils/components/GranteeDetails.tsx
+++ b/src/app/flow-councils/components/GranteeDetails.tsx
@@ -228,7 +228,7 @@ export default function GranteeDetails(props: GranteeDetailsProps) {
             variant="link"
             href={`/projects/${id}`}
             target="_blank"
-            className="d-flex justify-content-center align-items-center gap-2 mt-2 px-10 py-4 rounded-4 bg-secondary text-light text-decoration-none fw-semi-bold"
+            className="d-flex justify-content-center align-items-center gap-2 mt-2 px-10 py-4 rounded-4 bg-primary text-light text-decoration-none fw-semi-bold"
           >
             <Image
               src="/open-new.svg"

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -369,3 +369,13 @@ input[type="email"].mailing-list-input::placeholder {
   color: $light;
   opacity: 0.65;
 }
+
+.grantee-card {
+  &:hover {
+    box-shadow: 0 1rem 2.5rem rgba(#000, 0.2) !important;
+  }
+
+  &:active {
+    transform: scale(0.98);
+  }
+}


### PR DESCRIPTION
  - Card height: 430 → 470 (uniform, no grid shift)
  - Voter cases (votingPower truthy): the icon now renders in a 36px row above the voting slider or
   "Add to Ballot" button, right-aligned
  - Non-voter case: icon stays in the bottom-right exactly as before