### PR TITLE
fix: show available balance below stream rate & guard self-streams

### DIFF
--- a/src/app/projects/[id]/GardensPoolFunding.tsx
+++ b/src/app/projects/[id]/GardensPoolFunding.tsx
@@ -229,6 +229,13 @@ function StreamInputs({
           onChange={(e) => stream.handleMonthlyAmountChange(e.target.value)}
           className="rounded-3"
         />
+        {stream.address && stream.userMonthlyRate !== null && (
+          <Form.Text>
+            Available:{" "}
+            {formatNumber(Number(formatEther(stream.superTokenBalance)))}{" "}
+            {stream.selectedToken.symbol}
+          </Form.Text>
+        )}
       </Form.Group>
 
       {(stream.isSuperTokenNative || stream.isSuperTokenWrapper) && (
@@ -347,6 +354,11 @@ function StreamInputs({
         )}
       </Stack>
 
+      {stream.isSelfStream && (
+        <div className="text-danger" style={{ fontSize: "0.85rem" }}>
+          You cannot open a stream to yourself.
+        </div>
+      )}
       {stream.transactionError && (
         <div className="text-danger" style={{ fontSize: "0.85rem" }}>
           {stream.transactionError}

--- a/src/app/projects/[id]/useStreamFunding.ts
+++ b/src/app/projects/[id]/useStreamFunding.ts
@@ -522,13 +522,19 @@ export default function useStreamFunding(
   const bufferExceedsBalance =
     !!liquidationEstimate && liquidationEstimate.bufferExceedsBalance;
 
+  const isSelfStream =
+    !!address &&
+    !!receiverAddress &&
+    address.toLowerCase() === receiverAddress.toLowerCase();
+
   const canExecute =
     !!address &&
     !!newFlowRate &&
     BigInt(newFlowRate) > 0 &&
     !areTransactionsLoading &&
     !wrapAmountExceedsBalance &&
-    !bufferExceedsBalance;
+    !bufferExceedsBalance &&
+    !isSelfStream;
 
   const resetInputs = useCallback(() => {
     userEditedMonthlyAmount.current = false;
@@ -590,5 +596,6 @@ export default function useStreamFunding(
     isCorrectChain,
     switchChain,
     resetInputs,
+    isSelfStream,
   };
 }


### PR DESCRIPTION
## Summary
- Show the user's super token balance ("Available: X TOKEN") directly below the Monthly stream rate input, mirroring the pattern already used below the Wrap amount field
- Add a client-side check that prevents users from opening a stream to their own wallet, with a clear warning message ("You cannot open a stream to yourself.")

## Test plan
- [ ] Connect wallet on a project page → confirm "Available:" appears below Monthly stream rate with correct balance and token symbol
- [ ] Verify "Available:" is not shown when wallet is disconnected
- [ ] Connect with the project's own receiver wallet address → confirm warning text appears and Start Stream button is disabled
- [ ] Verify both fixes work on the Gardens Pool funding card and the Direct Funding card

🤖 Generated with [Claude Code](https://claude.com/claude-code)