### PR TITLE
feat: allow reactions with wallet only, remove SIWE requirement

### DIFF
--- a/src/app/api/flow-council/messages/[messageId]/reactions/route.ts
+++ b/src/app/api/flow-council/messages/[messageId]/reactions/route.ts
@@ -13,15 +13,7 @@ export async function POST(
 ) {
   try {
     const { messageId } = await params;
-    const { emoji, chainId, councilId } = await request.json();
-
-    const session = await getServerSession(authOptions);
-
-    if (!session?.address) {
-      return new Response(
-        JSON.stringify({ success: false, error: "Unauthenticated" }),
-      );
-    }
+    const { emoji, chainId, councilId, authorAddress } = await request.json();
 
     const validation = validateReactionEmoji(emoji);
     if (!validation.success) {
@@ -53,7 +45,24 @@ export async function POST(
       message.channelType === "PUBLIC_PROJECT" ||
       message.channelType === "PUBLIC_ROUND";
 
-    if (!isPublicChannel) {
+    let address: string;
+
+    if (isPublicChannel) {
+      if (!authorAddress || !isAddress(authorAddress)) {
+        return new Response(
+          JSON.stringify({ success: false, error: "Invalid author address" }),
+        );
+      }
+      address = authorAddress;
+    } else {
+      const session = await getServerSession(authOptions);
+
+      if (!session?.address) {
+        return new Response(
+          JSON.stringify({ success: false, error: "Unauthenticated" }),
+        );
+      }
+
       if (!chainId || !councilId) {
         return new Response(
           JSON.stringify({
@@ -92,13 +101,15 @@ export async function POST(
           JSON.stringify({ success: false, error: "Not authorized" }),
         );
       }
+
+      address = session.address;
     }
 
     const existing = await db
       .selectFrom("messageReactions")
       .select("id")
       .where("messageId", "=", messageIdNum)
-      .where("authorAddress", "=", session.address.toLowerCase())
+      .where("authorAddress", "=", address.toLowerCase())
       .where("emoji", "=", validation.data)
       .executeTakeFirst();
 
@@ -115,7 +126,7 @@ export async function POST(
       .insertInto("messageReactions")
       .values({
         messageId: messageIdNum,
-        authorAddress: session.address.toLowerCase(),
+        authorAddress: address.toLowerCase(),
         emoji: validation.data,
       })
       .execute();

--- a/src/app/api/flow-council/messages/route.ts
+++ b/src/app/api/flow-council/messages/route.ts
@@ -3,6 +3,7 @@ import { isAddress } from "viem";
 import { db } from "../db";
 import { authOptions } from "../../auth/[...nextauth]/route";
 import { fetchDisplayNames, fetchReactions } from "../enrichment";
+import { parseAddressParam } from "../validation";
 import { ChannelType } from "@/generated/kysely";
 import {
   sendChatMessageEmail,
@@ -186,12 +187,14 @@ export async function GET(request: Request) {
       managedProjectIds = managed.map((m) => m.projectId);
     }
 
+    const reactionsAddress = parseAddressParam(searchParams.get("address"));
+
     const authorAddressesForNames = messages.map((m) => m.authorAddress);
     const [displayNames, reactions] = await Promise.all([
       fetchDisplayNames(authorAddressesForNames),
       fetchReactions(
         messages.map((m) => m.id),
-        session?.address,
+        reactionsAddress,
       ),
     ]);
 

--- a/src/app/api/flow-council/round-feed/route.ts
+++ b/src/app/api/flow-council/round-feed/route.ts
@@ -1,10 +1,9 @@
-import { getServerSession } from "next-auth/next";
 import { isAddress } from "viem";
 import { db } from "../db";
-import { authOptions } from "../../auth/[...nextauth]/route";
 import { findRoundByCouncil } from "../auth";
 import { getAuthorAffiliations } from "../affiliations";
 import { fetchDisplayNames, fetchReactions } from "../enrichment";
+import { parseAddressParam } from "../validation";
 import { parseDetails, type ProjectMetadata } from "../utils";
 import type { ProjectDetails } from "@/types/project";
 
@@ -91,8 +90,6 @@ export async function GET(request: Request) {
       }
     }
 
-    const session = await getServerSession(authOptions);
-
     const authorAddresses = messages.map((m) => m.authorAddress);
     const affiliations = await getAuthorAffiliations(
       authorAddresses,
@@ -101,11 +98,13 @@ export async function GET(request: Request) {
       councilId,
     );
 
+    const reactionsAddress = parseAddressParam(searchParams.get("address"));
+
     const [displayNames, reactions] = await Promise.all([
       fetchDisplayNames(authorAddresses),
       fetchReactions(
         messages.map((m) => m.id),
-        session?.address,
+        reactionsAddress,
       ),
     ]);
 

--- a/src/app/api/flow-council/validation.ts
+++ b/src/app/api/flow-council/validation.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { isAddress } from "viem";
 import { CHARACTER_LIMITS } from "@/app/flow-councils/constants";
 import { ALLOWED_REACTIONS } from "@/app/flow-councils/lib/constants";
 import type {
@@ -275,6 +276,10 @@ export function validateDisplayName(data: unknown): ValidationResult<string> {
     return { success: false, error: issue.message };
   }
   return { success: true, data: result.data };
+}
+
+export function parseAddressParam(value: string | null): string | undefined {
+  return value && isAddress(value) ? value : undefined;
 }
 
 export function validateReactionEmoji(

--- a/src/app/flow-councils/components/ChatView.tsx
+++ b/src/app/flow-councils/components/ChatView.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useSession } from "next-auth/react";
+import { useConnectModal } from "@rainbow-me/rainbowkit";
 import Stack from "react-bootstrap/Stack";
 import Spinner from "react-bootstrap/Spinner";
 import Alert from "react-bootstrap/Alert";
@@ -74,6 +75,7 @@ export default function ChatView(props: ChatViewProps) {
   const [editingMessage, setEditingMessage] = useState<Message | null>(null);
 
   const { data: session } = useSession();
+  const { openConnectModal } = useConnectModal();
   const messagesContainerRef = useRef<HTMLDivElement>(null);
 
   const {
@@ -88,8 +90,9 @@ export default function ChatView(props: ChatViewProps) {
     messages,
     chainId,
     councilId,
-    sessionAddress: session?.address,
+    userAddress: currentUserAddress,
     newestFirst,
+    onConnectWallet: openConnectModal,
   });
 
   const authorAddresses = useMemo(() => {
@@ -106,9 +109,18 @@ export default function ChatView(props: ChatViewProps) {
     if (roundId) params.set("roundId", roundId.toString());
     if (applicationId) params.set("applicationId", applicationId.toString());
     if (projectId) params.set("projectId", projectId.toString());
+    if (currentUserAddress) params.set("address", currentUserAddress);
 
     return params.toString();
-  }, [channelType, chainId, councilId, roundId, applicationId, projectId]);
+  }, [
+    channelType,
+    chainId,
+    councilId,
+    roundId,
+    applicationId,
+    projectId,
+    currentUserAddress,
+  ]);
 
   const fetchMessages = useCallback(async () => {
     try {
@@ -341,7 +353,6 @@ export default function ChatView(props: ChatViewProps) {
                 onReactionToggle={(emoji) =>
                   handleReactionToggle(message.id, emoji)
                 }
-                reactionsDisabled={!session?.address}
                 isPinned={!!message.pinnedAt}
                 canPin={canModerate}
                 onPin={() =>

--- a/src/app/flow-councils/components/ChatView.tsx
+++ b/src/app/flow-councils/components/ChatView.tsx
@@ -101,6 +101,9 @@ export default function ChatView(props: ChatViewProps) {
 
   const { ensByAddress } = useEnsResolution(authorAddresses);
 
+  const currentUserAddressRef = useRef(currentUserAddress);
+  currentUserAddressRef.current = currentUserAddress;
+
   const buildQueryParams = useCallback(() => {
     const params = new URLSearchParams({ channelType });
 
@@ -109,18 +112,11 @@ export default function ChatView(props: ChatViewProps) {
     if (roundId) params.set("roundId", roundId.toString());
     if (applicationId) params.set("applicationId", applicationId.toString());
     if (projectId) params.set("projectId", projectId.toString());
-    if (currentUserAddress) params.set("address", currentUserAddress);
+    if (currentUserAddressRef.current)
+      params.set("address", currentUserAddressRef.current);
 
     return params.toString();
-  }, [
-    channelType,
-    chainId,
-    councilId,
-    roundId,
-    applicationId,
-    projectId,
-    currentUserAddress,
-  ]);
+  }, [channelType, chainId, councilId, roundId, applicationId, projectId]);
 
   const fetchMessages = useCallback(async () => {
     try {

--- a/src/app/flow-councils/components/RoundFeedView.tsx
+++ b/src/app/flow-councils/components/RoundFeedView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useSession } from "next-auth/react";
 import { useConnectModal } from "@rainbow-me/rainbowkit";
 import Stack from "react-bootstrap/Stack";
@@ -78,6 +78,9 @@ export default function RoundFeedView(props: RoundFeedViewProps) {
 
   const { ensByAddress } = useEnsResolution(authorAddresses);
 
+  const currentUserAddressRef = useRef(currentUserAddress);
+  currentUserAddressRef.current = currentUserAddress;
+
   const fetchMessages = useCallback(async () => {
     try {
       setIsLoading(true);
@@ -85,7 +88,8 @@ export default function RoundFeedView(props: RoundFeedViewProps) {
         chainId: chainId.toString(),
         councilId,
       });
-      if (currentUserAddress) params.set("address", currentUserAddress);
+      if (currentUserAddressRef.current)
+        params.set("address", currentUserAddressRef.current);
       const res = await fetch(`/api/flow-council/round-feed?${params}`);
       const data = await res.json();
 
@@ -109,7 +113,7 @@ export default function RoundFeedView(props: RoundFeedViewProps) {
     } finally {
       setIsLoading(false);
     }
-  }, [chainId, councilId, currentUserAddress, setFetchedData, clearData]);
+  }, [chainId, councilId, setFetchedData, clearData]);
 
   useEffect(() => {
     fetchMessages();

--- a/src/app/flow-councils/components/RoundFeedView.tsx
+++ b/src/app/flow-councils/components/RoundFeedView.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { useSession } from "next-auth/react";
+import { useConnectModal } from "@rainbow-me/rainbowkit";
 import Stack from "react-bootstrap/Stack";
 import Spinner from "react-bootstrap/Spinner";
 import Alert from "react-bootstrap/Alert";
@@ -52,6 +53,7 @@ export default function RoundFeedView(props: RoundFeedViewProps) {
   );
 
   const { data: session } = useSession();
+  const { openConnectModal } = useConnectModal();
 
   const {
     displayNames,
@@ -65,8 +67,9 @@ export default function RoundFeedView(props: RoundFeedViewProps) {
     messages,
     chainId,
     councilId,
-    sessionAddress: session?.address,
+    userAddress: currentUserAddress,
     newestFirst: true,
+    onConnectWallet: openConnectModal,
   });
 
   const authorAddresses = useMemo(() => {
@@ -82,6 +85,7 @@ export default function RoundFeedView(props: RoundFeedViewProps) {
         chainId: chainId.toString(),
         councilId,
       });
+      if (currentUserAddress) params.set("address", currentUserAddress);
       const res = await fetch(`/api/flow-council/round-feed?${params}`);
       const data = await res.json();
 
@@ -105,7 +109,7 @@ export default function RoundFeedView(props: RoundFeedViewProps) {
     } finally {
       setIsLoading(false);
     }
-  }, [chainId, councilId, setFetchedData, clearData]);
+  }, [chainId, councilId, currentUserAddress, setFetchedData, clearData]);
 
   useEffect(() => {
     fetchMessages();
@@ -258,7 +262,6 @@ export default function RoundFeedView(props: RoundFeedViewProps) {
                 onReactionToggle={(emoji) =>
                   handleReactionToggle(message.id, emoji)
                 }
-                reactionsDisabled={!session?.address}
                 isPinned={!!message.pinnedAt}
                 canPin={isAdmin}
                 onPin={() =>

--- a/src/app/flow-councils/components/chat/MessageItem.tsx
+++ b/src/app/flow-councils/components/chat/MessageItem.tsx
@@ -37,7 +37,6 @@ type MessageItemProps = {
   hideAdminTag?: boolean;
   reactions?: ReactionSummary[];
   onReactionToggle?: (emoji: string) => void;
-  reactionsDisabled?: boolean;
   isPinned?: boolean;
   canPin?: boolean;
   onPin?: () => void;
@@ -84,7 +83,6 @@ export default function MessageItem(props: MessageItemProps) {
     hideAdminTag,
     reactions,
     onReactionToggle,
-    reactionsDisabled,
     isPinned,
     canPin,
     onPin,
@@ -190,16 +188,14 @@ export default function MessageItem(props: MessageItemProps) {
       <Markdown className={`mb-0 ms-5 ${isSystemMessage ? "fst-italic" : ""}`}>
         {message.content}
       </Markdown>
-      {onReactionToggle &&
-        (!reactionsDisabled || (reactions && reactions.length > 0)) && (
-          <div className="ms-5">
-            <ReactionBar
-              reactions={reactions || []}
-              onToggle={onReactionToggle}
-              disabled={reactionsDisabled}
-            />
-          </div>
-        )}
+      {onReactionToggle && (
+        <div className="ms-5">
+          <ReactionBar
+            reactions={reactions || []}
+            onToggle={onReactionToggle}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/flow-councils/components/chat/ReactionBar.tsx
+++ b/src/app/flow-councils/components/chat/ReactionBar.tsx
@@ -16,14 +16,9 @@ export type ReactionSummary = {
 type ReactionBarProps = {
   reactions: ReactionSummary[];
   onToggle: (emoji: string) => void;
-  disabled?: boolean;
 };
 
-export default function ReactionBar({
-  reactions,
-  onToggle,
-  disabled = false,
-}: ReactionBarProps) {
+export default function ReactionBar({ reactions, onToggle }: ReactionBarProps) {
   const [showPicker, setShowPicker] = useState(false);
   const pickerRef = useRef<HTMLButtonElement>(null);
 
@@ -35,56 +30,49 @@ export default function ReactionBar({
           bg=""
           text="dark"
           className={`d-inline-flex align-items-center gap-1 fw-normal border ${r.hasReacted ? "border-primary" : ""}`}
-          role={disabled ? undefined : "button"}
-          onClick={disabled ? undefined : () => onToggle(r.emoji)}
-          style={{
-            cursor: disabled ? "default" : "pointer",
-            fontSize: "0.85rem",
-          }}
+          role="button"
+          onClick={() => onToggle(r.emoji)}
+          style={{ cursor: "pointer", fontSize: "0.85rem" }}
         >
           <span>{r.emoji}</span>
           <span>{r.count}</span>
         </Badge>
       ))}
-      {!disabled && (
-        <>
-          <button
-            ref={pickerRef}
-            onClick={() => setShowPicker(!showPicker)}
-            className="btn btn-sm btn-outline-secondary border rounded-pill d-inline-flex align-items-center justify-content-center"
-            style={{ width: 28, height: 28, padding: 0, fontSize: "0.8rem" }}
-          >
-            +
-          </button>
-          <Overlay
-            target={pickerRef.current}
-            show={showPicker}
-            placement="top"
-            rootClose
-            onHide={() => setShowPicker(false)}
-          >
-            <Popover>
-              <Popover.Body className="p-2">
-                <Stack direction="horizontal" gap={1}>
-                  {ALLOWED_REACTIONS.map((emoji) => (
-                    <button
-                      key={emoji}
-                      className="btn btn-sm btn-light"
-                      style={{ fontSize: "1.1rem", padding: "2px 6px" }}
-                      onClick={() => {
-                        onToggle(emoji);
-                        setShowPicker(false);
-                      }}
-                    >
-                      {emoji}
-                    </button>
-                  ))}
-                </Stack>
-              </Popover.Body>
-            </Popover>
-          </Overlay>
-        </>
-      )}
+      <button
+        ref={pickerRef}
+        onClick={() => setShowPicker(!showPicker)}
+        className="btn btn-sm btn-outline-secondary border rounded-pill d-inline-flex align-items-center justify-content-center"
+        style={{ width: 28, height: 28, padding: 0, fontSize: "0.8rem" }}
+      >
+        +
+      </button>
+      <Overlay
+        target={pickerRef.current}
+        show={showPicker}
+        placement="top"
+        rootClose
+        onHide={() => setShowPicker(false)}
+      >
+        <Popover>
+          <Popover.Body className="p-2">
+            <Stack direction="horizontal" gap={1}>
+              {ALLOWED_REACTIONS.map((emoji) => (
+                <button
+                  key={emoji}
+                  className="btn btn-sm btn-light"
+                  style={{ fontSize: "1.1rem", padding: "2px 6px" }}
+                  onClick={() => {
+                    onToggle(emoji);
+                    setShowPicker(false);
+                  }}
+                >
+                  {emoji}
+                </button>
+              ))}
+            </Stack>
+          </Popover.Body>
+        </Popover>
+      </Overlay>
     </Stack>
   );
 }

--- a/src/app/flow-councils/hooks/chatActions.ts
+++ b/src/app/flow-councils/hooks/chatActions.ts
@@ -10,16 +10,18 @@ type ChatActionsParams<T extends PinnableMessage> = {
   messages: T[];
   chainId?: number;
   councilId?: string;
-  sessionAddress?: string;
+  userAddress?: string;
   newestFirst?: boolean;
+  onConnectWallet?: () => void;
 };
 
 export function useChatActions<T extends PinnableMessage>({
   messages,
   chainId,
   councilId,
-  sessionAddress,
+  userAddress,
   newestFirst = false,
+  onConnectWallet,
 }: ChatActionsParams<T>) {
   const [displayNames, setDisplayNames] = useState<Record<string, string>>({});
   const [reactions, setReactions] = useState<Record<number, ReactionSummary[]>>(
@@ -99,7 +101,10 @@ export function useChatActions<T extends PinnableMessage>({
 
   const handleReactionToggle = useCallback(
     async (messageId: number, emoji: string) => {
-      if (!sessionAddress) return;
+      if (!userAddress) {
+        onConnectWallet?.();
+        return;
+      }
 
       let rollback: ReactionSummary[] | undefined;
 
@@ -129,7 +134,12 @@ export function useChatActions<T extends PinnableMessage>({
           `/api/flow-council/messages/${messageId}/reactions`,
           {
             method: "POST",
-            body: JSON.stringify({ emoji, chainId, councilId }),
+            body: JSON.stringify({
+              emoji,
+              chainId,
+              councilId,
+              authorAddress: userAddress,
+            }),
           },
         );
         const data = await res.json();
@@ -141,7 +151,7 @@ export function useChatActions<T extends PinnableMessage>({
         setReactions((r) => ({ ...r, [messageId]: rollback! }));
       }
     },
-    [sessionAddress, chainId, councilId],
+    [userAddress, onConnectWallet, chainId, councilId],
   );
 
   return {


### PR DESCRIPTION
## Summary
- Public channel reactions (project feed, round feed) no longer require SIWE — a connected wallet is sufficient
- The reaction "+" button and badges are always visible; clicking without a wallet triggers the connect modal
- Private channels (internal comments, communications) still require SIWE for permission checks

## Changes
- **Backend**: Reaction POST accepts `authorAddress` from body for public channels (skips session lookup). GET routes accept `address` query param for `hasReacted` via shared `parseAddressParam` helper.
- **Frontend**: `useChatActions` hook takes `userAddress` (renamed from `sessionAddress`) and `onConnectWallet` callback. ChatView/RoundFeedView pass wallet address and `openConnectModal`.

## Test plan
- [ ] Connect wallet (no SIWE) on a project feed page → click "+" → reaction applies immediately
- [ ] Refresh page → reaction still shows as highlighted (hasReacted via query param)
- [ ] No wallet → click "+" → wallet connect modal opens
- [ ] Round feed tab: same flow as above
- [ ] Private channels (internal comments): existing behavior unchanged, reactions still require SIWE

🤖 Generated with [Claude Code](https://claude.com/claude-code)