### PR TITLE
feat: show SUP rewards badge on 3 more explore cards

### DIFF
--- a/src/app/explore/explore.tsx
+++ b/src/app/explore/explore.tsx
@@ -96,6 +96,7 @@ export default function Explore(props: ExploreProps) {
             activeStreamCount={goodBuildersS3Inflow?.activeIncomingStreamCount}
             tokenSymbol="G$"
             link="https://flowstate.network/goodbuilders-3"
+            showSupRewards
           />
           <RoundCard
             name="Arbitrum Mini Apps"
@@ -121,6 +122,7 @@ export default function Explore(props: ExploreProps) {
             activeStreamCount={coreInflow?.activeIncomingStreamCount}
             tokenSymbol="ETHx"
             link="/flow-guilds/core"
+            showSupRewards
           />
           <RoundCard
             name="Cracked Devs"
@@ -145,6 +147,7 @@ export default function Explore(props: ExploreProps) {
             activeStreamCount={guildGuildInflow?.activeIncomingStreamCount}
             tokenSymbol="ETHx"
             link="/flow-guilds/guild-guild"
+            showSupRewards
           />
         </div>
         <span className="fs-4 fw-semi-bold">Completed</span>


### PR DESCRIPTION
## Summary
- Adds `showSupRewards` to the GoodBuilders S3, Core Contributors, and Guild Guild cards on `/explore`
- Same SUP logo treatment already used on the Arbitrum Mini Apps card

## Test plan
- [ ] Visit `/explore` and confirm the SUP badge appears on GoodBuilders S3, Core Contributors, and Guild Guild
- [ ] Confirm Arbitrum Mini Apps still renders the SUP badge
- [ ] Confirm Cracked Devs and Completed-section cards are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)