### PR TITLE
test: add API + DB integration tests (phase 2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@typescript-eslint/parser": "^7.9.0",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^4.1.4",
+    "dotenv": "^17.4.2",
     "eslint": "^8",
     "eslint-config-next": "15.5.15",
     "happy-dom": "^20.8.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.4
         version: 4.1.4(vitest@4.1.4)
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
       eslint:
         specifier: ^8
         version: 8.57.1
@@ -3646,6 +3649,10 @@ packages:
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
@@ -12254,6 +12261,8 @@ snapshots:
       csstype: 3.1.3
 
   dotenv@16.6.1: {}
+
+  dotenv@17.4.2: {}
 
   dunder-proto@1.0.1:
     dependencies:

--- a/src/app/api/flow-council/applications/route.integration.test.ts
+++ b/src/app/api/flow-council/applications/route.integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
 
 vi.mock("next-auth/next", () => ({
   getServerSession: vi.fn(),
@@ -38,10 +38,6 @@ import { mockSession, mockUnauthenticated } from "../../../../../tests/helpers/s
 const db = getTestDb();
 
 let fixture: SeededFixture;
-
-beforeAll(async () => {
-  fixture = await resetAndSeed(db);
-});
 
 afterAll(async () => {
   await resetDb(db);

--- a/src/app/api/flow-council/applications/route.integration.test.ts
+++ b/src/app/api/flow-council/applications/route.integration.test.ts
@@ -7,7 +7,7 @@ vi.mock("next-auth/next", () => ({
 vi.mock("@/app/api/auth/[...nextauth]/route", () => ({ authOptions: {} }));
 
 vi.mock("../db", async () => {
-  const { getTestDb } = await import("../../../../../tests/helpers/db");
+  const { getTestDb } = await import("@tests/helpers/db");
   return { db: getTestDb() };
 });
 
@@ -32,8 +32,8 @@ import {
   TEST_COUNCIL_ADDRESS,
   TEST_CHAIN_ID,
   type SeededFixture,
-} from "../../../../../tests/helpers/db";
-import { mockSession, mockUnauthenticated } from "../../../../../tests/helpers/session";
+} from "@tests/helpers/db";
+import { mockSession, mockUnauthenticated } from "@tests/helpers/session";
 
 const db = getTestDb();
 
@@ -171,7 +171,11 @@ describe("POST /api/flow-council/applications", () => {
         mode: "list",
       }),
     );
-    expect(hasOnChainRole).toHaveBeenCalled();
+    expect(hasOnChainRole).toHaveBeenCalledWith(
+      TEST_CHAIN_ID,
+      TEST_COUNCIL_ADDRESS,
+      TEST_MANAGER_ADDRESS,
+    );
   });
 });
 

--- a/src/app/api/flow-council/applications/route.integration.test.ts
+++ b/src/app/api/flow-council/applications/route.integration.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from "vitest";
+
+vi.mock("next-auth/next", () => ({
+  getServerSession: vi.fn(),
+}));
+
+vi.mock("@/app/api/auth/[...nextauth]/route", () => ({ authOptions: {} }));
+
+vi.mock("../db", async () => {
+  const { getTestDb } = await import("../../../../../tests/helpers/db");
+  return { db: getTestDb() };
+});
+
+vi.mock("../auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../auth")>();
+  return {
+    ...actual,
+    hasOnChainRole: vi.fn().mockResolvedValue(false),
+  };
+});
+
+import { POST, PUT } from "./route";
+import { hasOnChainRole } from "../auth";
+import {
+  getTestDb,
+  resetAndSeed,
+  resetDb,
+  TEST_MANAGER_ADDRESS,
+  TEST_OTHER_MANAGER_ADDRESS,
+  TEST_ADMIN_ADDRESS,
+  TEST_OUTSIDER_ADDRESS,
+  TEST_COUNCIL_ADDRESS,
+  TEST_CHAIN_ID,
+  type SeededFixture,
+} from "../../../../../tests/helpers/db";
+import { mockSession, mockUnauthenticated } from "../../../../../tests/helpers/session";
+
+const db = getTestDb();
+
+let fixture: SeededFixture;
+
+beforeAll(async () => {
+  fixture = await resetAndSeed(db);
+});
+
+afterAll(async () => {
+  await resetDb(db);
+  await db.destroy();
+});
+
+beforeEach(async () => {
+  vi.mocked(hasOnChainRole).mockResolvedValue(false);
+  fixture = await resetAndSeed(db);
+});
+
+async function readJson(res: Response) {
+  return JSON.parse(await res.text());
+}
+
+function postRequest(body: unknown) {
+  return new Request("http://localhost/api/flow-council/applications", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function putRequest(body: unknown) {
+  return new Request("http://localhost/api/flow-council/applications", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/flow-council/applications", () => {
+  it("returns 401 without a session", async () => {
+    mockUnauthenticated();
+    const res = await POST(postRequest({
+      chainId: TEST_CHAIN_ID,
+      councilId: TEST_COUNCIL_ADDRESS,
+    }));
+    expect(res.status).toBe(401);
+    const body = await readJson(res);
+    expect(body).toEqual({ success: false, error: "Unauthenticated" });
+  });
+
+  it("returns empty list when round does not exist", async () => {
+    mockSession(TEST_MANAGER_ADDRESS);
+    const res = await POST(
+      postRequest({
+        chainId: TEST_CHAIN_ID,
+        councilId: "0x0000000000000000000000000000000000000099",
+      }),
+    );
+    const body = await readJson(res);
+    expect(body).toEqual({ success: true, applications: [] });
+  });
+
+  it("rejects invalid chainId", async () => {
+    mockSession(TEST_MANAGER_ADDRESS);
+    const res = await POST(
+      postRequest({
+        chainId: 999999,
+        councilId: TEST_COUNCIL_ADDRESS,
+      }),
+    );
+    const body = await readJson(res);
+    expect(body).toEqual({ success: false, error: "Wrong network" });
+  });
+
+  it("rejects invalid councilId", async () => {
+    mockSession(TEST_MANAGER_ADDRESS);
+    const res = await POST(
+      postRequest({
+        chainId: TEST_CHAIN_ID,
+        councilId: "notanaddress",
+      }),
+    );
+    const body = await readJson(res);
+    expect(body).toEqual({ success: false, error: "Invalid council ID" });
+  });
+
+  it("returns only own applications in list mode for a non-admin manager", async () => {
+    mockSession(TEST_MANAGER_ADDRESS);
+    const res = await POST(
+      postRequest({
+        chainId: TEST_CHAIN_ID,
+        councilId: TEST_COUNCIL_ADDRESS,
+        mode: "list",
+      }),
+    );
+    const body = await readJson(res);
+    expect(body.success).toBe(true);
+    expect(body.applications).toHaveLength(1);
+    expect(body.applications[0].id).toBe(fixture.submittedApplicationId);
+    // list mode strips the full details payload
+    expect(body.applications[0]).not.toHaveProperty("details");
+  });
+
+  it("returns all applications with full details for an admin", async () => {
+    mockSession(TEST_ADMIN_ADDRESS);
+    const res = await POST(
+      postRequest({
+        chainId: TEST_CHAIN_ID,
+        councilId: TEST_COUNCIL_ADDRESS,
+      }),
+    );
+    const body = await readJson(res);
+    expect(body.success).toBe(true);
+    expect(body.applications.length).toBeGreaterThanOrEqual(3);
+    expect(body.applications[0]).toHaveProperty("details");
+    expect(body.applications[0]).toHaveProperty("managerAddresses");
+  });
+
+  it("returns empty list when caller manages no projects", async () => {
+    mockSession(TEST_OUTSIDER_ADDRESS);
+    const res = await POST(
+      postRequest({
+        chainId: TEST_CHAIN_ID,
+        councilId: TEST_COUNCIL_ADDRESS,
+        mode: "list",
+      }),
+    );
+    const body = await readJson(res);
+    expect(body).toEqual({ success: true, applications: [] });
+  });
+
+  it("still calls hasOnChainRole to check on-chain admin status", async () => {
+    mockSession(TEST_MANAGER_ADDRESS);
+    await POST(
+      postRequest({
+        chainId: TEST_CHAIN_ID,
+        councilId: TEST_COUNCIL_ADDRESS,
+        mode: "list",
+      }),
+    );
+    expect(hasOnChainRole).toHaveBeenCalled();
+  });
+});
+
+describe("PUT /api/flow-council/applications", () => {
+  it("returns 401 without a session", async () => {
+    mockUnauthenticated();
+    const res = await PUT(putRequest({}));
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects invalid projectId", async () => {
+    mockSession(TEST_MANAGER_ADDRESS);
+    const res = await PUT(
+      putRequest({
+        projectId: "not-a-number",
+        chainId: TEST_CHAIN_ID,
+        councilId: TEST_COUNCIL_ADDRESS,
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await readJson(res);
+    expect(body).toEqual({ success: false, error: "Invalid project ID" });
+  });
+
+  it("rejects invalid chainId", async () => {
+    mockSession(TEST_MANAGER_ADDRESS);
+    const res = await PUT(
+      putRequest({
+        projectId: fixture.alphaProjectId,
+        chainId: 999999,
+        councilId: TEST_COUNCIL_ADDRESS,
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await readJson(res);
+    expect(body).toEqual({ success: false, error: "Wrong network" });
+  });
+
+  it("rejects when caller is not a manager of the project", async () => {
+    mockSession(TEST_OUTSIDER_ADDRESS);
+    const res = await PUT(
+      putRequest({
+        projectId: fixture.alphaProjectId,
+        chainId: TEST_CHAIN_ID,
+        councilId: TEST_COUNCIL_ADDRESS,
+      }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 when the round does not exist", async () => {
+    mockSession(TEST_MANAGER_ADDRESS);
+    const res = await PUT(
+      putRequest({
+        projectId: fixture.alphaProjectId,
+        chainId: TEST_CHAIN_ID,
+        councilId: "0x0000000000000000000000000000000000000099",
+      }),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("updates an existing application draft", async () => {
+    mockSession(TEST_MANAGER_ADDRESS);
+    // Seed round has no formSchema → not dynamic. Omit details so
+    // validateRoundDetails (strict RoundDetails schema) is skipped.
+    const res = await PUT(
+      putRequest({
+        projectId: fixture.alphaProjectId,
+        chainId: TEST_CHAIN_ID,
+        councilId: TEST_COUNCIL_ADDRESS,
+      }),
+    );
+    const body = await readJson(res);
+    expect(body.success).toBe(true);
+    expect(body.application.id).toBe(fixture.submittedApplicationId);
+  });
+
+  it("returns 409 when the application is ACCEPTED and editsUnlocked is false", async () => {
+    mockSession(TEST_OTHER_MANAGER_ADDRESS);
+    const res = await PUT(
+      putRequest({
+        projectId: fixture.betaProjectId,
+        chainId: TEST_CHAIN_ID,
+        councilId: TEST_COUNCIL_ADDRESS,
+      }),
+    );
+    expect(res.status).toBe(409);
+    const body = await readJson(res);
+    expect(body.error).toMatch(/locked/i);
+  });
+
+  it("returns 409 when applications are closed and the application is new", async () => {
+    // Close the round and delete any existing application for a fresh project
+    await db
+      .updateTable("rounds")
+      .set({ applicationsClosed: true })
+      .where("id", "=", fixture.roundId)
+      .execute();
+
+    // Create a new project with no existing application
+    const newProject = await db
+      .insertInto("projects")
+      .values({
+        details: JSON.stringify({
+          name: "Fresh Project",
+          description: "x".repeat(250),
+        }),
+      })
+      .returning("id")
+      .executeTakeFirstOrThrow();
+
+    await db
+      .insertInto("projectManagers")
+      .values({
+        projectId: newProject.id,
+        managerAddress: TEST_MANAGER_ADDRESS,
+      })
+      .execute();
+
+    mockSession(TEST_MANAGER_ADDRESS);
+    const res = await PUT(
+      putRequest({
+        projectId: newProject.id,
+        chainId: TEST_CHAIN_ID,
+        councilId: TEST_COUNCIL_ADDRESS,
+      }),
+    );
+    expect(res.status).toBe(409);
+    const body = await readJson(res);
+    expect(body.error).toMatch(/closed/i);
+  });
+});

--- a/src/app/api/flow-council/projects/route.integration.test.ts
+++ b/src/app/api/flow-council/projects/route.integration.test.ts
@@ -7,7 +7,7 @@ vi.mock("next-auth/next", () => ({
 vi.mock("@/app/api/auth/[...nextauth]/route", () => ({ authOptions: {} }));
 
 vi.mock("../db", async () => {
-  const { getTestDb } = await import("../../../../../tests/helpers/db");
+  const { getTestDb } = await import("@tests/helpers/db");
   return { db: getTestDb() };
 });
 
@@ -19,8 +19,8 @@ import {
   TEST_MANAGER_ADDRESS,
   TEST_OTHER_MANAGER_ADDRESS,
   type SeededFixture,
-} from "../../../../../tests/helpers/db";
-import { mockSession, mockUnauthenticated } from "../../../../../tests/helpers/session";
+} from "@tests/helpers/db";
+import { mockSession, mockUnauthenticated } from "@tests/helpers/session";
 import { CHARACTER_LIMITS } from "@/app/flow-councils/constants";
 
 const db = getTestDb();

--- a/src/app/api/flow-council/projects/route.integration.test.ts
+++ b/src/app/api/flow-council/projects/route.integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
 
 vi.mock("next-auth/next", () => ({
   getServerSession: vi.fn(),
@@ -27,10 +27,6 @@ const db = getTestDb();
 const MIN_DESCRIPTION = "x".repeat(CHARACTER_LIMITS.projectDescription.min);
 
 let fixture: SeededFixture;
-
-beforeAll(async () => {
-  fixture = await resetAndSeed(db);
-});
 
 afterAll(async () => {
   await resetDb(db);

--- a/src/app/api/flow-council/projects/route.integration.test.ts
+++ b/src/app/api/flow-council/projects/route.integration.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from "vitest";
+
+vi.mock("next-auth/next", () => ({
+  getServerSession: vi.fn(),
+}));
+
+vi.mock("@/app/api/auth/[...nextauth]/route", () => ({ authOptions: {} }));
+
+vi.mock("../db", async () => {
+  const { getTestDb } = await import("../../../../../tests/helpers/db");
+  return { db: getTestDb() };
+});
+
+import { GET, POST, PATCH } from "./route";
+import {
+  getTestDb,
+  resetAndSeed,
+  resetDb,
+  TEST_MANAGER_ADDRESS,
+  TEST_OTHER_MANAGER_ADDRESS,
+  type SeededFixture,
+} from "../../../../../tests/helpers/db";
+import { mockSession, mockUnauthenticated } from "../../../../../tests/helpers/session";
+import { CHARACTER_LIMITS } from "@/app/flow-councils/constants";
+
+const db = getTestDb();
+const MIN_DESCRIPTION = "x".repeat(CHARACTER_LIMITS.projectDescription.min);
+
+let fixture: SeededFixture;
+
+beforeAll(async () => {
+  fixture = await resetAndSeed(db);
+});
+
+afterAll(async () => {
+  await resetDb(db);
+  await db.destroy();
+});
+
+beforeEach(async () => {
+  fixture = await resetAndSeed(db);
+});
+
+async function readJson(res: Response) {
+  return JSON.parse(await res.text());
+}
+
+describe("GET /api/flow-council/projects", () => {
+  it("returns 400-ish error when managerAddress is missing", async () => {
+    const res = await GET(new Request("http://localhost/api/flow-council/projects"));
+    const body = await readJson(res);
+    expect(body).toEqual({ success: false, error: "Invalid manager address" });
+  });
+
+  it("rejects invalid address format", async () => {
+    const res = await GET(
+      new Request("http://localhost/api/flow-council/projects?managerAddress=notanaddress"),
+    );
+    const body = await readJson(res);
+    expect(body.success).toBe(false);
+  });
+
+  it("returns projects for a known manager", async () => {
+    const res = await GET(
+      new Request(
+        `http://localhost/api/flow-council/projects?managerAddress=${TEST_MANAGER_ADDRESS}`,
+      ),
+    );
+    const body = await readJson(res);
+    expect(body.success).toBe(true);
+    expect(body.projects).toHaveLength(1);
+    expect(body.projects[0].id).toBe(fixture.alphaProjectId);
+  });
+
+  it("returns empty array for an address with no projects", async () => {
+    const res = await GET(
+      new Request(
+        "http://localhost/api/flow-council/projects?managerAddress=0x5555555555555555555555555555555555555555",
+      ),
+    );
+    const body = await readJson(res);
+    expect(body.success).toBe(true);
+    expect(body.projects).toEqual([]);
+  });
+});
+
+describe("POST /api/flow-council/projects", () => {
+  function postRequest(body: unknown) {
+    return new Request("http://localhost/api/flow-council/projects", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  }
+
+  it("rejects unauthenticated requests", async () => {
+    mockUnauthenticated();
+    const res = await POST(postRequest({ name: "x", description: MIN_DESCRIPTION }));
+    const body = await readJson(res);
+    expect(body).toEqual({ success: false, error: "Unauthenticated" });
+  });
+
+  it("rejects payload failing validation", async () => {
+    mockSession(TEST_MANAGER_ADDRESS);
+    const res = await POST(postRequest({ description: MIN_DESCRIPTION }));
+    const body = await readJson(res);
+    expect(body.success).toBe(false);
+  });
+
+  it("creates a project for a valid payload", async () => {
+    mockSession(TEST_MANAGER_ADDRESS);
+    const res = await POST(
+      postRequest({
+        name: "New Project",
+        description: MIN_DESCRIPTION,
+        managerAddresses: [TEST_MANAGER_ADDRESS],
+      }),
+    );
+    const body = await readJson(res);
+    expect(body.success).toBe(true);
+    expect(body.project.id).toBeTypeOf("number");
+  });
+
+  it("rejects if caller's address is not in managerAddresses", async () => {
+    mockSession(TEST_MANAGER_ADDRESS);
+    const res = await POST(
+      postRequest({
+        name: "New Project",
+        description: MIN_DESCRIPTION,
+        managerAddresses: [TEST_OTHER_MANAGER_ADDRESS],
+      }),
+    );
+    const body = await readJson(res);
+    expect(body).toEqual({
+      success: false,
+      error: "Your address must be included as a manager",
+    });
+  });
+});
+
+describe("PATCH /api/flow-council/projects", () => {
+  function patchRequest(body: unknown) {
+    return new Request("http://localhost/api/flow-council/projects", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  }
+
+  it("rejects unauthenticated requests", async () => {
+    mockUnauthenticated();
+    const res = await PATCH(patchRequest({ projectId: fixture.alphaProjectId }));
+    const body = await readJson(res);
+    expect(body).toEqual({ success: false, error: "Unauthenticated" });
+  });
+
+  it("rejects missing projectId", async () => {
+    mockSession(TEST_MANAGER_ADDRESS);
+    const res = await PATCH(patchRequest({}));
+    const body = await readJson(res);
+    expect(body).toEqual({ success: false, error: "Project ID is required" });
+  });
+
+  it("rejects non-manager", async () => {
+    mockSession(TEST_MANAGER_ADDRESS);
+    // alpha is managed by TEST_MANAGER_ADDRESS; beta is not
+    const res = await PATCH(patchRequest({ projectId: fixture.betaProjectId }));
+    const body = await readJson(res);
+    expect(body).toEqual({
+      success: false,
+      error: "Not authorized to update this project",
+    });
+  });
+
+  it("updates the project when caller is the manager", async () => {
+    mockSession(TEST_MANAGER_ADDRESS);
+    const res = await PATCH(
+      patchRequest({
+        projectId: fixture.alphaProjectId,
+        name: "Alpha Renamed",
+        description: MIN_DESCRIPTION,
+      }),
+    );
+    const body = await readJson(res);
+    expect(body.success).toBe(true);
+    const details =
+      typeof body.project.details === "string"
+        ? JSON.parse(body.project.details)
+        : body.project.details;
+    expect(details.name).toBe("Alpha Renamed");
+  });
+});

--- a/src/app/api/flow-council/validation.test.ts
+++ b/src/app/api/flow-council/validation.test.ts
@@ -118,7 +118,7 @@ describe("normalizeSocialHandle", () => {
     ).toBe("https://x.com/alice");
   });
 
-  it("normalizes twitter.com to x.com (allowed host)", () => {
+  it("preserves twitter.com as an allowed host", () => {
     expect(
       normalizeSocialHandle("https://twitter.com/alice", "twitter"),
     ).toBe("https://twitter.com/alice");

--- a/src/app/api/flow-council/validation.test.ts
+++ b/src/app/api/flow-council/validation.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateProjectDetails,
+  validateProfile,
+  validateReactionEmoji,
+  validateDynamicRoundDetails,
+  normalizeSocialHandle,
+  MAX_DETAILS_SIZE,
+} from "./validation";
+import { CHARACTER_LIMITS } from "@/app/flow-councils/constants";
+import { ALLOWED_REACTIONS } from "@/app/flow-councils/lib/constants";
+
+const MIN_DESCRIPTION = "x".repeat(CHARACTER_LIMITS.projectDescription.min);
+
+describe("validateProjectDetails", () => {
+  it("accepts a minimal valid payload", () => {
+    const result = validateProjectDetails({
+      name: "Proj",
+      description: MIN_DESCRIPTION,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing name", () => {
+    const result = validateProjectDetails({ description: MIN_DESCRIPTION });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects description below minimum length", () => {
+    const result = validateProjectDetails({
+      name: "Proj",
+      description: "too short",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects malformed github repo URL", () => {
+    const result = validateProjectDetails({
+      name: "Proj",
+      description: MIN_DESCRIPTION,
+      githubRepos: ["github.com/foo/bar"],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects github repo URL with .git suffix", () => {
+    const result = validateProjectDetails({
+      name: "Proj",
+      description: MIN_DESCRIPTION,
+      githubRepos: ["https://github.com/foo/bar.git"],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a valid github repo URL", () => {
+    const result = validateProjectDetails({
+      name: "Proj",
+      description: MIN_DESCRIPTION,
+      githubRepos: ["https://github.com/foo/bar"],
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("validateProfile", () => {
+  it("accepts a profile with a valid displayName", () => {
+    const result = validateProfile({ displayName: "alice" });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects displayName with special characters", () => {
+    const result = validateProfile({ displayName: "foo<bar" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an invalid email", () => {
+    const result = validateProfile({
+      displayName: "alice",
+      email: "not-an-email",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts an empty optional email", () => {
+    const result = validateProfile({ displayName: "alice", email: "" });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("validateReactionEmoji", () => {
+  it("accepts a value from ALLOWED_REACTIONS", () => {
+    const result = validateReactionEmoji(ALLOWED_REACTIONS[0]);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an arbitrary string", () => {
+    const result = validateReactionEmoji("not-an-emoji");
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("normalizeSocialHandle", () => {
+  it("converts a bare handle to a canonical twitter URL", () => {
+    expect(normalizeSocialHandle("alice", "twitter")).toBe(
+      "https://x.com/alice",
+    );
+  });
+
+  it("preserves a full canonical twitter URL", () => {
+    expect(normalizeSocialHandle("https://x.com/alice", "twitter")).toBe(
+      "https://x.com/alice",
+    );
+  });
+
+  it("strips tracking query params", () => {
+    expect(
+      normalizeSocialHandle("https://x.com/alice?ref=foo", "twitter"),
+    ).toBe("https://x.com/alice");
+  });
+
+  it("normalizes twitter.com to x.com (allowed host)", () => {
+    expect(
+      normalizeSocialHandle("https://twitter.com/alice", "twitter"),
+    ).toBe("https://twitter.com/alice");
+  });
+
+  it("extracts handle from a non-allowed host and rebuilds the URL", () => {
+    expect(
+      normalizeSocialHandle("https://facebook.com/alice", "twitter"),
+    ).toBe("https://x.com/alice");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(normalizeSocialHandle("", "twitter")).toBe("");
+  });
+});
+
+describe("validateDynamicRoundDetails", () => {
+  const formElements = [
+    {
+      id: "name",
+      type: "text" as const,
+      label: "Name",
+      required: true,
+    },
+    {
+      id: "homepage",
+      type: "url" as const,
+      label: "Homepage",
+    },
+  ];
+
+  it("accepts a valid payload", () => {
+    const result = validateDynamicRoundDetails(
+      { round: { name: "Proj", homepage: "https://example.com" } },
+      formElements,
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing required field", () => {
+    const result = validateDynamicRoundDetails(
+      { round: { homepage: "https://example.com" } },
+      formElements,
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid URL", () => {
+    const result = validateDynamicRoundDetails(
+      { round: { name: "Proj", homepage: "not a url" } },
+      formElements,
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects unknown field", () => {
+    const result = validateDynamicRoundDetails(
+      { round: { name: "Proj", rogue: "extra" } },
+      formElements,
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects payload exceeding MAX_DETAILS_SIZE", () => {
+    const huge = "x".repeat(MAX_DETAILS_SIZE);
+    const result = validateDynamicRoundDetails(
+      { round: { name: huge } },
+      formElements,
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing round key", () => {
+    const result = validateDynamicRoundDetails({}, formElements);
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -1,6 +1,7 @@
-import { Kysely, CamelCasePlugin } from "kysely";
+import { Kysely, CamelCasePlugin, sql } from "kysely";
 import { NeonDialect } from "kysely-neon";
 import type { DB } from "@/generated/kysely";
+import { CHARACTER_LIMITS } from "@/app/flow-councils/constants";
 
 export const TEST_MANAGER_ADDRESS =
   "0x1111111111111111111111111111111111111111";
@@ -44,29 +45,33 @@ export function getTestDb(): Kysely<DB> {
   return cached;
 }
 
-// Deletion order respects FK dependencies: children before parents.
-const TABLES_IN_DELETE_ORDER = [
-  "messageReactions",
+// TRUNCATE ... RESTART IDENTITY CASCADE wipes every table in one round-trip
+// and resets sequences, avoiding the per-table DELETE chatter and the
+// FK-ordering maintenance that goes with it. Physical (snake_case) table
+// names are used here because raw SQL bypasses the CamelCasePlugin.
+const TABLES_TO_RESET = [
+  "message_reactions",
   "messages",
-  "milestoneProgress",
+  "milestone_progress",
   "recipients",
   "applications",
-  "projectEmails",
-  "projectManagers",
+  "project_emails",
+  "project_managers",
   "projects",
-  "userProfiles",
-  "roundAdminEmails",
-  "roundAdmins",
+  "user_profiles",
+  "round_admin_emails",
+  "round_admins",
   "rounds",
 ] as const;
 
 export async function resetDb(db: Kysely<DB>): Promise<void> {
-  for (const table of TABLES_IN_DELETE_ORDER) {
-    await db.deleteFrom(table).execute();
-  }
+  const identifiers = TABLES_TO_RESET.map((t) => sql.table(t));
+  await sql`truncate table ${sql.join(identifiers)} restart identity cascade`.execute(
+    db,
+  );
 }
 
-const MIN_DESCRIPTION = "x".repeat(250);
+const MIN_DESCRIPTION = "x".repeat(CHARACTER_LIMITS.projectDescription.min);
 
 export type SeededFixture = {
   roundId: number;

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -1,0 +1,209 @@
+import { Kysely, CamelCasePlugin } from "kysely";
+import { NeonDialect } from "kysely-neon";
+import type { DB } from "@/generated/kysely";
+
+export const TEST_MANAGER_ADDRESS =
+  "0x1111111111111111111111111111111111111111";
+export const TEST_OTHER_MANAGER_ADDRESS =
+  "0x3333333333333333333333333333333333333333";
+export const TEST_ADMIN_ADDRESS =
+  "0x2222222222222222222222222222222222222222";
+export const TEST_OUTSIDER_ADDRESS =
+  "0x4444444444444444444444444444444444444444";
+export const TEST_COUNCIL_ADDRESS =
+  "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+export const TEST_CHAIN_ID = 10;
+
+let cached: Kysely<DB> | null = null;
+
+export function getTestDb(): Kysely<DB> {
+  if (cached) return cached;
+  const connectionString = process.env.TEST_DATABASE_URL;
+  if (!connectionString) {
+    throw new Error(
+      "TEST_DATABASE_URL is not set — put it in .env.test.local at the repo root",
+    );
+  }
+  // Guard against pointing the test helpers at the production DB. resetDb()
+  // issues DELETEs across every table; aborting here is the last line of
+  // defence if TEST_DATABASE_URL is misconfigured.
+  const prodUrl = process.env.COUNCIL_DATABASE_URL;
+  if (prodUrl && connectionString === prodUrl) {
+    throw new Error(
+      "TEST_DATABASE_URL equals COUNCIL_DATABASE_URL — refusing to run tests against production",
+    );
+  }
+  cached = new Kysely<DB>({
+    dialect: new NeonDialect({ connectionString }),
+    plugins: [new CamelCasePlugin()],
+  });
+  return cached;
+}
+
+// Deletion order respects FK dependencies: children before parents.
+const TABLES_IN_DELETE_ORDER = [
+  "messageReactions",
+  "messages",
+  "milestoneProgress",
+  "recipients",
+  "applications",
+  "projectEmails",
+  "projectManagers",
+  "projects",
+  "roundAdminEmails",
+  "roundAdmins",
+  "rounds",
+] as const;
+
+export async function resetDb(db: Kysely<DB>): Promise<void> {
+  for (const table of TABLES_IN_DELETE_ORDER) {
+    await db.deleteFrom(table).execute();
+  }
+}
+
+const MIN_DESCRIPTION = "x".repeat(250);
+
+export type SeededFixture = {
+  roundId: number;
+  alphaProjectId: number;
+  betaProjectId: number;
+  submittedApplicationId: number;
+  acceptedApplicationId: number;
+  rejectedApplicationId: number;
+  messageId: number;
+};
+
+export async function seedTestData(db: Kysely<DB>): Promise<SeededFixture> {
+  const round = await db
+    .insertInto("rounds")
+    .values({
+      chainId: TEST_CHAIN_ID,
+      flowCouncilAddress: TEST_COUNCIL_ADDRESS,
+      applicationsClosed: false,
+      details: JSON.stringify({}),
+    })
+    .returning("id")
+    .executeTakeFirstOrThrow();
+
+  await db
+    .insertInto("roundAdmins")
+    .values({ roundId: round.id, adminAddress: TEST_ADMIN_ADDRESS })
+    .execute();
+
+  const alpha = await db
+    .insertInto("projects")
+    .values({
+      details: JSON.stringify({
+        name: "Project Alpha",
+        description: MIN_DESCRIPTION,
+      }),
+    })
+    .returning("id")
+    .executeTakeFirstOrThrow();
+
+  const beta = await db
+    .insertInto("projects")
+    .values({
+      details: JSON.stringify({
+        name: "Project Beta",
+        description: MIN_DESCRIPTION,
+      }),
+    })
+    .returning("id")
+    .executeTakeFirstOrThrow();
+
+  await db
+    .insertInto("projectManagers")
+    .values([
+      { projectId: alpha.id, managerAddress: TEST_MANAGER_ADDRESS },
+      { projectId: beta.id, managerAddress: TEST_OTHER_MANAGER_ADDRESS },
+    ])
+    .execute();
+
+  const submitted = await db
+    .insertInto("applications")
+    .values({
+      projectId: alpha.id,
+      roundId: round.id,
+      fundingAddress: TEST_MANAGER_ADDRESS,
+      status: "SUBMITTED",
+      details: JSON.stringify({}),
+    })
+    .returning("id")
+    .executeTakeFirstOrThrow();
+
+  const accepted = await db
+    .insertInto("applications")
+    .values({
+      projectId: beta.id,
+      roundId: round.id,
+      fundingAddress: TEST_OTHER_MANAGER_ADDRESS,
+      status: "ACCEPTED",
+      details: JSON.stringify({}),
+    })
+    .returning("id")
+    .executeTakeFirstOrThrow();
+
+  // Third project just for the REJECTED application so the (project, round)
+  // unique pattern is not fought.
+  const gamma = await db
+    .insertInto("projects")
+    .values({
+      details: JSON.stringify({
+        name: "Project Gamma",
+        description: MIN_DESCRIPTION,
+      }),
+    })
+    .returning("id")
+    .executeTakeFirstOrThrow();
+  await db
+    .insertInto("projectManagers")
+    .values({ projectId: gamma.id, managerAddress: TEST_OTHER_MANAGER_ADDRESS })
+    .execute();
+  const rejected = await db
+    .insertInto("applications")
+    .values({
+      projectId: gamma.id,
+      roundId: round.id,
+      fundingAddress: TEST_OTHER_MANAGER_ADDRESS,
+      status: "REJECTED",
+      details: JSON.stringify({}),
+    })
+    .returning("id")
+    .executeTakeFirstOrThrow();
+
+  const message = await db
+    .insertInto("messages")
+    .values({
+      channelType: "PUBLIC_ROUND",
+      roundId: round.id,
+      authorAddress: TEST_MANAGER_ADDRESS,
+      content: "hello round",
+    })
+    .returning("id")
+    .executeTakeFirstOrThrow();
+
+  await db
+    .insertInto("messageReactions")
+    .values({
+      messageId: message.id,
+      authorAddress: TEST_MANAGER_ADDRESS,
+      emoji: "\u{1F44D}",
+    })
+    .execute();
+
+  return {
+    roundId: round.id,
+    alphaProjectId: alpha.id,
+    betaProjectId: beta.id,
+    submittedApplicationId: submitted.id,
+    acceptedApplicationId: accepted.id,
+    rejectedApplicationId: rejected.id,
+    messageId: message.id,
+  };
+}
+
+export async function resetAndSeed(db: Kysely<DB>): Promise<SeededFixture> {
+  await resetDb(db);
+  return seedTestData(db);
+}

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -45,10 +45,7 @@ export function getTestDb(): Kysely<DB> {
   return cached;
 }
 
-// TRUNCATE ... RESTART IDENTITY CASCADE wipes every table in one round-trip
-// and resets sequences, avoiding the per-table DELETE chatter and the
-// FK-ordering maintenance that goes with it. Physical (snake_case) table
-// names are used here because raw SQL bypasses the CamelCasePlugin.
+// Physical (snake_case) table names — raw SQL bypasses the CamelCasePlugin.
 const TABLES_TO_RESET = [
   "message_reactions",
   "messages",

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -14,6 +14,10 @@ export const TEST_COUNCIL_ADDRESS =
   "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
 export const TEST_CHAIN_ID = 10;
 
+// Singleton shared across all test files in the same process. Vitest's
+// integration project forks per file (fileParallelism: false + forks pool),
+// so `db.destroy()` in one file's afterAll only closes this process's
+// connection. If that isolation model changes, this needs revisiting.
 let cached: Kysely<DB> | null = null;
 
 export function getTestDb(): Kysely<DB> {
@@ -50,6 +54,7 @@ const TABLES_IN_DELETE_ORDER = [
   "projectEmails",
   "projectManagers",
   "projects",
+  "userProfiles",
   "roundAdminEmails",
   "roundAdmins",
   "rounds",

--- a/tests/helpers/session.ts
+++ b/tests/helpers/session.ts
@@ -1,5 +1,6 @@
 import { vi } from "vitest";
 import { getServerSession } from "next-auth/next";
+import type { Session } from "next-auth";
 
 // Callers must put `vi.mock("next-auth/next")` and
 // `vi.mock("@/app/api/auth/[...nextauth]/route", () => ({ authOptions: {} }))`
@@ -7,13 +8,12 @@ import { getServerSession } from "next-auth/next";
 // configure the mock's return value per-test.
 
 export function mockSession(address: string) {
-  vi.mocked(getServerSession).mockResolvedValue({
+  const session: Session = {
     address,
     user: { name: address, image: "" },
-    // Minimal session shape — cast because the app extends Session with
-    // an address field not present in the base type.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } as any);
+    expires: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+  };
+  vi.mocked(getServerSession).mockResolvedValue(session);
 }
 
 export function mockUnauthenticated() {

--- a/tests/helpers/session.ts
+++ b/tests/helpers/session.ts
@@ -1,0 +1,21 @@
+import { vi } from "vitest";
+import { getServerSession } from "next-auth/next";
+
+// Callers must put `vi.mock("next-auth/next")` and
+// `vi.mock("@/app/api/auth/[...nextauth]/route", () => ({ authOptions: {} }))`
+// at the top of their test file. These calls are hoisted; helpers can then
+// configure the mock's return value per-test.
+
+export function mockSession(address: string) {
+  vi.mocked(getServerSession).mockResolvedValue({
+    address,
+    user: { name: address, image: "" },
+    // Minimal session shape — cast because the app extends Session with
+    // an address field not present in the base type.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+}
+
+export function mockUnauthenticated() {
+  vi.mocked(getServerSession).mockResolvedValue(null);
+}

--- a/tests/setup/global.ts
+++ b/tests/setup/global.ts
@@ -1,0 +1,22 @@
+import { execSync } from "node:child_process";
+import { config } from "dotenv";
+import { fileURLToPath, URL } from "node:url";
+
+export default async function globalSetup() {
+  config({
+    path: fileURLToPath(new URL("../../.env.test.local", import.meta.url)),
+    quiet: true,
+  });
+
+  const testUrl = process.env.TEST_DATABASE_URL;
+  if (!testUrl) {
+    throw new Error(
+      "TEST_DATABASE_URL is not set — put it in .env.test.local at the repo root",
+    );
+  }
+
+  execSync("pnpm prisma migrate deploy", {
+    stdio: "inherit",
+    env: { ...process.env, DATABASE_URL: testUrl },
+  });
+}

--- a/tests/setup/global.ts
+++ b/tests/setup/global.ts
@@ -15,9 +15,24 @@ export default async function globalSetup() {
     );
   }
 
+  // Neon computes auto-suspend when idle; Prisma's default connect timeout can
+  // fire before a cold compute finishes booting. Ensure connect_timeout is
+  // generous enough to ride out the wake.
+  const migrateUrl = withConnectTimeout(testUrl, 30);
+
+  // prisma.config.ts reads COUNCIL_DATABASE_URL — override it (not DATABASE_URL)
+  // so `migrate deploy` targets the test branch, not production.
   execSync("pnpm prisma migrate deploy", {
     stdio: "inherit",
-    timeout: 30_000,
-    env: { ...process.env, DATABASE_URL: testUrl },
+    timeout: 60_000,
+    env: { ...process.env, COUNCIL_DATABASE_URL: migrateUrl },
   });
+}
+
+function withConnectTimeout(urlString: string, seconds: number): string {
+  const url = new URL(urlString);
+  if (!url.searchParams.has("connect_timeout")) {
+    url.searchParams.set("connect_timeout", String(seconds));
+  }
+  return url.toString();
 }

--- a/tests/setup/global.ts
+++ b/tests/setup/global.ts
@@ -17,6 +17,7 @@ export default async function globalSetup() {
 
   execSync("pnpm prisma migrate deploy", {
     stdio: "inherit",
+    timeout: 30_000,
     env: { ...process.env, DATABASE_URL: testUrl },
   });
 }

--- a/tests/setup/integration-env.ts
+++ b/tests/setup/integration-env.ts
@@ -1,0 +1,7 @@
+import { config } from "dotenv";
+import { fileURLToPath, URL } from "node:url";
+
+config({
+  path: fileURLToPath(new URL("../../.env.test.local", import.meta.url)),
+  quiet: true,
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "jsx": "preserve",
     "incremental": true,
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@tests/*": ["./tests/*"]
     },
     "plugins": [
       {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -33,6 +33,10 @@ export default defineConfig({
           // Integration tests share a single Neon test branch; run them
           // sequentially to avoid FK races during reset/seed.
           fileParallelism: false,
+          // Hooks and tests both drive the pooled Neon endpoint; the default
+          // 10s/5s budgets are tight once round-trip latency is factored in.
+          hookTimeout: 30_000,
+          testTimeout: 30_000,
         },
       },
     ],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -27,6 +27,11 @@ export default defineConfig({
           name: "integration",
           environment: "node",
           include: ["src/**/*.integration.test.{ts,tsx}"],
+          setupFiles: ["./tests/setup/integration-env.ts"],
+          globalSetup: ["./tests/setup/global.ts"],
+          // Integration tests share a single Neon test branch; run them
+          // sequentially to avoid FK races during reset/seed.
+          fileParallelism: false,
         },
       },
     ],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": fileURLToPath(new URL("./src", import.meta.url)),
+      "@tests": fileURLToPath(new URL("./tests", import.meta.url)),
     },
   },
   test: {


### PR DESCRIPTION
## Summary
- Adds Vitest integration project wired to a Neon test branch via `.env.test.local`
- Adds test helpers: `getTestDb`, `resetAndSeed`, `mockSession` / `mockUnauthenticated`
- Adds integration tests for `/api/flow-council/projects` (GET/POST/PATCH) and `/api/flow-council/applications` (POST/PUT), covering auth, validation, role checks, locked-status, and applications-closed paths
- Adds unit tests for Zod schemas in `flow-council/validation.ts`
- `globalSetup` runs `prisma migrate deploy` against the test branch so schema stays in sync
- `resetDb` guards against running against `COUNCIL_DATABASE_URL`

## Test plan
- [x] `pnpm test:unit` — 36 tests pass
- [x] `pnpm test:integration` — 28 tests pass
- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean