### PR TITLE
fix: normalize website and demo URLs to prevent malformed links

### DIFF
--- a/src/app/flow-councils/components/GranteeDetails.tsx
+++ b/src/app/flow-councils/components/GranteeDetails.tsx
@@ -136,7 +136,7 @@ export default function GranteeDetails(props: GranteeDetailsProps) {
             {!!details.website && (
               <Button
                 variant="link"
-                href={`https://${details.website}`}
+                href={`https://${details.website.replace(/^https?:\/\//, "")}`}
                 target="_blank"
                 className="p-0"
               >
@@ -146,7 +146,7 @@ export default function GranteeDetails(props: GranteeDetailsProps) {
             {!!details.demoUrl && (
               <Button
                 variant="link"
-                href={details.demoUrl}
+                href={`https://${details.demoUrl.replace(/^https?:\/\//, "")}`}
                 target="_blank"
                 className="p-0"
               >

--- a/src/app/projects/[id]/project.tsx
+++ b/src/app/projects/[id]/project.tsx
@@ -238,7 +238,7 @@ export default function Project(props: ProjectProps) {
           {!!details?.demoUrl && (
             <Button
               variant="link"
-              href={details.demoUrl}
+              href={`https://${details.demoUrl.replace(/^https?:\/\//, "")}`}
               target="_blank"
               className="d-flex gap-1 align-items-center p-0 text-info text-decoration-none overflow-hidden"
               style={{ width: !isMobile ? "33%" : "100%", minWidth: 0 }}


### PR DESCRIPTION
## Summary
- **Fixes double-protocol bug** in `GranteeDetails.tsx` where `website` was rendered as `https://${details.website}` — producing `https://http://...` when the stored value already had a protocol (e.g. Esusu project in GoodBuilders Season 3)
- **Normalizes `demoUrl`** in both `GranteeDetails.tsx` and `project.tsx` using the same strip-then-prepend pattern

## Test plan
- [ ] Open a Flow Council page → click a recipient whose website was entered with `http://` → verify the website link in Recipient Details opens correctly
- [ ] Verify demo URL links also open correctly on both the Recipient Details panel and the `/projects/[id]` page

🤖 Generated with [Claude Code](https://claude.com/claude-code)