### PR TITLE
fix: replace siwe package with viem/siwe and fix SIWE auth bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "remove-markdown": "^0.5.5",
     "sass": "^1.75.0",
     "sharp": "^0.33.5",
-    "siwe": "^3.0.0",
     "use-clamp-text": "^1.1.1",
     "viem": "2.46.3",
     "wagmi": "2.19.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,9 +134,6 @@ importers:
       sharp:
         specifier: ^0.33.5
         version: 0.33.5
-      siwe:
-        specifier: ^3.0.0
-        version: 3.0.0(ethers@5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       use-clamp-text:
         specifier: ^1.1.1
         version: 1.1.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -587,96 +584,6 @@ packages:
     resolution: {integrity: sha512-zQ0IqbdX8FZ9aw11vP+dZkKDkS+kgIvQPHnSAXzP9pLu+Rfu3D3XEeLbicvoXJTYnhZiPmsZUxgdzXwNKxRPbA==}
     engines: {node: '>=14'}
 
-  '@ethersproject/abi@5.7.0':
-    resolution: {integrity: sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==}
-
-  '@ethersproject/abstract-provider@5.7.0':
-    resolution: {integrity: sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==}
-
-  '@ethersproject/abstract-signer@5.7.0':
-    resolution: {integrity: sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==}
-
-  '@ethersproject/address@5.7.0':
-    resolution: {integrity: sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==}
-
-  '@ethersproject/base64@5.7.0':
-    resolution: {integrity: sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==}
-
-  '@ethersproject/basex@5.7.0':
-    resolution: {integrity: sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==}
-
-  '@ethersproject/bignumber@5.7.0':
-    resolution: {integrity: sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==}
-
-  '@ethersproject/bytes@5.7.0':
-    resolution: {integrity: sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==}
-
-  '@ethersproject/constants@5.7.0':
-    resolution: {integrity: sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==}
-
-  '@ethersproject/contracts@5.7.0':
-    resolution: {integrity: sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==}
-
-  '@ethersproject/hash@5.7.0':
-    resolution: {integrity: sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==}
-
-  '@ethersproject/hdnode@5.7.0':
-    resolution: {integrity: sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==}
-
-  '@ethersproject/json-wallets@5.7.0':
-    resolution: {integrity: sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==}
-
-  '@ethersproject/keccak256@5.7.0':
-    resolution: {integrity: sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==}
-
-  '@ethersproject/logger@5.7.0':
-    resolution: {integrity: sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==}
-
-  '@ethersproject/networks@5.7.1':
-    resolution: {integrity: sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==}
-
-  '@ethersproject/pbkdf2@5.7.0':
-    resolution: {integrity: sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==}
-
-  '@ethersproject/properties@5.7.0':
-    resolution: {integrity: sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==}
-
-  '@ethersproject/providers@5.7.2':
-    resolution: {integrity: sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==}
-
-  '@ethersproject/random@5.7.0':
-    resolution: {integrity: sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==}
-
-  '@ethersproject/rlp@5.7.0':
-    resolution: {integrity: sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==}
-
-  '@ethersproject/sha2@5.7.0':
-    resolution: {integrity: sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==}
-
-  '@ethersproject/signing-key@5.7.0':
-    resolution: {integrity: sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==}
-
-  '@ethersproject/solidity@5.7.0':
-    resolution: {integrity: sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==}
-
-  '@ethersproject/strings@5.7.0':
-    resolution: {integrity: sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==}
-
-  '@ethersproject/transactions@5.7.0':
-    resolution: {integrity: sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==}
-
-  '@ethersproject/units@5.7.0':
-    resolution: {integrity: sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==}
-
-  '@ethersproject/wallet@5.7.0':
-    resolution: {integrity: sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==}
-
-  '@ethersproject/web@5.7.1':
-    resolution: {integrity: sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==}
-
-  '@ethersproject/wordlists@5.7.0':
-    resolution: {integrity: sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==}
-
   '@gemini-wallet/core@0.3.2':
     resolution: {integrity: sha512-Z4aHi3ECFf5oWYWM3F1rW83GJfB9OvhBYPTmb5q+VyK3uvzvS48lwo+jwh2eOoCRWEuT/crpb9Vwp2QaS5JqgQ==}
     peerDependencies:
@@ -784,144 +691,170 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm64@1.2.0':
     resolution: {integrity: sha512-RXwd0CgG+uPRX5YYrkzKyalt2OJYRiJQ8ED/fi1tq9WQW2jsQIn0tqrlR5l5dr/rjqq6AHAxURhj2DVjyQWSOA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.0':
     resolution: {integrity: sha512-mWd2uWvDtL/nvIzThLq3fr2nnGfyr/XMXlq8ZJ9WMR6PXijHlC3ksp0IpuhK6bougvQrchUAfzRLnbsen0Cqvw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.0':
     resolution: {integrity: sha512-Xod/7KaDDHkYu2phxxfeEPXfVXFKx70EAFZ0qyUdOjCcxbjqyJOEUpDe6RIyaunGxT34Anf9ue/wuWOqBW2WcQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.0':
     resolution: {integrity: sha512-eMKfzDxLGT8mnmPJTNMcjfO33fLiTDsrMlUVcp6b96ETbnJmd4uvZxVJSKPQfS+odwfVaGifhsB07J1LynFehw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.0':
     resolution: {integrity: sha512-ZW3FPWIc7K1sH9E3nxIGB3y3dZkpJlMnkk7z5tu1nSkBoCgw2nSRTFHI5pB/3CQaJM0pdzMF3paf9ckKMSE9Tg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.0':
     resolution: {integrity: sha512-UG+LqQJbf5VJ8NWJ5Z3tdIe/HXjuIdo4JeVNADXBFuG7z9zjoegpzzGIyV5zQKi4zaJjnAd2+g2nna8TZvuW9Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.0':
     resolution: {integrity: sha512-SRYOLR7CXPgNze8akZwjoGBoN1ThNZoqpOgfnOxmWsklTGVfJiGJoC/Lod7aNMGA1jSsKWM1+HRX43OP6p9+6Q==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm64@0.34.3':
     resolution: {integrity: sha512-QdrKe3EvQrqwkDrtuTIjI0bu6YEJHTgEeqdzI3uWJOH6G1O8Nl1iEeVYRGdj1h5I21CqxSvQp1Yv7xeU3ZewbA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.3':
     resolution: {integrity: sha512-oBK9l+h6KBN0i3dC8rYntLiVfW8D8wH+NPNT3O/WBHeW0OQWCjfWksLUaPidsrDKpJgXp3G3/hkmhptAW0I3+A==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.3':
     resolution: {integrity: sha512-GLtbLQMCNC5nxuImPR2+RgrviwKwVql28FWZIW1zWruy6zLgA5/x2ZXk3mxj58X/tszVF69KK0Is83V8YgWhLA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.3':
     resolution: {integrity: sha512-3gahT+A6c4cdc2edhsLHmIOXMb17ltffJlxR0aC2VPZfwKoTGZec6u5GrFgdR7ciJSsHT27BD3TIuGcuRT0KmQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.3':
     resolution: {integrity: sha512-8kYso8d806ypnSq3/Ly0QEw90V5ZoHh10yH0HnrzOCr6DKAPI6QVHvwleqMkVQ0m+fc7EH8ah0BB0QPuWY6zJQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-arm64@0.34.3':
     resolution: {integrity: sha512-vAjbHDlr4izEiXM1OTggpCcPg9tn4YriK5vAjowJsHwdBIdx0fYRsURkxLG2RLm9gyBq66gwtWI8Gx0/ov+JKQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.3':
     resolution: {integrity: sha512-gCWUn9547K5bwvOn9l5XGAEjVTTRji4aPTqLzGXHvIr6bIDZKNTA34seMPgM0WmSf+RYBH411VavCejp3PkOeQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -1152,24 +1085,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.3.5':
     resolution: {integrity: sha512-k8aVScYZ++BnS2P69ClK7v4nOu702jcF9AIHKu6llhHEtBSmM2zkPGl9yoqbSU/657IIIb0QHpdxEr0iW9z53A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.3.5':
     resolution: {integrity: sha512-2xYU0DI9DGN/bAHzVwADid22ba5d/xrbrQlr2U+/Q5WkFUzeL0TDR963BdrtLS/4bMmKZGptLeg6282H/S2i8A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.3.5':
     resolution: {integrity: sha512-TRYIqAGf1KCbuAB0gjhdn5Ytd8fV+wJSM2Nh2is/xEqR8PZHxfQuaiNhoF50XfY90sNpaRMaGhF6E+qjV1b9Tg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.3.5':
     resolution: {integrity: sha512-h04/7iMEUSMY6fDGCvdanKqlO1qYvzNxntZlCzfE8i5P0uqzVQWQquU1TIhlz0VqGQGXLrFDuTJVONpqGqjGKQ==}
@@ -1278,36 +1215,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.0':
     resolution: {integrity: sha512-6uHywSIzz8+vi2lAzFeltnYbdHsDm3iIB57d4g5oaB9vKwjb6N6dRIgZMujw4nm5r6v9/BQH0noq6DzHrqr2pA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.0':
     resolution: {integrity: sha512-BfNjXwZKxBy4WibDb/LDCriWSKLz+jJRL3cM/DllnHH5QUyoiUNEp3GmL80ZqxeumoADfCCP19+qiYiC8gUBjA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.0':
     resolution: {integrity: sha512-S1qARKOphxfiBEkwLUbHjCY9BWPdWnW9j7f7Hb2jPplu8UZ3nes7zpPOW9bkLbHRvWM0WDTsjdOTUgW0xLBN1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.0':
     resolution: {integrity: sha512-d9AOkusyXARkFD66S6zlGXyzx5RvY+chTP9Jp0ypSTC9d4lzyRs9ovGf/80VCxjKddcUvnsGwCHWuF2EoPgWjw==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.0':
     resolution: {integrity: sha512-iqOC+GoTDoFyk/VYSFHwjHhYrk8bljW6zOhPuhi5t9ulqiYq1togGJB5e3PwYVFFfeVgc6pbz3JdQyDoBszVaA==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.0':
     resolution: {integrity: sha512-twtft1d+JRNkM5YbmexfcH/N4znDtjgysFaV9zvZmmJezQsKpkfLYJ+JFV3uygugK6AtIM2oADPkB2AdhBrNig==}
@@ -2282,21 +2225,6 @@ packages:
   '@solana/web3.js@1.98.2':
     resolution: {integrity: sha512-BqVwEG+TaG2yCkBMbD3C4hdpustR4FpuUFRPUmqRZYYlPI9Hg4XMWxHWOWRzHE9Lkc9NDjzXFX7lDXSgzC7R1A==}
 
-  '@spruceid/siwe-parser@3.0.0':
-    resolution: {integrity: sha512-Y92k63ilw/8jH9Ry4G2e7lQd0jZAvb0d/Q7ssSD0D9mp/Zt2aCXIc3g0ny9yhplpAx1QXHsMz/JJptHK/zDGdw==}
-
-  '@stablelib/binary@1.0.1':
-    resolution: {integrity: sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==}
-
-  '@stablelib/int@1.0.1':
-    resolution: {integrity: sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w==}
-
-  '@stablelib/random@1.0.2':
-    resolution: {integrity: sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==}
-
-  '@stablelib/wipe@1.0.1':
-    resolution: {integrity: sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg==}
-
   '@stackso/js-core@0.5.11':
     resolution: {integrity: sha512-gq4y3Oj4yOkt9jqELOHB+qB+Jmi6GOIPokaRFVfEBcW8IiPX+Hi1jBl8/nxvfbRTRcLCdOliRDcQOiaaGs3HsQ==}
 
@@ -2821,9 +2749,6 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  aes-js@3.0.0:
-    resolution: {integrity: sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==}
-
   agentkeepalive@4.6.0:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
@@ -2854,9 +2779,6 @@ packages:
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
-
-  apg-js@4.4.0:
-    resolution: {integrity: sha512-fefmXFknJmtgtNEXfPwZKYkMFX4Fyeyz+fNF6JWp87biGOPslJbCBVU158zvKRZfHBKnJDy8CMM40oLFGkXT8Q==}
 
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
@@ -2963,9 +2885,6 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  bech32@1.1.4:
-    resolution: {integrity: sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==}
-
   big.js@6.2.2:
     resolution: {integrity: sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ==}
 
@@ -2978,9 +2897,6 @@ packages:
 
   blockstore-core@4.4.1:
     resolution: {integrity: sha512-peXfL9ZLx1cb84QALocMjhT8CsQ4JsreI/AitlN1inipSdC/G+jcYVJCqeCD5ecSTv/0LMpg8NlAPH/eBYZLjA==}
-
-  bn.js@4.12.1:
-    resolution: {integrity: sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==}
 
   bn.js@5.2.1:
     resolution: {integrity: sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==}
@@ -3005,9 +2921,6 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
-
-  brorand@1.1.0:
-    resolution: {integrity: sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==}
 
   browser-readablestream-to-it@2.0.7:
     resolution: {integrity: sha512-g1Aznml3HmqTLSXylZhGwdfnAa67+vlNAYhT9ROJZkAxY7yYmWusND10olvCMPe4sVhZyVwn5tPkRzOg85kBEg==}
@@ -3587,9 +3500,6 @@ packages:
   effect@3.18.4:
     resolution: {integrity: sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==}
 
-  elliptic@6.5.4:
-    resolution: {integrity: sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==}
-
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -3795,9 +3705,6 @@ packages:
 
   ethereum-cryptography@2.2.1:
     resolution: {integrity: sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==}
-
-  ethers@5.7.2:
-    resolution: {integrity: sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==}
 
   eventemitter2@6.4.9:
     resolution: {integrity: sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==}
@@ -4083,9 +3990,6 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
-  hash.js@1.1.7:
-    resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
-
   hashlru@2.3.0:
     resolution: {integrity: sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A==}
 
@@ -4101,9 +4005,6 @@ packages:
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
-
-  hmac-drbg@1.0.1:
-    resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
 
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
@@ -4504,9 +4405,6 @@ packages:
   jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
 
-  js-sha3@0.8.0:
-    resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
-
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -4808,12 +4706,6 @@ packages:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
     engines: {node: '>=10.0.0'}
     hasBin: true
-
-  minimalistic-assert@1.0.1:
-    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
-
-  minimalistic-crypto-utils@1.0.1:
-    resolution: {integrity: sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -5668,9 +5560,6 @@ packages:
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
 
-  scrypt-js@3.0.1:
-    resolution: {integrity: sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==}
-
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -5751,11 +5640,6 @@ packages:
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
-
-  siwe@3.0.0:
-    resolution: {integrity: sha512-P2/ry7dHYJA6JJ5+veS//Gn2XDwNb3JMvuD6xiXX8L/PJ1SNVD4a3a8xqEbmANx+7kNQcD8YAh1B9bNKKvRy/g==}
-    peerDependencies:
-      ethers: ^5.6.8 || ^6.0.8
 
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
@@ -6329,18 +6213,6 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
-
-  ws@7.4.6:
-    resolution: {integrity: sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==}
-    engines: {node: '>=8.3.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
 
   ws@7.5.10:
     resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
@@ -7557,261 +7429,6 @@ snapshots:
       '@ethereumjs/rlp': 4.0.1
       ethereum-cryptography: 2.2.1
       micro-ftch: 0.3.1
-
-  '@ethersproject/abi@5.7.0':
-    dependencies:
-      '@ethersproject/address': 5.7.0
-      '@ethersproject/bignumber': 5.7.0
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/constants': 5.7.0
-      '@ethersproject/hash': 5.7.0
-      '@ethersproject/keccak256': 5.7.0
-      '@ethersproject/logger': 5.7.0
-      '@ethersproject/properties': 5.7.0
-      '@ethersproject/strings': 5.7.0
-
-  '@ethersproject/abstract-provider@5.7.0':
-    dependencies:
-      '@ethersproject/bignumber': 5.7.0
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/logger': 5.7.0
-      '@ethersproject/networks': 5.7.1
-      '@ethersproject/properties': 5.7.0
-      '@ethersproject/transactions': 5.7.0
-      '@ethersproject/web': 5.7.1
-
-  '@ethersproject/abstract-signer@5.7.0':
-    dependencies:
-      '@ethersproject/abstract-provider': 5.7.0
-      '@ethersproject/bignumber': 5.7.0
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/logger': 5.7.0
-      '@ethersproject/properties': 5.7.0
-
-  '@ethersproject/address@5.7.0':
-    dependencies:
-      '@ethersproject/bignumber': 5.7.0
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/keccak256': 5.7.0
-      '@ethersproject/logger': 5.7.0
-      '@ethersproject/rlp': 5.7.0
-
-  '@ethersproject/base64@5.7.0':
-    dependencies:
-      '@ethersproject/bytes': 5.7.0
-
-  '@ethersproject/basex@5.7.0':
-    dependencies:
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/properties': 5.7.0
-
-  '@ethersproject/bignumber@5.7.0':
-    dependencies:
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/logger': 5.7.0
-      bn.js: 5.2.1
-
-  '@ethersproject/bytes@5.7.0':
-    dependencies:
-      '@ethersproject/logger': 5.7.0
-
-  '@ethersproject/constants@5.7.0':
-    dependencies:
-      '@ethersproject/bignumber': 5.7.0
-
-  '@ethersproject/contracts@5.7.0':
-    dependencies:
-      '@ethersproject/abi': 5.7.0
-      '@ethersproject/abstract-provider': 5.7.0
-      '@ethersproject/abstract-signer': 5.7.0
-      '@ethersproject/address': 5.7.0
-      '@ethersproject/bignumber': 5.7.0
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/constants': 5.7.0
-      '@ethersproject/logger': 5.7.0
-      '@ethersproject/properties': 5.7.0
-      '@ethersproject/transactions': 5.7.0
-
-  '@ethersproject/hash@5.7.0':
-    dependencies:
-      '@ethersproject/abstract-signer': 5.7.0
-      '@ethersproject/address': 5.7.0
-      '@ethersproject/base64': 5.7.0
-      '@ethersproject/bignumber': 5.7.0
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/keccak256': 5.7.0
-      '@ethersproject/logger': 5.7.0
-      '@ethersproject/properties': 5.7.0
-      '@ethersproject/strings': 5.7.0
-
-  '@ethersproject/hdnode@5.7.0':
-    dependencies:
-      '@ethersproject/abstract-signer': 5.7.0
-      '@ethersproject/basex': 5.7.0
-      '@ethersproject/bignumber': 5.7.0
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/logger': 5.7.0
-      '@ethersproject/pbkdf2': 5.7.0
-      '@ethersproject/properties': 5.7.0
-      '@ethersproject/sha2': 5.7.0
-      '@ethersproject/signing-key': 5.7.0
-      '@ethersproject/strings': 5.7.0
-      '@ethersproject/transactions': 5.7.0
-      '@ethersproject/wordlists': 5.7.0
-
-  '@ethersproject/json-wallets@5.7.0':
-    dependencies:
-      '@ethersproject/abstract-signer': 5.7.0
-      '@ethersproject/address': 5.7.0
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/hdnode': 5.7.0
-      '@ethersproject/keccak256': 5.7.0
-      '@ethersproject/logger': 5.7.0
-      '@ethersproject/pbkdf2': 5.7.0
-      '@ethersproject/properties': 5.7.0
-      '@ethersproject/random': 5.7.0
-      '@ethersproject/strings': 5.7.0
-      '@ethersproject/transactions': 5.7.0
-      aes-js: 3.0.0
-      scrypt-js: 3.0.1
-
-  '@ethersproject/keccak256@5.7.0':
-    dependencies:
-      '@ethersproject/bytes': 5.7.0
-      js-sha3: 0.8.0
-
-  '@ethersproject/logger@5.7.0': {}
-
-  '@ethersproject/networks@5.7.1':
-    dependencies:
-      '@ethersproject/logger': 5.7.0
-
-  '@ethersproject/pbkdf2@5.7.0':
-    dependencies:
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/sha2': 5.7.0
-
-  '@ethersproject/properties@5.7.0':
-    dependencies:
-      '@ethersproject/logger': 5.7.0
-
-  '@ethersproject/providers@5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
-    dependencies:
-      '@ethersproject/abstract-provider': 5.7.0
-      '@ethersproject/abstract-signer': 5.7.0
-      '@ethersproject/address': 5.7.0
-      '@ethersproject/base64': 5.7.0
-      '@ethersproject/basex': 5.7.0
-      '@ethersproject/bignumber': 5.7.0
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/constants': 5.7.0
-      '@ethersproject/hash': 5.7.0
-      '@ethersproject/logger': 5.7.0
-      '@ethersproject/networks': 5.7.1
-      '@ethersproject/properties': 5.7.0
-      '@ethersproject/random': 5.7.0
-      '@ethersproject/rlp': 5.7.0
-      '@ethersproject/sha2': 5.7.0
-      '@ethersproject/strings': 5.7.0
-      '@ethersproject/transactions': 5.7.0
-      '@ethersproject/web': 5.7.1
-      bech32: 1.1.4
-      ws: 7.4.6(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
-  '@ethersproject/random@5.7.0':
-    dependencies:
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/logger': 5.7.0
-
-  '@ethersproject/rlp@5.7.0':
-    dependencies:
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/logger': 5.7.0
-
-  '@ethersproject/sha2@5.7.0':
-    dependencies:
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/logger': 5.7.0
-      hash.js: 1.1.7
-
-  '@ethersproject/signing-key@5.7.0':
-    dependencies:
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/logger': 5.7.0
-      '@ethersproject/properties': 5.7.0
-      bn.js: 5.2.1
-      elliptic: 6.5.4
-      hash.js: 1.1.7
-
-  '@ethersproject/solidity@5.7.0':
-    dependencies:
-      '@ethersproject/bignumber': 5.7.0
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/keccak256': 5.7.0
-      '@ethersproject/logger': 5.7.0
-      '@ethersproject/sha2': 5.7.0
-      '@ethersproject/strings': 5.7.0
-
-  '@ethersproject/strings@5.7.0':
-    dependencies:
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/constants': 5.7.0
-      '@ethersproject/logger': 5.7.0
-
-  '@ethersproject/transactions@5.7.0':
-    dependencies:
-      '@ethersproject/address': 5.7.0
-      '@ethersproject/bignumber': 5.7.0
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/constants': 5.7.0
-      '@ethersproject/keccak256': 5.7.0
-      '@ethersproject/logger': 5.7.0
-      '@ethersproject/properties': 5.7.0
-      '@ethersproject/rlp': 5.7.0
-      '@ethersproject/signing-key': 5.7.0
-
-  '@ethersproject/units@5.7.0':
-    dependencies:
-      '@ethersproject/bignumber': 5.7.0
-      '@ethersproject/constants': 5.7.0
-      '@ethersproject/logger': 5.7.0
-
-  '@ethersproject/wallet@5.7.0':
-    dependencies:
-      '@ethersproject/abstract-provider': 5.7.0
-      '@ethersproject/abstract-signer': 5.7.0
-      '@ethersproject/address': 5.7.0
-      '@ethersproject/bignumber': 5.7.0
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/hash': 5.7.0
-      '@ethersproject/hdnode': 5.7.0
-      '@ethersproject/json-wallets': 5.7.0
-      '@ethersproject/keccak256': 5.7.0
-      '@ethersproject/logger': 5.7.0
-      '@ethersproject/properties': 5.7.0
-      '@ethersproject/random': 5.7.0
-      '@ethersproject/signing-key': 5.7.0
-      '@ethersproject/transactions': 5.7.0
-      '@ethersproject/wordlists': 5.7.0
-
-  '@ethersproject/web@5.7.1':
-    dependencies:
-      '@ethersproject/base64': 5.7.0
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/logger': 5.7.0
-      '@ethersproject/properties': 5.7.0
-      '@ethersproject/strings': 5.7.0
-
-  '@ethersproject/wordlists@5.7.0':
-    dependencies:
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/hash': 5.7.0
-      '@ethersproject/logger': 5.7.0
-      '@ethersproject/properties': 5.7.0
-      '@ethersproject/strings': 5.7.0
 
   '@gemini-wallet/core@0.3.2(viem@2.46.3(bufferutil@4.0.9)(typescript@5.7.2)(utf-8-validate@5.0.10)(zod@4.3.6))':
     dependencies:
@@ -10270,24 +9887,6 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@spruceid/siwe-parser@3.0.0':
-    dependencies:
-      '@noble/hashes': 1.8.0
-      apg-js: 4.4.0
-
-  '@stablelib/binary@1.0.1':
-    dependencies:
-      '@stablelib/int': 1.0.1
-
-  '@stablelib/int@1.0.1': {}
-
-  '@stablelib/random@1.0.2':
-    dependencies:
-      '@stablelib/binary': 1.0.1
-      '@stablelib/wipe': 1.0.1
-
-  '@stablelib/wipe@1.0.1': {}
-
   '@stackso/js-core@0.5.11(bufferutil@4.0.9)(typescript@5.7.2)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
       '@solana/web3.js': 1.98.2(bufferutil@4.0.9)(typescript@5.7.2)(utf-8-validate@5.0.10)
@@ -11380,8 +10979,6 @@ snapshots:
 
   acorn@8.14.0: {}
 
-  aes-js@3.0.0: {}
-
   agentkeepalive@4.6.0:
     dependencies:
       humanize-ms: 1.2.1
@@ -11409,8 +11006,6 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
-
-  apg-js@4.4.0: {}
 
   arg@5.0.2: {}
 
@@ -11543,8 +11138,6 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  bech32@1.1.4: {}
-
   big.js@6.2.2: {}
 
   binary-extensions@2.3.0: {}
@@ -11562,8 +11155,6 @@ snapshots:
       it-merge: 3.0.5
       it-pushable: 3.2.3
       multiformats: 13.3.1
-
-  bn.js@4.12.1: {}
 
   bn.js@5.2.1: {}
 
@@ -11591,8 +11182,6 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
-
-  brorand@1.1.0: {}
 
   browser-readablestream-to-it@2.0.7: {}
 
@@ -12166,16 +11755,6 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
 
-  elliptic@6.5.4:
-    dependencies:
-      bn.js: 4.12.1
-      brorand: 1.1.0
-      hash.js: 1.1.7
-      hmac-drbg: 1.0.1
-      inherits: 2.0.4
-      minimalistic-assert: 1.0.1
-      minimalistic-crypto-utils: 1.0.1
-
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
@@ -12550,42 +12129,6 @@ snapshots:
       '@scure/bip32': 1.4.0
       '@scure/bip39': 1.3.0
 
-  ethers@5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10):
-    dependencies:
-      '@ethersproject/abi': 5.7.0
-      '@ethersproject/abstract-provider': 5.7.0
-      '@ethersproject/abstract-signer': 5.7.0
-      '@ethersproject/address': 5.7.0
-      '@ethersproject/base64': 5.7.0
-      '@ethersproject/basex': 5.7.0
-      '@ethersproject/bignumber': 5.7.0
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/constants': 5.7.0
-      '@ethersproject/contracts': 5.7.0
-      '@ethersproject/hash': 5.7.0
-      '@ethersproject/hdnode': 5.7.0
-      '@ethersproject/json-wallets': 5.7.0
-      '@ethersproject/keccak256': 5.7.0
-      '@ethersproject/logger': 5.7.0
-      '@ethersproject/networks': 5.7.1
-      '@ethersproject/pbkdf2': 5.7.0
-      '@ethersproject/properties': 5.7.0
-      '@ethersproject/providers': 5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      '@ethersproject/random': 5.7.0
-      '@ethersproject/rlp': 5.7.0
-      '@ethersproject/sha2': 5.7.0
-      '@ethersproject/signing-key': 5.7.0
-      '@ethersproject/solidity': 5.7.0
-      '@ethersproject/strings': 5.7.0
-      '@ethersproject/transactions': 5.7.0
-      '@ethersproject/units': 5.7.0
-      '@ethersproject/wallet': 5.7.0
-      '@ethersproject/web': 5.7.1
-      '@ethersproject/wordlists': 5.7.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
   eventemitter2@6.4.9: {}
 
   eventemitter3@4.0.4: {}
@@ -12879,11 +12422,6 @@ snapshots:
     dependencies:
       has-symbols: 1.1.0
 
-  hash.js@1.1.7:
-    dependencies:
-      inherits: 2.0.4
-      minimalistic-assert: 1.0.1
-
   hashlru@2.3.0: {}
 
   hasown@2.0.2:
@@ -12917,12 +12455,6 @@ snapshots:
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
-
-  hmac-drbg@1.0.1:
-    dependencies:
-      hash.js: 1.1.7
-      minimalistic-assert: 1.0.1
-      minimalistic-crypto-utils: 1.0.1
 
   hoist-non-react-statics@3.3.2:
     dependencies:
@@ -13367,8 +12899,6 @@ snapshots:
   jose@4.15.9: {}
 
   jose@6.1.3: {}
-
-  js-sha3@0.8.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -13873,10 +13403,6 @@ snapshots:
       mime-db: 1.52.0
 
   mime@3.0.0: {}
-
-  minimalistic-assert@1.0.1: {}
-
-  minimalistic-crypto-utils@1.0.1: {}
 
   minimatch@3.1.2:
     dependencies:
@@ -14841,8 +14367,6 @@ snapshots:
 
   scheduler@0.26.0: {}
 
-  scrypt-js@3.0.1: {}
-
   semver@6.3.1: {}
 
   semver@7.6.3: {}
@@ -14979,12 +14503,6 @@ snapshots:
       is-arrayish: 0.3.2
 
   sisteransi@1.0.5: {}
-
-  siwe@3.0.0(ethers@5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
-    dependencies:
-      '@spruceid/siwe-parser': 3.0.0
-      '@stablelib/random': 1.0.2
-      ethers: 5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
 
   slash@3.0.0: {}
 
@@ -15651,11 +15169,6 @@ snapshots:
       strip-ansi: 7.1.0
 
   wrappy@1.0.2: {}
-
-  ws@7.4.6(bufferutil@4.0.9)(utf-8-validate@5.0.10):
-    optionalDependencies:
-      bufferutil: 4.0.9
-      utf-8-validate: 5.0.10
 
   ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10):
     optionalDependencies:

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -2,8 +2,7 @@ import { headers, cookies as nextCookies } from "next/headers";
 import NextAuth, { NextAuthOptions } from "next-auth";
 import CredentialsProvider from "next-auth/providers/credentials";
 import { createPublicClient, http, type Hex } from "viem";
-import { verifySiweMessage } from "viem/siwe";
-import { SiweMessage } from "siwe";
+import { parseSiweMessage, verifySiweMessage } from "viem/siwe";
 import { networks } from "@/lib/networks";
 
 function getPublicClient(chainId: number) {
@@ -32,8 +31,8 @@ const providers = [
     async authorize(credentials) {
       try {
         const headersList = await headers();
-        const siwe = new SiweMessage(JSON.parse(credentials?.message || "{}"));
-        const message = siwe.prepareMessage();
+        const message = credentials?.message || "";
+        const siweFields = parseSiweMessage(message);
 
         const nextAuthUrl = new URL(
           headersList.get("origin") ?? "https://flowstate.network",
@@ -41,7 +40,7 @@ const providers = [
         const cookies = await nextCookies();
         const nonce = cookies.get("next-auth.csrf-token")?.value.split("|")[0];
 
-        const publicClient = getPublicClient(siwe.chainId);
+        const publicClient = getPublicClient(siweFields.chainId!);
 
         const isValid = await verifySiweMessage(publicClient, {
           message,
@@ -51,7 +50,7 @@ const providers = [
         });
 
         if (isValid) {
-          return { id: siwe.address };
+          return { id: siweFields.address! };
         }
         return null;
       } catch (e) {

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -34,13 +34,15 @@ const providers = [
         const message = credentials?.message || "";
         const siweFields = parseSiweMessage(message);
 
+        if (!siweFields.chainId || !siweFields.address) return null;
+
         const nextAuthUrl = new URL(
           headersList.get("origin") ?? "https://flowstate.network",
         );
         const cookies = await nextCookies();
         const nonce = cookies.get("next-auth.csrf-token")?.value.split("|")[0];
 
-        const publicClient = getPublicClient(siweFields.chainId!);
+        const publicClient = getPublicClient(siweFields.chainId);
 
         const isValid = await verifySiweMessage(publicClient, {
           message,
@@ -50,7 +52,7 @@ const providers = [
         });
 
         if (isValid) {
-          return { id: siweFields.address! };
+          return { id: siweFields.address };
         }
         return null;
       } catch (e) {

--- a/src/app/flow-councils/[chainId]/[councilId]/flow-council.tsx
+++ b/src/app/flow-councils/[chainId]/[councilId]/flow-council.tsx
@@ -30,11 +30,9 @@ import { shuffle, getPlaceholderImageSrc, generateColor } from "@/lib/utils";
 export default function FlowCouncil({
   chainId,
   councilId,
-  csfrToken,
 }: {
   chainId: number;
   councilId: string;
-  csfrToken: string;
 }) {
   const [selectedTab, setSelectedTab] = useState("grantees");
   const [grantees, setGrantees] = useState<Grantee[]>([]);
@@ -429,11 +427,7 @@ export default function FlowCouncil({
               </Stack>
             </Tab.Pane>
             <Tab.Pane eventKey="feed">
-              <FeedTab
-                chainId={chainId}
-                councilId={councilId}
-                csfrToken={csfrToken}
-              />
+              <FeedTab chainId={chainId} councilId={councilId} />
             </Tab.Pane>
           </Tab.Content>
         </Tab.Container>

--- a/src/app/flow-councils/[chainId]/[councilId]/page.tsx
+++ b/src/app/flow-councils/[chainId]/[councilId]/page.tsx
@@ -1,4 +1,3 @@
-import { cookies as nextCookies } from "next/headers";
 import FlowCouncil from "./flow-council";
 
 type Params = {
@@ -7,14 +6,7 @@ type Params = {
 };
 
 export default async function Page({ params }: { params: Promise<Params> }) {
-  const cookies = await nextCookies();
   const { chainId, councilId } = await params;
 
-  return (
-    <FlowCouncil
-      chainId={Number(chainId)}
-      councilId={councilId}
-      csfrToken={cookies.get("next-auth.csrf-token")?.value.split("|")[0] ?? ""}
-    />
-  );
+  return <FlowCouncil chainId={Number(chainId)} councilId={councilId} />;
 }

--- a/src/app/flow-councils/application/[chainId]/[councilId]/[projectId]/application.tsx
+++ b/src/app/flow-councils/application/[chainId]/[councilId]/[projectId]/application.tsx
@@ -22,11 +22,10 @@ type ApplicationProps = {
   chainId: number;
   councilId: string;
   projectId?: string;
-  csrfToken: string;
 };
 
 export default function Application(props: ApplicationProps) {
-  const { chainId, councilId, projectId, csrfToken } = props;
+  const { chainId, councilId, projectId } = props;
 
   const router = useRouter();
   const { address } = useAccount();
@@ -227,7 +226,6 @@ export default function Application(props: ApplicationProps) {
         <Tab.Content>
           <Tab.Pane eventKey="project">
             <ProjectTab
-              csrfToken={csrfToken}
               project={project}
               isLoading={isLoading}
               onSave={handleProjectSaved}

--- a/src/app/flow-councils/application/[chainId]/[councilId]/[projectId]/layout.tsx
+++ b/src/app/flow-councils/application/[chainId]/[councilId]/[projectId]/layout.tsx
@@ -37,7 +37,6 @@ export default function ApplicationLayout({
   const [applicationStatus, setApplicationStatus] =
     useState<ApplicationStatus>(null);
   const [isLoading, setIsLoading] = useState(true);
-  const [csrfToken, setCsrfToken] = useState<string>("");
 
   const { address, chain: connectedChain } = useAccount();
   const { data: session } = useSession();
@@ -49,17 +48,6 @@ export default function ApplicationLayout({
   useEffect(() => {
     params.then((p) => setResolvedParams(p));
   }, [params]);
-
-  // Get CSRF token from cookies
-  useEffect(() => {
-    const cookies = document.cookie.split(";");
-    const csrfCookie = cookies.find((c) =>
-      c.trim().startsWith("next-auth.csrf-token="),
-    );
-    if (csrfCookie) {
-      setCsrfToken(csrfCookie.split("=")[1]?.split("|")[0] ?? "");
-    }
-  }, []);
 
   const chainId = resolvedParams ? Number(resolvedParams.chainId) : null;
   const councilId = resolvedParams?.councilId ?? null;
@@ -166,7 +154,7 @@ export default function ApplicationLayout({
             } else if (connectedChain?.id !== chainId) {
               switchChain({ chainId: chainId! });
             } else {
-              handleSignIn(csrfToken);
+              handleSignIn();
             }
           }}
         >

--- a/src/app/flow-councils/application/[chainId]/[councilId]/[projectId]/page.tsx
+++ b/src/app/flow-councils/application/[chainId]/[councilId]/[projectId]/page.tsx
@@ -1,4 +1,3 @@
-import { cookies as nextCookies } from "next/headers";
 import Application from "./application";
 
 export default async function Page({
@@ -6,7 +5,6 @@ export default async function Page({
 }: {
   params: Promise<{ chainId: string; councilId: string; projectId: string }>;
 }) {
-  const cookies = await nextCookies();
   const { chainId, councilId, projectId } = await params;
 
   return (
@@ -14,7 +12,6 @@ export default async function Page({
       chainId={Number(chainId)}
       councilId={councilId}
       projectId={projectId === "new" ? undefined : projectId}
-      csrfToken={cookies.get("next-auth.csrf-token")?.value.split("|")[0] ?? ""}
     />
   );
 }

--- a/src/app/flow-councils/application/[chainId]/[councilId]/page.tsx
+++ b/src/app/flow-councils/application/[chainId]/[councilId]/page.tsx
@@ -1,4 +1,3 @@
-import { cookies as nextCookies } from "next/headers";
 import ProjectSelection from "./project-selection";
 
 export default async function Page({
@@ -6,14 +5,7 @@ export default async function Page({
 }: {
   params: Promise<{ chainId: string; councilId: string }>;
 }) {
-  const cookies = await nextCookies();
   const { chainId, councilId } = await params;
 
-  return (
-    <ProjectSelection
-      chainId={Number(chainId)}
-      councilId={councilId}
-      csrfToken={cookies.get("next-auth.csrf-token")?.value.split("|")[0] ?? ""}
-    />
-  );
+  return <ProjectSelection chainId={Number(chainId)} councilId={councilId} />;
 }

--- a/src/app/flow-councils/application/[chainId]/[councilId]/project-selection.tsx
+++ b/src/app/flow-councils/application/[chainId]/[councilId]/project-selection.tsx
@@ -22,7 +22,6 @@ import { Project, ProjectDetails } from "@/types/project";
 type ProjectSelectionProps = {
   chainId: number;
   councilId: string;
-  csrfToken: string;
 };
 
 type Application = {
@@ -62,7 +61,7 @@ const SUPERFLUID_QUERY = gql`
 `;
 
 export default function ProjectSelection(props: ProjectSelectionProps) {
-  const { chainId, councilId, csrfToken } = props;
+  const { chainId, councilId } = props;
 
   const [projects, setProjects] = useState<Project[]>([]);
   const [applications, setApplications] = useState<Application[]>([]);
@@ -337,7 +336,7 @@ export default function ProjectSelection(props: ProjectSelectionProps) {
               } else if (connectedChain?.id !== chainId) {
                 switchChain({ chainId });
               } else {
-                handleSignIn(csrfToken);
+                handleSignIn();
               }
             }}
           >

--- a/src/app/flow-councils/communications/[chainId]/[councilId]/communications.tsx
+++ b/src/app/flow-councils/communications/[chainId]/[councilId]/communications.tsx
@@ -22,7 +22,6 @@ type CommunicationsProps = {
   chainId: number;
   councilId: string;
   hostname: string;
-  csfrToken: string;
 };
 
 type ProjectChannel = {
@@ -41,7 +40,7 @@ const FLOW_COUNCIL_QUERY = gql`
 `;
 
 export default function Communications(props: CommunicationsProps) {
-  const { chainId, councilId, csfrToken } = props;
+  const { chainId, councilId } = props;
 
   const [channels, setChannels] = useState<ProjectChannel[]>([]);
   const [isLoadingChannels, setIsLoadingChannels] = useState(true);
@@ -203,7 +202,7 @@ export default function Communications(props: CommunicationsProps) {
             } else if (connectedChain?.id !== chainId) {
               switchChain({ chainId });
             } else {
-              handleSignIn(csfrToken);
+              handleSignIn();
             }
           }}
         >

--- a/src/app/flow-councils/communications/[chainId]/[councilId]/page.tsx
+++ b/src/app/flow-councils/communications/[chainId]/[councilId]/page.tsx
@@ -1,4 +1,4 @@
-import { headers, cookies as nextCookies } from "next/headers";
+import { headers } from "next/headers";
 import Communications from "./communications";
 
 export default async function Page({
@@ -8,7 +8,6 @@ export default async function Page({
 }) {
   const headersList = await headers();
   const hostname = headersList.get("host");
-  const cookies = await nextCookies();
   const { chainId, councilId } = await params;
 
   return (
@@ -16,7 +15,6 @@ export default async function Page({
       chainId={Number(chainId)}
       councilId={councilId}
       hostname={hostname ?? ""}
-      csfrToken={cookies.get("next-auth.csrf-token")?.value.split("|")[0] ?? ""}
     />
   );
 }

--- a/src/app/flow-councils/components/FeedTab.tsx
+++ b/src/app/flow-councils/components/FeedTab.tsx
@@ -12,14 +12,9 @@ import useSiwe from "@/hooks/siwe";
 type FeedTabProps = {
   chainId: number;
   councilId: string;
-  csfrToken: string;
 };
 
-export default function FeedTab({
-  chainId,
-  councilId,
-  csfrToken,
-}: FeedTabProps) {
+export default function FeedTab({ chainId, councilId }: FeedTabProps) {
   const [roundId, setRoundId] = useState<number | null>(null);
   const [isAdmin, setIsAdmin] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
@@ -86,7 +81,7 @@ export default function FeedTab({
             } else if (connectedChain?.id !== chainId) {
               switchChain({ chainId });
             } else {
-              handleSignIn(csfrToken);
+              handleSignIn();
             }
           }}
         >

--- a/src/app/flow-councils/components/ProjectModal.tsx
+++ b/src/app/flow-councils/components/ProjectModal.tsx
@@ -6,7 +6,6 @@ import { Project } from "@/types/project";
 
 type ProjectModalProps = {
   show: boolean;
-  csrfToken: string;
   handleClose: () => void;
   onProjectCreated: () => void;
   mode: "create" | "edit";
@@ -14,8 +13,7 @@ type ProjectModalProps = {
 };
 
 export default function ProjectModal(props: ProjectModalProps) {
-  const { show, csrfToken, handleClose, onProjectCreated, mode, project } =
-    props;
+  const { show, handleClose, onProjectCreated, mode, project } = props;
 
   return (
     <Modal
@@ -33,7 +31,6 @@ export default function ProjectModal(props: ProjectModalProps) {
       </Modal.Header>
       <Modal.Body className="p-4">
         <ProjectTab
-          csrfToken={csrfToken}
           project={project}
           isLoading={false}
           onSave={() => {

--- a/src/app/flow-councils/components/ProjectTab.tsx
+++ b/src/app/flow-councils/components/ProjectTab.tsx
@@ -51,7 +51,6 @@ async function uploadToS3(file: Blob, fileName: string): Promise<string> {
 }
 
 type ProjectTabProps = {
-  csrfToken: string;
   project: Project | null;
   isLoading: boolean;
   onSave: (project: Project) => void;
@@ -93,7 +92,7 @@ const isValidGithubRepo = (url: string): boolean => {
 };
 
 export default function ProjectTab(props: ProjectTabProps) {
-  const { csrfToken, project, isLoading, onSave, onCancel } = props;
+  const { project, isLoading, onSave, onCancel } = props;
 
   const [form, setForm] = useState<ProjectForm>({
     name: "",
@@ -367,7 +366,7 @@ export default function ProjectTab(props: ProjectTabProps) {
     if (!address && openConnectModal) {
       openConnectModal();
     } else if (!session || session.address !== address) {
-      handleSignIn(csrfToken);
+      handleSignIn();
     } else if (isValid) {
       handleSaveProject();
     }

--- a/src/app/flow-councils/launch/[chainId]/[councilId]/page.tsx
+++ b/src/app/flow-councils/launch/[chainId]/[councilId]/page.tsx
@@ -1,4 +1,3 @@
-import { cookies as nextCookies } from "next/headers";
 import Launch from "../../launch";
 import { networks } from "@/lib/networks";
 
@@ -9,18 +8,11 @@ export default async function Page({
 }: {
   params: Promise<{ chainId: string; councilId: string }>;
 }) {
-  const cookies = await nextCookies();
   const { chainId, councilId } = await params;
 
   const network =
     networks.find((network) => network.id === Number(chainId)) ??
     defaultNetwork;
 
-  return (
-    <Launch
-      defaultNetwork={network}
-      councilId={councilId}
-      csrfToken={cookies.get("next-auth.csrf-token")?.value.split("|")[0] ?? ""}
-    />
-  );
+  return <Launch defaultNetwork={network} councilId={councilId} />;
 }

--- a/src/app/flow-councils/launch/launch.tsx
+++ b/src/app/flow-councils/launch/launch.tsx
@@ -34,7 +34,6 @@ const SUPERAPP_SPLITTER_SIDE_PORTION = BigInt(50);
 type LaunchProps = {
   defaultNetwork: Network;
   councilId?: string;
-  csrfToken: string;
 };
 
 const FLOW_COUNCIL_QUERY = gql`
@@ -47,7 +46,7 @@ const FLOW_COUNCIL_QUERY = gql`
 `;
 
 export default function Launch(props: LaunchProps) {
-  const { defaultNetwork, councilId, csrfToken } = props;
+  const { defaultNetwork, councilId } = props;
 
   const [selectedNetwork, setSelectedNetwork] =
     useState<Network>(defaultNetwork);
@@ -310,7 +309,7 @@ export default function Launch(props: LaunchProps) {
                 : connectedChain?.id !== selectedNetwork.id
                   ? switchChain({ chainId: selectedNetwork.id })
                   : !session || session.address !== address
-                    ? handleSignIn(csrfToken)
+                    ? handleSignIn()
                     : handleSubmit()
             }
           >

--- a/src/app/flow-councils/launch/page.tsx
+++ b/src/app/flow-councils/launch/page.tsx
@@ -1,4 +1,3 @@
-import { cookies as nextCookies } from "next/headers";
 import type { SearchParams } from "@/types/searchParams";
 import Launch from "./launch";
 import { networks } from "@/lib/networks";
@@ -9,16 +8,10 @@ export default async function Page({
   searchParams: Promise<SearchParams>;
 }) {
   const { chainId } = await searchParams;
-  const cookies = await nextCookies();
 
   const network =
     networks.find((network) => network.id === Number(chainId)) ??
     networks.find((network) => network.label === "celo")!;
 
-  return (
-    <Launch
-      defaultNetwork={network}
-      csrfToken={cookies.get("next-auth.csrf-token")?.value.split("|")[0] ?? ""}
-    />
-  );
+  return <Launch defaultNetwork={network} />;
 }

--- a/src/app/flow-councils/permissions/[chainId]/[councilId]/page.tsx
+++ b/src/app/flow-councils/permissions/[chainId]/[councilId]/page.tsx
@@ -1,4 +1,3 @@
-import { cookies as nextCookies } from "next/headers";
 import Permissions from "../../permissions";
 
 export default async function Page({
@@ -6,14 +5,7 @@ export default async function Page({
 }: {
   params: Promise<{ chainId: string; councilId: string }>;
 }) {
-  const cookies = await nextCookies();
   const { chainId, councilId } = await params;
 
-  return (
-    <Permissions
-      chainId={Number(chainId)}
-      councilId={councilId}
-      csrfToken={cookies.get("next-auth.csrf-token")?.value.split("|")[0] ?? ""}
-    />
-  );
+  return <Permissions chainId={Number(chainId)} councilId={councilId} />;
 }

--- a/src/app/flow-councils/permissions/permissions.tsx
+++ b/src/app/flow-councils/permissions/permissions.tsx
@@ -31,7 +31,6 @@ import {
 type PermissionsProps = {
   chainId?: number;
   councilId?: string;
-  csrfToken: string;
 };
 type ManagerEntry = {
   address: string;
@@ -59,7 +58,7 @@ const FLOW_COUNCIL_QUERY = gql`
 `;
 
 export default function Permissions(props: PermissionsProps) {
-  const { chainId, councilId, csrfToken } = props;
+  const { chainId, councilId } = props;
 
   const [transactionError, setTransactionError] = useState("");
   const [transactionSuccess, setTransactionSuccess] = useState(false);
@@ -578,7 +577,7 @@ export default function Permissions(props: PermissionsProps) {
                 } else if (connectedChain?.id !== chainId) {
                   switchChain({ chainId: chainId! });
                 } else {
-                  handleSignIn(csrfToken);
+                  handleSignIn();
                 }
               }}
             >

--- a/src/app/flow-councils/review/[chainId]/[councilId]/page.tsx
+++ b/src/app/flow-councils/review/[chainId]/[councilId]/page.tsx
@@ -1,4 +1,4 @@
-import { headers, cookies as nextCookies } from "next/headers";
+import { headers } from "next/headers";
 import Review from "../../review";
 
 export default async function Page({
@@ -8,7 +8,6 @@ export default async function Page({
 }) {
   const headersList = await headers();
   const hostname = headersList.get("host");
-  const cookies = await nextCookies();
   const { chainId, councilId } = await params;
 
   return (
@@ -16,7 +15,6 @@ export default async function Page({
       chainId={Number(chainId)}
       councilId={councilId}
       hostname={hostname ?? ""}
-      csfrToken={cookies.get("next-auth.csrf-token")?.value.split("|")[0] ?? ""}
     />
   );
 }

--- a/src/app/flow-councils/review/review.tsx
+++ b/src/app/flow-councils/review/review.tsx
@@ -47,7 +47,6 @@ type ReviewProps = {
   chainId?: number;
   councilId?: string;
   hostname: string;
-  csfrToken: string;
 };
 
 type ApplicationDetails = RoundForm & {
@@ -110,7 +109,7 @@ const FLOW_COUNCIL_QUERY = gql`
 `;
 
 export default function Review(props: ReviewProps) {
-  const { chainId, councilId, hostname, csfrToken } = props;
+  const { chainId, councilId, hostname } = props;
 
   const [applications, setApplications] = useState<ApplicationSummary[]>([]);
   const [selectedApplication, setSelectedApplication] =
@@ -598,7 +597,7 @@ export default function Review(props: ReviewProps) {
                 ? openConnectModal()
                 : connectedChain?.id !== chainId
                   ? switchChain({ chainId })
-                  : handleSignIn(csfrToken);
+                  : handleSignIn();
             }}
           >
             Sign In With Ethereum

--- a/src/app/flow-councils/round-metadata/[chainId]/[councilId]/page.tsx
+++ b/src/app/flow-councils/round-metadata/[chainId]/[councilId]/page.tsx
@@ -1,4 +1,3 @@
-import { cookies as nextCookies } from "next/headers";
 import RoundMetadata from "../../round-metadata";
 
 export default async function Page({
@@ -6,14 +5,7 @@ export default async function Page({
 }: {
   params: Promise<{ chainId: string; councilId: string }>;
 }) {
-  const cookies = await nextCookies();
   const { chainId, councilId } = await params;
 
-  return (
-    <RoundMetadata
-      chainId={Number(chainId)}
-      councilId={councilId}
-      csrfToken={cookies.get("next-auth.csrf-token")?.value.split("|")[0] ?? ""}
-    />
-  );
+  return <RoundMetadata chainId={Number(chainId)} councilId={councilId} />;
 }

--- a/src/app/flow-councils/round-metadata/round-metadata.tsx
+++ b/src/app/flow-councils/round-metadata/round-metadata.tsx
@@ -52,7 +52,6 @@ async function uploadToS3(file: Blob, fileName: string): Promise<string> {
 type RoundMetadataProps = {
   chainId: number;
   councilId?: string;
-  csrfToken: string;
 };
 
 type RoundDetails = {
@@ -62,7 +61,7 @@ type RoundDetails = {
 };
 
 export default function RoundMetadata(props: RoundMetadataProps) {
-  const { chainId, councilId, csrfToken } = props;
+  const { chainId, councilId } = props;
 
   const [roundDetails, setRoundDetails] = useState<RoundDetails>({
     name: "",
@@ -340,7 +339,7 @@ export default function RoundMetadata(props: RoundMetadataProps) {
                 } else if (connectedChain?.id !== chainId) {
                   switchChain({ chainId });
                 } else {
-                  handleSignIn(csrfToken);
+                  handleSignIn();
                 }
               }}
             >

--- a/src/app/profile/profile.tsx
+++ b/src/app/profile/profile.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { useAccount } from "wagmi";
-import { getCsrfToken, useSession } from "next-auth/react";
+import { useSession } from "next-auth/react";
 import { useConnectModal } from "@rainbow-me/rainbowkit";
 import Container from "react-bootstrap/Container";
 import Form from "react-bootstrap/Form";
@@ -136,13 +136,7 @@ export default function Profile() {
           <Button
             variant="secondary"
             disabled={!address}
-            onClick={() =>
-              getCsrfToken()
-                .then((token) => {
-                  if (token) handleSignIn(token);
-                })
-                .catch(console.error)
-            }
+            onClick={() => handleSignIn()}
             className="fs-lg fw-semi-bold rounded-4 px-10 py-4"
           >
             Sign In With Ethereum

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -1,4 +1,3 @@
-import { cookies as nextCookies } from "next/headers";
 import type { SearchParams } from "@/types/searchParams";
 import Project from "./project";
 
@@ -10,14 +9,7 @@ export default async function Page({
   searchParams: Promise<SearchParams>;
 }) {
   const { id } = await params;
-  const cookies = await nextCookies();
   const { edit } = await searchParams;
 
-  return (
-    <Project
-      projectId={id}
-      csrfToken={cookies.get("next-auth.csrf-token")?.value.split("|")[0] ?? ""}
-      editMode={edit === "true"}
-    />
-  );
+  return <Project projectId={id} editMode={edit === "true"} />;
 }

--- a/src/app/projects/[id]/project.tsx
+++ b/src/app/projects/[id]/project.tsx
@@ -28,7 +28,6 @@ import { getGardensPoolNetwork } from "@/lib/gardensPool";
 
 type ProjectProps = {
   projectId: string;
-  csrfToken: string;
   editMode: boolean;
 };
 
@@ -44,7 +43,7 @@ type ProjectData = {
 const VALID_TABS = ["details", "feed", "milestones"];
 
 export default function Project(props: ProjectProps) {
-  const { projectId, csrfToken, editMode } = props;
+  const { projectId, editMode } = props;
 
   const searchParams = useSearchParams();
   const tabParam = searchParams.get("tab");
@@ -450,7 +449,6 @@ export default function Project(props: ProjectProps) {
       {project && isManager && (
         <ProjectModal
           show={showEditModal}
-          csrfToken={csrfToken}
           handleClose={() => {
             setShowEditModal(false);
             router.replace(`/projects/${projectId}`);

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,4 +1,3 @@
-import { cookies as nextCookies } from "next/headers";
 import type { SearchParams } from "@/types/searchParams";
 import Projects from "./projects";
 
@@ -7,13 +6,7 @@ export default async function Page({
 }: {
   searchParams: Promise<SearchParams>;
 }) {
-  const cookies = await nextCookies();
   const { owner } = await searchParams;
 
-  return (
-    <Projects
-      csrfToken={cookies.get("next-auth.csrf-token")?.value.split("|")[0] ?? ""}
-      owner={owner ?? null}
-    />
-  );
+  return <Projects owner={owner ?? null} />;
 }

--- a/src/app/projects/projects.tsx
+++ b/src/app/projects/projects.tsx
@@ -17,12 +17,11 @@ import { useMediaQuery } from "@/hooks/mediaQuery";
 import { Project, ProjectDetails } from "@/types/project";
 
 type ProjectsProps = {
-  csrfToken: string;
   owner: string | null;
 };
 
 export default function Projects(props: ProjectsProps) {
-  const { csrfToken, owner } = props;
+  const { owner } = props;
 
   const [showProjectCreationModal, setShowProjectCreationModal] =
     useState(false);
@@ -103,7 +102,7 @@ export default function Projects(props: ProjectsProps) {
     if (!address && openConnectModal) {
       openConnectModal();
     } else if (!session || session.address !== address) {
-      handleSignIn(csrfToken);
+      handleSignIn();
       setPendingCreate(true);
     } else {
       setShowProjectCreationModal(true);
@@ -179,7 +178,6 @@ export default function Projects(props: ProjectsProps) {
       )}
       <ProjectModal
         show={showProjectCreationModal}
-        csrfToken={csrfToken}
         handleClose={() => setShowProjectCreationModal(false)}
         onProjectCreated={fetchProjects}
         mode="create"

--- a/src/context/FlowCouncil.tsx
+++ b/src/context/FlowCouncil.tsx
@@ -220,7 +220,7 @@ function FlowCouncilContextProviderInner({
     councilId?.toLowerCase() === GOODBUILDERS_COUNCIL_ADDRESSES[1];
   const { staleVotes, isLoading: isLoadingStaleVotes } = useStaleVotesQuery(
     isGoodDollarCouncil ? councilId : "",
-    isGoodDollarCouncil ? address ?? "" : "",
+    isGoodDollarCouncil ? (address ?? "") : "",
   );
   const staleVotesList = useMemo((): Vote[] => {
     if (!currentBallot?.votes || !council?.recipients) return [];

--- a/src/hooks/requireAuth.ts
+++ b/src/hooks/requireAuth.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef } from "react";
 import { useAccount } from "wagmi";
-import { getCsrfToken, useSession } from "next-auth/react";
+import { useSession } from "next-auth/react";
 import { useConnectModal } from "@rainbow-me/rainbowkit";
 import useSiwe from "./siwe";
 
@@ -24,11 +24,7 @@ export default function useRequireAuth() {
         return false;
       }
       if (!hasSession) {
-        getCsrfToken()
-          .then((token) => {
-            if (token) handleSignIn(token);
-          })
-          .catch(console.error);
+        handleSignIn();
         const id = ++latestAuthRequestId;
         pendingRef.current = { id, callback: onAuthed };
         return false;

--- a/src/hooks/siwe.ts
+++ b/src/hooks/siwe.ts
@@ -1,6 +1,6 @@
 import { signIn } from "next-auth/react";
-import { SiweMessage } from "siwe";
 import { useAccount, useSignMessage } from "wagmi";
+import { createSiweMessage } from "viem/siwe";
 
 export default function useSiwe() {
   const { address, chain } = useAccount();
@@ -9,21 +9,19 @@ export default function useSiwe() {
   const handleSignIn = async (csfrToken: string) => {
     try {
       const callbackUrl = "/protected";
-      const message = new SiweMessage({
+      const message = createSiweMessage({
         domain: window.location.host,
-        address,
+        address: address!,
         statement: "Sign in with Ethereum to Flow State.",
         uri: window.location.origin,
-        version: "1",
-        chainId: chain?.id,
+        version: "1" as const,
+        chainId: chain!.id,
         nonce: csfrToken,
       });
-      const signature = await signMessageAsync({
-        message: message.prepareMessage(),
-      });
+      const signature = await signMessageAsync({ message });
 
       signIn("credentials", {
-        message: JSON.stringify(message),
+        message,
         redirect: false,
         signature,
         callbackUrl,

--- a/src/hooks/siwe.ts
+++ b/src/hooks/siwe.ts
@@ -1,35 +1,60 @@
-import { signIn } from "next-auth/react";
-import { useAccount, useSignMessage } from "wagmi";
+import { useCallback } from "react";
+import { getCsrfToken, signIn } from "next-auth/react";
+import { useAccount, useSignMessage, useSwitchChain } from "wagmi";
+import { ConnectorChainMismatchError } from "@wagmi/core";
 import { createSiweMessage } from "viem/siwe";
 
 export default function useSiwe() {
   const { address, chain } = useAccount();
   const { signMessageAsync } = useSignMessage();
+  const { switchChainAsync } = useSwitchChain();
 
-  const handleSignIn = async (csfrToken: string) => {
+  const handleSignIn = useCallback(async () => {
     try {
-      const callbackUrl = "/protected";
+      if (!address || !chain) return;
+
+      const nonce = await getCsrfToken();
+      if (!nonce) return;
+
       const message = createSiweMessage({
         domain: window.location.host,
-        address: address!,
+        address,
         statement: "Sign in with Ethereum to Flow State.",
         uri: window.location.origin,
-        version: "1" as const,
-        chainId: chain!.id,
-        nonce: csfrToken,
+        version: "1",
+        chainId: chain.id,
+        nonce,
       });
-      const signature = await signMessageAsync({ message });
 
-      signIn("credentials", {
-        message,
-        redirect: false,
-        signature,
-        callbackUrl,
-      });
+      try {
+        const signature = await signMessageAsync({ message });
+
+        signIn("credentials", {
+          message,
+          redirect: false,
+          signature,
+        });
+      } catch (error) {
+        if (error instanceof ConnectorChainMismatchError) {
+          await switchChainAsync({ chainId: chain.id });
+          const signature = await signMessageAsync({ message });
+
+          signIn("credentials", {
+            message,
+            redirect: false,
+            signature,
+          });
+        } else {
+          throw error;
+        }
+      }
     } catch (error) {
+      if (error instanceof Error && error.name === "UserRejectedRequestError") {
+        return;
+      }
       window.alert(error);
     }
-  };
+  }, [address, chain, signMessageAsync, switchChainAsync]);
 
   return { handleSignIn };
 }


### PR DESCRIPTION
## Summary
- Replaces the `siwe` npm package with `viem/siwe` utilities (`createSiweMessage`, `parseSiweMessage`, `verifySiweMessage`), removing a direct dependency
- Fixes broken SIWE sign-in for users without an existing NextAuth session (empty nonce from missing cookie caused `SiweInvalidMessageFieldError`)
- Fixes `ConnectorChainMismatchError` when the wallet is on a different chain than wagmi expects (e.g. wallet on Arbitrum, wagmi tracking Base)
- Removes CSRF token prop-drilling from 11 server pages and 13 client components

## What changed

**`src/hooks/siwe.ts`** — the core of the fix:
- `handleSignIn()` now fetches the CSRF token internally via `getCsrfToken()` instead of accepting it as a parameter. This guarantees a valid nonce regardless of cookie state.
- Wrapped in `useCallback` for referential stability
- Added `if (!address || !chain) return` guard instead of non-null assertions
- Catches `ConnectorChainMismatchError` → auto-switches chain and retries signing
- Silences `UserRejectedRequestError` (user dismissed wallet popup)

**`src/app/api/auth/[...nextauth]/route.ts`**:
- Replaced `new SiweMessage()` + `prepareMessage()` with `parseSiweMessage()` from viem/siwe
- Message is now passed as a plain string (not JSON-serialized) matching `createSiweMessage` output

**11 server page files**: Removed `cookies()` reads and `csrfToken` prop passing
**13 client component files**: Removed `csrfToken`/`csfrToken` props and updated `handleSignIn()` calls (no args)

## Test plan
- [ ] Connect wallet on `/projects` and click Create Project — should sign in without nonce error
- [ ] Test with wallet on a different chain than the app expects — should auto-switch and sign
- [ ] Dismiss the wallet signature popup — should return silently (no alert)
- [ ] Test SIWE sign-in on flow council pages (review, permissions, communications, launch)
- [ ] Test with a Safe wallet (smart contract wallet)
- [ ] Verify sign-in works on first visit (no prior NextAuth cookies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)