### PR TITLE
feat: add configurable milestone question type to dynamic form builder

### DIFF
--- a/prisma/migrations/20260427000000_widen_milestone_type/migration.sql
+++ b/prisma/migrations/20260427000000_widen_milestone_type/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "milestone_progress" ALTER COLUMN "milestone_type" TYPE VARCHAR(100);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -128,7 +128,7 @@ model Recipient {
 model MilestoneProgress {
   id              Int         @id @default(autoincrement())
   applicationId   Int         @map("application_id")
-  milestoneType   String      @map("milestone_type") @db.VarChar(10)
+  milestoneType   String      @map("milestone_type") @db.VarChar(100)
   milestoneIndex  Int         @map("milestone_index")
   progress        Json?
   createdAt       DateTime    @default(now()) @map("created_at")

--- a/src/app/api/flow-council/projects/[projectId]/milestones/route.ts
+++ b/src/app/api/flow-council/projects/[projectId]/milestones/route.ts
@@ -9,6 +9,11 @@ import {
 } from "@/app/api/flow-council/validation";
 import type { RoundForm } from "@/app/flow-councils/types/round";
 import type {
+  FormSchema,
+  MilestoneQuestion,
+} from "@/app/flow-councils/types/formSchema";
+import type { DynamicMilestoneValue } from "@/app/flow-councils/components/DynamicMilestoneInput";
+import type {
   ApplicationMilestones,
   MilestoneWithProgress,
   MilestoneProgressData,
@@ -26,6 +31,73 @@ function emptyProgress(itemCount: number): MilestoneProgressData {
       completion: 0,
       evidence: [],
     })),
+  };
+}
+
+type DynamicAppDetails = {
+  round?: Record<string, unknown>;
+  attestation?: Record<string, unknown>;
+};
+
+// Dynamic apps store answers under appDetails.round[elementId].
+// Legacy apps use top-level buildGoals/growthGoals; absence of a 'round'
+// key is the discriminant.
+function isDynamicAppDetails(appDetails: unknown): appDetails is {
+  round: Record<string, unknown>;
+} {
+  return (
+    !!appDetails &&
+    typeof appDetails === "object" &&
+    "round" in (appDetails as object) &&
+    typeof (appDetails as DynamicAppDetails).round === "object" &&
+    (appDetails as DynamicAppDetails).round !== null
+  );
+}
+
+function getMilestoneElements(
+  formSchema: FormSchema | null | undefined,
+): MilestoneQuestion[] {
+  if (!formSchema?.round) return [];
+  return formSchema.round.filter(
+    (el): el is MilestoneQuestion => el.type === "milestone",
+  );
+}
+
+function resolveDynamicLabels(
+  formSchema: FormSchema | null | undefined,
+  elementId: string,
+): { milestoneLabel: string; itemLabel: string } {
+  const element = getMilestoneElements(formSchema).find(
+    (el) => el.id === elementId,
+  );
+  return {
+    milestoneLabel:
+      element?.milestoneLabel || element?.label || "Milestone",
+    itemLabel: element?.itemLabel || "Deliverable",
+  };
+}
+
+const LEGACY_MILESTONE_LABELS: Record<string, string> = {
+  build: "Build",
+  growth: "Growth",
+};
+
+const LEGACY_ITEM_LABELS: Record<string, string> = {
+  build: "Deliverable",
+  growth: "Activation",
+};
+
+function getMilestoneLabels(
+  milestoneType: string,
+  formSchema: FormSchema | null | undefined,
+  isDynamic: boolean,
+): { milestoneLabel: string; itemLabel: string } {
+  if (isDynamic) {
+    return resolveDynamicLabels(formSchema, milestoneType);
+  }
+  return {
+    milestoneLabel: LEGACY_MILESTONE_LABELS[milestoneType] ?? milestoneType,
+    itemLabel: LEGACY_ITEM_LABELS[milestoneType] ?? "Deliverable",
   };
 }
 
@@ -74,38 +146,74 @@ export async function GET(_request: Request, { params }: RouteParams) {
     }
 
     const result: ApplicationMilestones[] = applications.map((app) => {
-      const roundDetails = parseDetails<{ name?: string }>(app.roundDetails);
-      const appDetails = parseDetails<RoundForm>(app.appDetails);
+      const roundDetails = parseDetails<{
+        name?: string;
+        formSchema?: FormSchema;
+      }>(app.roundDetails);
+      const appDetailsRaw = parseDetails<RoundForm & DynamicAppDetails>(
+        app.appDetails,
+      );
       const milestones: MilestoneWithProgress[] = [];
 
-      if (appDetails?.buildGoals?.milestones) {
-        appDetails.buildGoals.milestones.forEach((m, i) => {
-          const key = `${app.applicationId}-build-${i}`;
-          milestones.push({
-            type: "build",
-            index: i,
-            title: m.title,
-            description: m.description,
-            itemNames: m.deliverables,
-            progress:
-              progressMap.get(key) ?? emptyProgress(m.deliverables.length),
+      if (isDynamicAppDetails(appDetailsRaw)) {
+        const milestoneElements = getMilestoneElements(roundDetails?.formSchema);
+        for (const element of milestoneElements) {
+          const raw = appDetailsRaw.round[element.id];
+          if (!Array.isArray(raw)) continue;
+          const milestoneLabel =
+            element.milestoneLabel || element.label || "Milestone";
+          const itemLabel = element.itemLabel || "Deliverable";
+          (raw as DynamicMilestoneValue[]).forEach((m, i) => {
+            if (!m || typeof m !== "object") return;
+            const items = Array.isArray(m.items) ? m.items : [];
+            const key = `${app.applicationId}-${element.id}-${i}`;
+            milestones.push({
+              type: element.id,
+              milestoneLabel,
+              itemLabel,
+              index: i,
+              title: typeof m.title === "string" ? m.title : "",
+              description:
+                typeof m.description === "string" ? m.description : "",
+              itemNames: items,
+              progress: progressMap.get(key) ?? emptyProgress(items.length),
+            });
           });
-        });
-      }
+        }
+      } else {
+        if (appDetailsRaw?.buildGoals?.milestones) {
+          appDetailsRaw.buildGoals.milestones.forEach((m, i) => {
+            const key = `${app.applicationId}-build-${i}`;
+            milestones.push({
+              type: "build",
+              milestoneLabel: "Build",
+              itemLabel: "Deliverable",
+              index: i,
+              title: m.title,
+              description: m.description,
+              itemNames: m.deliverables,
+              progress:
+                progressMap.get(key) ?? emptyProgress(m.deliverables.length),
+            });
+          });
+        }
 
-      if (appDetails?.growthGoals?.milestones) {
-        appDetails.growthGoals.milestones.forEach((m, i) => {
-          const key = `${app.applicationId}-growth-${i}`;
-          milestones.push({
-            type: "growth",
-            index: i,
-            title: m.title,
-            description: m.description,
-            itemNames: m.activations,
-            progress:
-              progressMap.get(key) ?? emptyProgress(m.activations.length),
+        if (appDetailsRaw?.growthGoals?.milestones) {
+          appDetailsRaw.growthGoals.milestones.forEach((m, i) => {
+            const key = `${app.applicationId}-growth-${i}`;
+            milestones.push({
+              type: "growth",
+              milestoneLabel: "Growth",
+              itemLabel: "Activation",
+              index: i,
+              title: m.title,
+              description: m.description,
+              itemNames: m.activations,
+              progress:
+                progressMap.get(key) ?? emptyProgress(m.activations.length),
+            });
           });
-        });
+        }
       }
 
       return {
@@ -129,15 +237,6 @@ export async function GET(_request: Request, { params }: RouteParams) {
 }
 
 const MILESTONE_AUTHOR_ADDRESS = "0x0000000000000000000000000000000000000000";
-const MILESTONE_TYPE_LABELS: Record<string, string> = {
-  build: "Build",
-  growth: "Growth",
-};
-
-const MILESTONE_ITEM_LABELS: Record<string, string> = {
-  build: "Deliverable",
-  growth: "Activation",
-};
 
 function buildEvidencePostContent(
   verb: "added to" | "updated on",
@@ -208,7 +307,9 @@ export async function PATCH(request: Request, { params }: RouteParams) {
 
     if (
       typeof applicationId !== "number" ||
-      !["build", "growth"].includes(milestoneType) ||
+      typeof milestoneType !== "string" ||
+      milestoneType.length === 0 ||
+      milestoneType.length > 100 ||
       typeof milestoneIndex !== "number"
     ) {
       return Response.json({ success: false, error: "Invalid parameters" });
@@ -236,6 +337,37 @@ export async function PATCH(request: Request, { params }: RouteParams) {
       });
     }
 
+    const appDetailsParsed = parseDetails<RoundForm & DynamicAppDetails>(
+      application.details,
+    );
+    const isDynamic = isDynamicAppDetails(appDetailsParsed);
+
+    if (!isDynamic && !["build", "growth"].includes(milestoneType)) {
+      return Response.json({ success: false, error: "Invalid parameters" });
+    }
+
+    // For dynamic apps, milestoneType is used as an object-key lookup against
+    // appDetails.round. Verify it matches a milestone element declared in the
+    // round's formSchema so a manager cannot probe or overwrite arbitrary keys
+    // in the stored application JSON (e.g. __proto__, unrelated fields).
+    let dynamicMilestoneElement: MilestoneQuestion | undefined;
+    if (isDynamic) {
+      const roundForLookup = await db
+        .selectFrom("rounds")
+        .select("details")
+        .where("id", "=", application.roundId)
+        .executeTakeFirst();
+      const roundDetailsForLookup = parseDetails<{
+        formSchema?: FormSchema;
+      }>(roundForLookup?.details);
+      dynamicMilestoneElement = getMilestoneElements(
+        roundDetailsForLookup?.formSchema,
+      ).find((el) => el.id === milestoneType);
+      if (!dynamicMilestoneElement) {
+        return Response.json({ success: false, error: "Invalid parameters" });
+      }
+    }
+
     if (definition) {
       if (!application.editsUnlocked) {
         return new Response(
@@ -255,14 +387,47 @@ export async function PATCH(request: Request, { params }: RouteParams) {
         });
       }
 
-      const appDetails = parseDetails<RoundForm>(application.details);
-      if (!appDetails) {
+      if (!appDetailsParsed) {
         return Response.json({
           success: false,
           error: "Failed to parse application details",
         });
       }
 
+      if (isDynamic) {
+        const dynamicAppDetails = appDetailsParsed as DynamicAppDetails & {
+          round: Record<string, unknown>;
+        };
+        const milestonesArray = dynamicAppDetails.round[milestoneType];
+        if (
+          !Array.isArray(milestonesArray) ||
+          milestoneIndex >= milestonesArray.length
+        ) {
+          return Response.json({
+            success: false,
+            error: "Milestone index out of range",
+          });
+        }
+        const updated: DynamicMilestoneValue = {
+          title: parsedDef.data.title,
+          description: parsedDef.data.description,
+          items: parsedDef.data.items,
+        };
+        (milestonesArray as DynamicMilestoneValue[])[milestoneIndex] = updated;
+
+        await db
+          .updateTable("applications")
+          .set({
+            details: JSON.stringify(dynamicAppDetails),
+            updatedAt: new Date(),
+          })
+          .where("id", "=", applicationId)
+          .execute();
+
+        return Response.json({ success: true });
+      }
+
+      const appDetails = appDetailsParsed as RoundForm;
       const milestonesArray =
         milestoneType === "build"
           ? appDetails.buildGoals?.milestones
@@ -347,10 +512,16 @@ export async function PATCH(request: Request, { params }: RouteParams) {
       .where("id", "=", application.roundId)
       .executeTakeFirst();
 
-    const roundDetails = parseDetails<{ name?: string }>(roundData?.details);
+    const roundDetails = parseDetails<{
+      name?: string;
+      formSchema?: FormSchema;
+    }>(roundData?.details);
     const roundName = roundDetails?.name ?? "Round";
-    const typeLabel = MILESTONE_TYPE_LABELS[milestoneType] ?? milestoneType;
-    const itemLabel = MILESTONE_ITEM_LABELS[milestoneType] ?? "Deliverable";
+    const { milestoneLabel: typeLabel, itemLabel } = getMilestoneLabels(
+      milestoneType,
+      roundDetails?.formSchema,
+      isDynamic,
+    );
 
     for (let i = 0; i < newProgress.items.length; i++) {
       const newItem = newProgress.items[i];

--- a/src/app/api/flow-council/projects/[projectId]/milestones/route.ts
+++ b/src/app/api/flow-council/projects/[projectId]/milestones/route.ts
@@ -9,6 +9,7 @@ import {
   makeMilestoneDefinitionSchema,
   MAX_STRING_LENGTH,
 } from "@/app/api/flow-council/validation";
+import { CHARACTER_LIMITS } from "@/app/flow-councils/constants";
 import type { RoundForm } from "@/app/flow-councils/types/round";
 import type {
   FormSchema,
@@ -166,6 +167,9 @@ export async function GET(_request: Request, { params }: RouteParams) {
           const milestoneLabel =
             element.milestoneLabel || element.label || "Milestone";
           const itemLabel = element.itemLabel || "Deliverable";
+          const descriptionMinChars = element.descriptionMinChars ?? 0;
+          const descriptionMaxChars =
+            element.descriptionMaxChars ?? MAX_STRING_LENGTH;
           (raw as DynamicMilestoneValue[]).forEach((m, i) => {
             if (!m || typeof m !== "object") return;
             const items = Array.isArray(m.items) ? m.items : [];
@@ -180,6 +184,8 @@ export async function GET(_request: Request, { params }: RouteParams) {
                 typeof m.description === "string" ? m.description : "",
               itemNames: items,
               progress: progressMap.get(key) ?? emptyProgress(items.length),
+              descriptionMinChars,
+              descriptionMaxChars,
             });
           });
         }
@@ -197,6 +203,8 @@ export async function GET(_request: Request, { params }: RouteParams) {
               itemNames: m.deliverables,
               progress:
                 progressMap.get(key) ?? emptyProgress(m.deliverables.length),
+              descriptionMinChars: CHARACTER_LIMITS.milestoneDescription.min,
+              descriptionMaxChars: CHARACTER_LIMITS.milestoneDescription.max,
             });
           });
         }
@@ -214,6 +222,8 @@ export async function GET(_request: Request, { params }: RouteParams) {
               itemNames: m.activations,
               progress:
                 progressMap.get(key) ?? emptyProgress(m.activations.length),
+              descriptionMinChars: CHARACTER_LIMITS.milestoneDescription.min,
+              descriptionMaxChars: CHARACTER_LIMITS.milestoneDescription.max,
             });
           });
         }

--- a/src/app/api/flow-council/projects/[projectId]/milestones/route.ts
+++ b/src/app/api/flow-council/projects/[projectId]/milestones/route.ts
@@ -71,8 +71,7 @@ function resolveDynamicLabels(
     (el) => el.id === elementId,
   );
   return {
-    milestoneLabel:
-      element?.milestoneLabel || element?.label || "Milestone",
+    milestoneLabel: element?.milestoneLabel || element?.label || "Milestone",
     itemLabel: element?.itemLabel || "Deliverable",
   };
 }
@@ -156,7 +155,9 @@ export async function GET(_request: Request, { params }: RouteParams) {
       const milestones: MilestoneWithProgress[] = [];
 
       if (isDynamicAppDetails(appDetailsRaw)) {
-        const milestoneElements = getMilestoneElements(roundDetails?.formSchema);
+        const milestoneElements = getMilestoneElements(
+          roundDetails?.formSchema,
+        );
         for (const element of milestoneElements) {
           const raw = appDetailsRaw.round[element.id];
           if (!Array.isArray(raw)) continue;

--- a/src/app/api/flow-council/projects/[projectId]/milestones/route.ts
+++ b/src/app/api/flow-council/projects/[projectId]/milestones/route.ts
@@ -6,6 +6,8 @@ import { parseDetails } from "@/app/api/flow-council/utils";
 import {
   milestoneProgressSchema,
   milestoneDefinitionSchema,
+  makeMilestoneDefinitionSchema,
+  MAX_STRING_LENGTH,
 } from "@/app/api/flow-council/validation";
 import type { RoundForm } from "@/app/flow-councils/types/round";
 import type {
@@ -348,22 +350,34 @@ export async function PATCH(request: Request, { params }: RouteParams) {
       return Response.json({ success: false, error: "Invalid parameters" });
     }
 
+    // Fetched once and reused for the dynamic-element lookup and the feed-post
+    // round name below, instead of querying the same row twice per request.
+    // Skipped only on the legacy definition-edit path, where neither is needed.
+    const needsRoundDetails = isDynamic || !definition;
+    let roundDetailsParsed: {
+      name?: string;
+      formSchema?: FormSchema;
+    } | null = null;
+    if (needsRoundDetails) {
+      const roundRow = await db
+        .selectFrom("rounds")
+        .select("details")
+        .where("id", "=", application.roundId)
+        .executeTakeFirst();
+      roundDetailsParsed = parseDetails<{
+        name?: string;
+        formSchema?: FormSchema;
+      }>(roundRow?.details);
+    }
+
     // For dynamic apps, milestoneType is used as an object-key lookup against
     // appDetails.round. Verify it matches a milestone element declared in the
     // round's formSchema so a manager cannot probe or overwrite arbitrary keys
     // in the stored application JSON (e.g. __proto__, unrelated fields).
     let dynamicMilestoneElement: MilestoneQuestion | undefined;
     if (isDynamic) {
-      const roundForLookup = await db
-        .selectFrom("rounds")
-        .select("details")
-        .where("id", "=", application.roundId)
-        .executeTakeFirst();
-      const roundDetailsForLookup = parseDetails<{
-        formSchema?: FormSchema;
-      }>(roundForLookup?.details);
       dynamicMilestoneElement = getMilestoneElements(
-        roundDetailsForLookup?.formSchema,
+        roundDetailsParsed?.formSchema,
       ).find((el) => el.id === milestoneType);
       if (!dynamicMilestoneElement) {
         return Response.json({ success: false, error: "Invalid parameters" });
@@ -381,7 +395,18 @@ export async function PATCH(request: Request, { params }: RouteParams) {
         );
       }
 
-      const parsedDef = milestoneDefinitionSchema.safeParse(definition);
+      // Dynamic milestones honor the per-element descriptionMin/MaxChars
+      // configured in the round's formSchema. Falling back to the legacy
+      // 500–5000 bounds here would lock applicants out of editing data they
+      // were allowed to submit (e.g. an admin-configured 100–8000 range).
+      const definitionSchema = dynamicMilestoneElement
+        ? makeMilestoneDefinitionSchema({
+            descriptionMinChars: dynamicMilestoneElement.descriptionMinChars ?? 0,
+            descriptionMaxChars:
+              dynamicMilestoneElement.descriptionMaxChars ?? MAX_STRING_LENGTH,
+          })
+        : milestoneDefinitionSchema;
+      const parsedDef = definitionSchema.safeParse(definition);
       if (!parsedDef.success) {
         return Response.json({
           success: false,
@@ -508,20 +533,10 @@ export async function PATCH(request: Request, { params }: RouteParams) {
     const newProgress = parsed.data;
     const feedMessages: string[] = [];
 
-    const roundData = await db
-      .selectFrom("rounds")
-      .select("details")
-      .where("id", "=", application.roundId)
-      .executeTakeFirst();
-
-    const roundDetails = parseDetails<{
-      name?: string;
-      formSchema?: FormSchema;
-    }>(roundData?.details);
-    const roundName = roundDetails?.name ?? "Round";
+    const roundName = roundDetailsParsed?.name ?? "Round";
     const { milestoneLabel: typeLabel, itemLabel } = getMilestoneLabels(
       milestoneType,
-      roundDetails?.formSchema,
+      roundDetailsParsed?.formSchema,
       isDynamic,
     );
 

--- a/src/app/api/flow-council/projects/[projectId]/milestones/route.ts
+++ b/src/app/api/flow-council/projects/[projectId]/milestones/route.ts
@@ -77,8 +77,8 @@ function resolveDynamicLabels(
 }
 
 const LEGACY_MILESTONE_LABELS: Record<string, string> = {
-  build: "Build",
-  growth: "Growth",
+  build: "Build Milestone",
+  growth: "Growth Milestone",
 };
 
 const LEGACY_ITEM_LABELS: Record<string, string> = {
@@ -187,7 +187,7 @@ export async function GET(_request: Request, { params }: RouteParams) {
             const key = `${app.applicationId}-build-${i}`;
             milestones.push({
               type: "build",
-              milestoneLabel: "Build",
+              milestoneLabel: "Build Milestone",
               itemLabel: "Deliverable",
               index: i,
               title: m.title,
@@ -204,7 +204,7 @@ export async function GET(_request: Request, { params }: RouteParams) {
             const key = `${app.applicationId}-growth-${i}`;
             milestones.push({
               type: "growth",
-              milestoneLabel: "Growth",
+              milestoneLabel: "Growth Milestone",
               itemLabel: "Activation",
               index: i,
               title: m.title,
@@ -251,7 +251,7 @@ function buildEvidencePostContent(
   evidence: EvidenceLink[],
   pid: number,
 ): string {
-  const header = `Evidence ${verb} ${roundName} - ${typeLabel} Milestone ${milestoneIndex + 1} - ${itemLabel} ${itemIndex + 1} (${completion}% Complete)`;
+  const header = `Evidence ${verb} ${roundName} - ${typeLabel} ${milestoneIndex + 1} - ${itemLabel} ${itemIndex + 1} (${completion}% Complete)`;
   const lines = evidence.map((e) => `- [${e.name}](${e.link})`);
   return `${header}:\n\n${lines.join("\n")}\n\n[Go to the milestone](/projects/${pid}?tab=milestones&milestone=${milestoneType}-${milestoneIndex})`;
 }
@@ -264,7 +264,7 @@ function buildTextUpdatePostContent(
   otherDetails: string,
   pid: number,
 ): string {
-  return `Details updated on ${roundName} - ${typeLabel} Milestone ${milestoneIndex + 1}:\n\n${otherDetails}\n\n[Go to the milestone](/projects/${pid}?tab=milestones&milestone=${milestoneType}-${milestoneIndex})`;
+  return `Details updated on ${roundName} - ${typeLabel} ${milestoneIndex + 1}:\n\n${otherDetails}\n\n[Go to the milestone](/projects/${pid}?tab=milestones&milestone=${milestoneType}-${milestoneIndex})`;
 }
 
 export async function PATCH(request: Request, { params }: RouteParams) {
@@ -311,7 +311,8 @@ export async function PATCH(request: Request, { params }: RouteParams) {
       typeof milestoneType !== "string" ||
       milestoneType.length === 0 ||
       milestoneType.length > 100 ||
-      typeof milestoneIndex !== "number"
+      !Number.isInteger(milestoneIndex) ||
+      milestoneIndex < 0
     ) {
       return Response.json({ success: false, error: "Invalid parameters" });
     }

--- a/src/app/api/flow-council/projects/milestones.integration.test.ts
+++ b/src/app/api/flow-council/projects/milestones.integration.test.ts
@@ -313,7 +313,7 @@ describe("GET /api/flow-council/projects/[projectId]/milestones — dynamic", ()
     const round = await seedRoundWithMilestoneSchema(
       ELEMENT_UUID,
       "Engineering Milestone",
-      "Key Result",
+      "Activation",
     );
 
     const project = await db
@@ -331,7 +331,7 @@ describe("GET /api/flow-council/projects/[projectId]/milestones — dynamic", ()
       {
         title: "Ship the API",
         description: "x".repeat(50),
-        items: ["Key Result 1", "Key Result 2"],
+        items: ["Activation 1", "Activation 2"],
       },
     ]);
 
@@ -347,9 +347,9 @@ describe("GET /api/flow-council/projects/[projectId]/milestones — dynamic", ()
     const [milestone] = body.applications[0].milestones;
     expect(milestone.type).toBe(ELEMENT_UUID);
     expect(milestone.milestoneLabel).toBe("Engineering Milestone");
-    expect(milestone.itemLabel).toBe("Key Result");
+    expect(milestone.itemLabel).toBe("Activation");
     expect(milestone.title).toBe("Ship the API");
-    expect(milestone.itemNames).toEqual(["Key Result 1", "Key Result 2"]);
+    expect(milestone.itemNames).toEqual(["Activation 1", "Activation 2"]);
   });
 });
 
@@ -362,7 +362,7 @@ describe("GET — legacy and dynamic applications do not cross-pollute", () => {
     const round = await seedRoundWithMilestoneSchema(
       ELEMENT_UUID,
       "Engineering Milestone",
-      "Key Result",
+      "Activation",
     );
 
     // A second round for the legacy application. Use a distinct chainId so we
@@ -399,7 +399,7 @@ describe("GET — legacy and dynamic applications do not cross-pollute", () => {
         {
           title: "Dynamic Milestone",
           description: "z".repeat(50),
-          items: ["KR 1"],
+          items: ["Activation 1"],
         },
       ],
     );
@@ -601,7 +601,7 @@ describe("PATCH /api/flow-council/projects/[projectId]/milestones — dynamic", 
     const round = await seedRoundWithMilestoneSchema(
       ELEMENT_UUID,
       "Engineering Milestone",
-      "Key Result",
+      "Activation",
     );
 
     const project = await db
@@ -623,7 +623,7 @@ describe("PATCH /api/flow-council/projects/[projectId]/milestones — dynamic", 
         {
           title: "Original Title",
           description: "x".repeat(50),
-          items: ["KR 1"],
+          items: ["Activation 1"],
         },
       ],
     );
@@ -674,7 +674,7 @@ describe("PATCH /api/flow-council/projects/[projectId]/milestones — dynamic", 
     const round = await seedRoundWithMilestoneSchema(
       ELEMENT_UUID,
       "Engineering Milestone",
-      "Key Result",
+      "Activation",
     );
 
     const project = await db
@@ -694,7 +694,7 @@ describe("PATCH /api/flow-council/projects/[projectId]/milestones — dynamic", 
           {
             title: "Locked Dynamic Milestone",
             description: "x".repeat(50),
-            items: ["KR 1"],
+            items: ["Activation 1"],
           },
         ],
       },
@@ -727,7 +727,7 @@ describe("PATCH /api/flow-council/projects/[projectId]/milestones — dynamic", 
     const round = await seedRoundWithMilestoneSchema(
       ELEMENT_UUID,
       "Engineering Milestone",
-      "Key Result",
+      "Activation",
     );
 
     const project = await db
@@ -791,7 +791,7 @@ describe("PATCH /api/flow-council/projects/[projectId]/milestones — dynamic", 
     const round = await seedRoundWithMilestoneSchema(
       ELEMENT_UUID,
       "Engineering Milestone",
-      "Key Result",
+      "Activation",
     );
 
     const project = await db
@@ -813,7 +813,7 @@ describe("PATCH /api/flow-council/projects/[projectId]/milestones — dynamic", 
         {
           title: "Only Milestone",
           description: "x".repeat(50),
-          items: ["KR 1"],
+          items: ["Activation 1"],
         },
       ],
     );
@@ -845,7 +845,7 @@ describe("PATCH /api/flow-council/projects/[projectId]/milestones — dynamic", 
     const round = await seedRoundWithMilestoneSchema(
       ELEMENT_UUID,
       "Engineering Milestone",
-      "Key Result",
+      "Activation",
     );
 
     const project = await db
@@ -942,7 +942,7 @@ describe("PATCH — milestoneType length validation", () => {
     const round = await seedRoundWithMilestoneSchema(
       ELEMENT_UUID,
       "Engineering Milestone",
-      "Key Result",
+      "Activation",
     );
 
     const app = await seedDynamicApplication(

--- a/src/app/api/flow-council/projects/milestones.integration.test.ts
+++ b/src/app/api/flow-council/projects/milestones.integration.test.ts
@@ -16,7 +16,7 @@ vi.mock("next-auth/next", () => ({
 
 vi.mock("@/app/api/auth/[...nextauth]/route", () => ({ authOptions: {} }));
 
-vi.mock("../../db", async () => {
+vi.mock("../db", async () => {
   const { getTestDb } = await import("@tests/helpers/db");
   return { db: getTestDb() };
 });
@@ -179,17 +179,20 @@ async function seedDynamicApplication(
     .executeTakeFirstOrThrow();
 }
 
-/** Seed a round with a formSchema containing a milestone element */
+/** Seed a round with a formSchema containing a milestone element.
+ * Uses a chainId distinct from the fixture round to avoid the
+ * (chain_id, flow_council_address) unique constraint. */
 async function seedRoundWithMilestoneSchema(
   elementId: string,
   milestoneLabel: string,
   itemLabel: string,
   minCount: number = 1,
+  chainId: number = TEST_CHAIN_ID + 1,
 ) {
   const round = await db
     .insertInto("rounds")
     .values({
-      chainId: TEST_CHAIN_ID,
+      chainId,
       flowCouncilAddress: TEST_COUNCIL_ADDRESS,
       applicationsClosed: false,
       details: JSON.stringify({
@@ -361,11 +364,13 @@ describe("GET — legacy and dynamic applications do not cross-pollute", () => {
       "Key Result",
     );
 
-    // A second round for the legacy application (same council, different ID)
+    // A second round for the legacy application. Use a distinct chainId so we
+    // don't collide with the fixture round or the dynamic round on
+    // (chain_id, flow_council_address).
     const legacyRound = await db
       .insertInto("rounds")
       .values({
-        chainId: TEST_CHAIN_ID,
+        chainId: TEST_CHAIN_ID + 2,
         flowCouncilAddress: TEST_COUNCIL_ADDRESS,
         applicationsClosed: false,
         details: JSON.stringify({ name: "Legacy Round" }),
@@ -477,7 +482,15 @@ describe("PATCH /api/flow-council/projects/[projectId]/milestones — legacy", (
       .where("id", "=", app.id)
       .executeTakeFirstOrThrow();
 
-    const details = JSON.parse(updated.details as string);
+    const details = updated.details as {
+      buildGoals: {
+        milestones: Array<{
+          title: string;
+          description: string;
+          deliverables: string[];
+        }>;
+      };
+    };
     expect(details.buildGoals.milestones[0].title).toBe("Updated Build Title");
     expect(details.buildGoals.milestones[0].deliverables).toEqual([
       "New Deliverable",
@@ -621,7 +634,7 @@ describe("PATCH /api/flow-council/projects/[projectId]/milestones — dynamic", 
         milestoneIndex: 0,
         definition: {
           title: "Updated Dynamic Title",
-          description: "d".repeat(50),
+          description: "d".repeat(500),
           items: ["Updated KR 1", "KR 2"],
         },
       }),
@@ -637,7 +650,12 @@ describe("PATCH /api/flow-council/projects/[projectId]/milestones — dynamic", 
       .where("id", "=", app.id)
       .executeTakeFirstOrThrow();
 
-    const details = JSON.parse(updated.details as string);
+    const details = updated.details as {
+      round: Record<
+        string,
+        Array<{ title: string; description: string; items: string[] }>
+      >;
+    };
     expect(details.round[ELEMENT_UUID][0].title).toBe("Updated Dynamic Title");
     expect(details.round[ELEMENT_UUID][0].items).toEqual([
       "Updated KR 1",
@@ -645,7 +663,7 @@ describe("PATCH /api/flow-council/projects/[projectId]/milestones — dynamic", 
     ]);
     // Gap 4: title and description must persist exactly as sent
     expect(details.round[ELEMENT_UUID][0].title).toBe("Updated Dynamic Title");
-    expect(details.round[ELEMENT_UUID][0].description).toBe("d".repeat(50));
+    expect(details.round[ELEMENT_UUID][0].description).toBe("d".repeat(500));
   });
 
   // Gap 2: editsUnlocked=false rejection — dynamic path
@@ -688,7 +706,7 @@ describe("PATCH /api/flow-council/projects/[projectId]/milestones — dynamic", 
         milestoneIndex: 0,
         definition: {
           title: "Should Be Blocked",
-          description: "b".repeat(50),
+          description: "b".repeat(500),
           items: ["Blocked KR"],
         },
       }),
@@ -807,7 +825,7 @@ describe("PATCH /api/flow-council/projects/[projectId]/milestones — dynamic", 
         milestoneIndex: 5,
         definition: {
           title: "Ghost Milestone",
-          description: "g".repeat(50),
+          description: "g".repeat(500),
           items: ["item"],
         },
       }),

--- a/src/app/api/flow-council/projects/milestones.integration.test.ts
+++ b/src/app/api/flow-council/projects/milestones.integration.test.ts
@@ -1,0 +1,994 @@
+/**
+ * Integration tests for the milestones GET and PATCH routes.
+ * Covers both legacy (buildGoals/growthGoals) and dynamic (round[<elementId>])
+ * milestone storage introduced by "Configurable Milestone Question Type for
+ * Dynamic Form Builder".
+ *
+ * All tests that depend on the new feature are expected to FAIL until the
+ * feature is implemented. Legacy-path tests may already pass.
+ */
+
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+
+vi.mock("next-auth/next", () => ({
+  getServerSession: vi.fn(),
+}));
+
+vi.mock("@/app/api/auth/[...nextauth]/route", () => ({ authOptions: {} }));
+
+vi.mock("../../db", async () => {
+  const { getTestDb } = await import("@tests/helpers/db");
+  return { db: getTestDb() };
+});
+
+// Route handlers under test
+import { GET, PATCH } from "./[projectId]/milestones/route";
+
+import {
+  getTestDb,
+  resetAndSeed,
+  resetDb,
+  TEST_MANAGER_ADDRESS,
+  TEST_CHAIN_ID,
+  TEST_COUNCIL_ADDRESS,
+  type SeededFixture,
+} from "@tests/helpers/db";
+import { mockSession } from "@tests/helpers/session";
+
+const db = getTestDb();
+
+let fixture: SeededFixture;
+
+afterAll(async () => {
+  await resetDb(db);
+  await db.destroy();
+});
+
+beforeEach(async () => {
+  fixture = await resetAndSeed(db);
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type TestMilestone = {
+  type: string;
+  milestoneLabel: string;
+  itemLabel: string;
+  index: number;
+  title: string;
+  description: string;
+  itemNames: string[];
+};
+
+type TestApplication = {
+  applicationId: number;
+  milestones: TestMilestone[];
+};
+
+const ELEMENT_UUID = "b2c3d4e5-f6a7-8901-bcde-f12345678901";
+
+async function readJson(res: Response) {
+  return JSON.parse(await res.text());
+}
+
+function makeGetRequest(projectId: number) {
+  return new Request(
+    `http://localhost/api/flow-council/projects/${projectId}/milestones`,
+  );
+}
+
+function makePatchRequest(projectId: number, body: unknown) {
+  return new Request(
+    `http://localhost/api/flow-council/projects/${projectId}/milestones`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+function makeRouteParams(projectId: number) {
+  return { params: Promise.resolve({ projectId: String(projectId) }) };
+}
+
+/** Seed an ACCEPTED application with legacy buildGoals/growthGoals milestones */
+async function seedLegacyApplication(projectId: number, roundId: number) {
+  return db
+    .insertInto("applications")
+    .values({
+      projectId,
+      roundId,
+      fundingAddress: TEST_MANAGER_ADDRESS,
+      status: "ACCEPTED",
+      editsUnlocked: true,
+      details: JSON.stringify({
+        buildGoals: {
+          primaryBuildGoal: "Build something",
+          milestones: [
+            {
+              title: "Build Milestone 1",
+              description: "x".repeat(500),
+              deliverables: ["Deliverable A", "Deliverable B"],
+            },
+          ],
+          ecosystemImpact: "",
+        },
+        growthGoals: {
+          primaryGrowthGoal: "Grow something",
+          targetUsers: "Everyone",
+          milestones: [
+            {
+              title: "Growth Milestone 1",
+              description: "y".repeat(500),
+              activations: ["Activation 1"],
+            },
+          ],
+          ecosystemImpact: "",
+        },
+      }),
+    })
+    .returning("id")
+    .executeTakeFirstOrThrow();
+}
+
+/** Seed an ACCEPTED application with editsUnlocked: false */
+async function seedLockedApplication(
+  projectId: number,
+  roundId: number,
+  details: unknown,
+) {
+  return db
+    .insertInto("applications")
+    .values({
+      projectId,
+      roundId,
+      fundingAddress: TEST_MANAGER_ADDRESS,
+      status: "ACCEPTED",
+      editsUnlocked: false,
+      details: JSON.stringify(details),
+    })
+    .returning("id")
+    .executeTakeFirstOrThrow();
+}
+
+/** Seed an ACCEPTED application with a dynamic milestone field */
+async function seedDynamicApplication(
+  projectId: number,
+  roundId: number,
+  elementId: string,
+  milestones: Array<{ title: string; description: string; items: string[] }>,
+) {
+  return db
+    .insertInto("applications")
+    .values({
+      projectId,
+      roundId,
+      fundingAddress: TEST_MANAGER_ADDRESS,
+      status: "ACCEPTED",
+      editsUnlocked: true,
+      details: JSON.stringify({
+        round: {
+          [elementId]: milestones,
+        },
+      }),
+    })
+    .returning("id")
+    .executeTakeFirstOrThrow();
+}
+
+/** Seed a round with a formSchema containing a milestone element */
+async function seedRoundWithMilestoneSchema(
+  elementId: string,
+  milestoneLabel: string,
+  itemLabel: string,
+  minCount: number = 1,
+) {
+  const round = await db
+    .insertInto("rounds")
+    .values({
+      chainId: TEST_CHAIN_ID,
+      flowCouncilAddress: TEST_COUNCIL_ADDRESS,
+      applicationsClosed: false,
+      details: JSON.stringify({
+        name: "Engineering Round",
+        formSchema: {
+          round: [
+            {
+              id: elementId,
+              type: "milestone",
+              label: "Engineering Milestones",
+              milestoneLabel,
+              itemLabel,
+              minCount,
+              descriptionMinChars: 50,
+              descriptionMaxChars: 2000,
+            },
+          ],
+          attestation: [],
+        },
+      }),
+    })
+    .returning("id")
+    .executeTakeFirstOrThrow();
+  return round;
+}
+
+// ---------------------------------------------------------------------------
+// GET — legacy path
+// ---------------------------------------------------------------------------
+
+describe("GET /api/flow-council/projects/[projectId]/milestones — legacy", () => {
+  it("returns MilestoneWithProgress[] with type 'build'/'growth' for legacy application", async () => {
+    // Create a fresh project with an accepted legacy application
+    const project = await db
+      .insertInto("projects")
+      .values({ details: JSON.stringify({ name: "Legacy Project" }) })
+      .returning("id")
+      .executeTakeFirstOrThrow();
+
+    await db
+      .insertInto("projectManagers")
+      .values({ projectId: project.id, managerAddress: TEST_MANAGER_ADDRESS })
+      .execute();
+
+    await seedLegacyApplication(project.id, fixture.roundId);
+
+    const res = await GET(makeGetRequest(project.id), makeRouteParams(project.id));
+    const body = await readJson(res);
+
+    expect(body.success).toBe(true);
+    expect(body.applications).toHaveLength(1);
+
+    const milestones = body.applications[0].milestones;
+    const buildMilestone = milestones.find(
+      (m: TestMilestone) => m.type === "build",
+    );
+    const growthMilestone = milestones.find(
+      (m: TestMilestone) => m.type === "growth",
+    );
+
+    expect(buildMilestone).toBeDefined();
+    expect(buildMilestone.title).toBe("Build Milestone 1");
+    expect(buildMilestone.itemNames).toEqual(["Deliverable A", "Deliverable B"]);
+
+    expect(growthMilestone).toBeDefined();
+    expect(growthMilestone.title).toBe("Growth Milestone 1");
+    expect(growthMilestone.itemNames).toEqual(["Activation 1"]);
+  });
+
+  it("legacy milestones expose milestoneLabel 'Build'/'Growth' and itemLabel 'Deliverable'/'Activation'", async () => {
+    const project = await db
+      .insertInto("projects")
+      .values({ details: JSON.stringify({ name: "Legacy Labels Project" }) })
+      .returning("id")
+      .executeTakeFirstOrThrow();
+
+    await db
+      .insertInto("projectManagers")
+      .values({ projectId: project.id, managerAddress: TEST_MANAGER_ADDRESS })
+      .execute();
+
+    await seedLegacyApplication(project.id, fixture.roundId);
+
+    const res = await GET(makeGetRequest(project.id), makeRouteParams(project.id));
+    const body = await readJson(res);
+
+    expect(body.success).toBe(true);
+    const milestones = body.applications[0].milestones;
+
+    const buildM = milestones.find((m: TestMilestone) => m.type === "build");
+    const growthM = milestones.find((m: TestMilestone) => m.type === "growth");
+
+    // The feature spec states legacy milestones must expose these labels
+    // so the UI can render them consistently alongside dynamic milestones.
+    expect(buildM.milestoneLabel).toBe("Build");
+    expect(buildM.itemLabel).toBe("Deliverable");
+    expect(growthM.milestoneLabel).toBe("Growth");
+    expect(growthM.itemLabel).toBe("Activation");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET — dynamic path
+// ---------------------------------------------------------------------------
+
+describe("GET /api/flow-council/projects/[projectId]/milestones — dynamic", () => {
+  it("returns milestones with type=<elementId>, milestoneLabel, and itemLabel from the round formSchema", async () => {
+    const round = await seedRoundWithMilestoneSchema(
+      ELEMENT_UUID,
+      "Engineering Milestone",
+      "Key Result",
+    );
+
+    const project = await db
+      .insertInto("projects")
+      .values({ details: JSON.stringify({ name: "Dynamic Project" }) })
+      .returning("id")
+      .executeTakeFirstOrThrow();
+
+    await db
+      .insertInto("projectManagers")
+      .values({ projectId: project.id, managerAddress: TEST_MANAGER_ADDRESS })
+      .execute();
+
+    await seedDynamicApplication(project.id, round.id, ELEMENT_UUID, [
+      {
+        title: "Ship the API",
+        description: "x".repeat(50),
+        items: ["Key Result 1", "Key Result 2"],
+      },
+    ]);
+
+    const res = await GET(makeGetRequest(project.id), makeRouteParams(project.id));
+    const body = await readJson(res);
+
+    expect(body.success).toBe(true);
+    expect(body.applications).toHaveLength(1);
+
+    const [milestone] = body.applications[0].milestones;
+    expect(milestone.type).toBe(ELEMENT_UUID);
+    expect(milestone.milestoneLabel).toBe("Engineering Milestone");
+    expect(milestone.itemLabel).toBe("Key Result");
+    expect(milestone.title).toBe("Ship the API");
+    expect(milestone.itemNames).toEqual(["Key Result 1", "Key Result 2"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET — coexistence: legacy + dynamic applications under the same project
+// ---------------------------------------------------------------------------
+
+describe("GET — legacy and dynamic applications do not cross-pollute", () => {
+  it("each application's milestones are isolated from other applications on the same project", async () => {
+    const round = await seedRoundWithMilestoneSchema(
+      ELEMENT_UUID,
+      "Engineering Milestone",
+      "Key Result",
+    );
+
+    // A second round for the legacy application (same council, different ID)
+    const legacyRound = await db
+      .insertInto("rounds")
+      .values({
+        chainId: TEST_CHAIN_ID,
+        flowCouncilAddress: TEST_COUNCIL_ADDRESS,
+        applicationsClosed: false,
+        details: JSON.stringify({ name: "Legacy Round" }),
+      })
+      .returning("id")
+      .executeTakeFirstOrThrow();
+
+    const project = await db
+      .insertInto("projects")
+      .values({ details: JSON.stringify({ name: "Mixed Project" }) })
+      .returning("id")
+      .executeTakeFirstOrThrow();
+
+    await db
+      .insertInto("projectManagers")
+      .values({ projectId: project.id, managerAddress: TEST_MANAGER_ADDRESS })
+      .execute();
+
+    const legacyApp = await seedLegacyApplication(project.id, legacyRound.id);
+    const dynamicApp = await seedDynamicApplication(project.id, round.id, ELEMENT_UUID, [
+      {
+        title: "Dynamic Milestone",
+        description: "z".repeat(50),
+        items: ["KR 1"],
+      },
+    ]);
+
+    const res = await GET(makeGetRequest(project.id), makeRouteParams(project.id));
+    const body = await readJson(res);
+
+    expect(body.success).toBe(true);
+    expect(body.applications).toHaveLength(2);
+
+    const legacyResult = body.applications.find(
+      (a: TestApplication) => a.applicationId === legacyApp.id,
+    );
+    const dynamicResult = body.applications.find(
+      (a: TestApplication) => a.applicationId === dynamicApp.id,
+    );
+
+    // Legacy application only has legacy milestones
+    const legacyTypes = legacyResult.milestones.map(
+      (m: TestMilestone) => m.type,
+    );
+    expect(legacyTypes).toContain("build");
+    expect(legacyTypes).toContain("growth");
+    expect(legacyTypes).not.toContain(ELEMENT_UUID);
+
+    // Dynamic application only has dynamic milestones
+    const dynamicTypes = dynamicResult.milestones.map(
+      (m: TestMilestone) => m.type,
+    );
+    expect(dynamicTypes).toContain(ELEMENT_UUID);
+    expect(dynamicTypes).not.toContain("build");
+    expect(dynamicTypes).not.toContain("growth");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PATCH — legacy path
+// ---------------------------------------------------------------------------
+
+describe("PATCH /api/flow-council/projects/[projectId]/milestones — legacy", () => {
+  it("definition edit with milestoneType 'build' writes to buildGoals.milestones[index]", async () => {
+    mockSession(TEST_MANAGER_ADDRESS);
+
+    const project = await db
+      .insertInto("projects")
+      .values({ details: JSON.stringify({ name: "Patch Legacy Project" }) })
+      .returning("id")
+      .executeTakeFirstOrThrow();
+
+    await db
+      .insertInto("projectManagers")
+      .values({ projectId: project.id, managerAddress: TEST_MANAGER_ADDRESS })
+      .execute();
+
+    const app = await seedLegacyApplication(project.id, fixture.roundId);
+
+    const res = await PATCH(
+      makePatchRequest(project.id, {
+        applicationId: app.id,
+        milestoneType: "build",
+        milestoneIndex: 0,
+        definition: {
+          title: "Updated Build Title",
+          description: "u".repeat(500),
+          items: ["New Deliverable"],
+        },
+      }),
+      makeRouteParams(project.id),
+    );
+
+    const body = await readJson(res);
+    expect(body.success).toBe(true);
+
+    // Verify the update was written to the DB
+    const updated = await db
+      .selectFrom("applications")
+      .select("details")
+      .where("id", "=", app.id)
+      .executeTakeFirstOrThrow();
+
+    const details = JSON.parse(updated.details as string);
+    expect(details.buildGoals.milestones[0].title).toBe("Updated Build Title");
+    expect(details.buildGoals.milestones[0].deliverables).toEqual([
+      "New Deliverable",
+    ]);
+    // Gap 4: title and description must persist exactly as sent
+    expect(details.buildGoals.milestones[0].title).toBe("Updated Build Title");
+    expect(details.buildGoals.milestones[0].description).toBe("u".repeat(500));
+  });
+
+  it("rejects out-of-range milestoneIndex for 'build' with 400-class error", async () => {
+    mockSession(TEST_MANAGER_ADDRESS);
+
+    const project = await db
+      .insertInto("projects")
+      .values({ details: JSON.stringify({ name: "OOB Legacy Project" }) })
+      .returning("id")
+      .executeTakeFirstOrThrow();
+
+    await db
+      .insertInto("projectManagers")
+      .values({ projectId: project.id, managerAddress: TEST_MANAGER_ADDRESS })
+      .execute();
+
+    const app = await seedLegacyApplication(project.id, fixture.roundId);
+
+    // Index 99 is way beyond the single milestone in the fixture
+    const res = await PATCH(
+      makePatchRequest(project.id, {
+        applicationId: app.id,
+        milestoneType: "build",
+        milestoneIndex: 99,
+        definition: {
+          title: "Should Not Exist",
+          description: "x".repeat(500),
+          items: ["item"],
+        },
+      }),
+      makeRouteParams(project.id),
+    );
+
+    const body = await readJson(res);
+    expect(body.success).toBe(false);
+    // The route returns a 400-level body; the HTTP status or body error must
+    // indicate an out-of-range / invalid index condition.
+    expect(body.error).toMatch(/out of range|invalid|index/i);
+  });
+
+  // Gap 2: editsUnlocked=false rejection — legacy path
+  it("rejects definition edit when editsUnlocked is false (legacy)", async () => {
+    mockSession(TEST_MANAGER_ADDRESS);
+
+    const project = await db
+      .insertInto("projects")
+      .values({ details: JSON.stringify({ name: "Locked Legacy Project" }) })
+      .returning("id")
+      .executeTakeFirstOrThrow();
+
+    await db
+      .insertInto("projectManagers")
+      .values({ projectId: project.id, managerAddress: TEST_MANAGER_ADDRESS })
+      .execute();
+
+    const app = await seedLockedApplication(project.id, fixture.roundId, {
+      buildGoals: {
+        primaryBuildGoal: "Build something",
+        milestones: [
+          {
+            title: "Locked Milestone",
+            description: "x".repeat(500),
+            deliverables: ["Deliverable A"],
+          },
+        ],
+        ecosystemImpact: "",
+      },
+    });
+
+    const res = await PATCH(
+      makePatchRequest(project.id, {
+        applicationId: app.id,
+        milestoneType: "build",
+        milestoneIndex: 0,
+        definition: {
+          title: "Should Be Blocked",
+          description: "b".repeat(500),
+          items: ["Blocked Item"],
+        },
+      }),
+      makeRouteParams(project.id),
+    );
+
+    // Route at milestones/route.ts:240 returns 403 when !editsUnlocked
+    expect(res.status).toBe(403);
+    const body = await readJson(res);
+    expect(body.success).toBe(false);
+    expect(body.error).toMatch(/edit|unlock/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PATCH — dynamic path
+// ---------------------------------------------------------------------------
+
+describe("PATCH /api/flow-council/projects/[projectId]/milestones — dynamic", () => {
+  it("definition edit with milestoneType=<UUID> writes to appDetails.round[UUID][index]", async () => {
+    mockSession(TEST_MANAGER_ADDRESS);
+
+    const round = await seedRoundWithMilestoneSchema(
+      ELEMENT_UUID,
+      "Engineering Milestone",
+      "Key Result",
+    );
+
+    const project = await db
+      .insertInto("projects")
+      .values({ details: JSON.stringify({ name: "Patch Dynamic Project" }) })
+      .returning("id")
+      .executeTakeFirstOrThrow();
+
+    await db
+      .insertInto("projectManagers")
+      .values({ projectId: project.id, managerAddress: TEST_MANAGER_ADDRESS })
+      .execute();
+
+    const app = await seedDynamicApplication(project.id, round.id, ELEMENT_UUID, [
+      {
+        title: "Original Title",
+        description: "x".repeat(50),
+        items: ["KR 1"],
+      },
+    ]);
+
+    const res = await PATCH(
+      makePatchRequest(project.id, {
+        applicationId: app.id,
+        milestoneType: ELEMENT_UUID,
+        milestoneIndex: 0,
+        definition: {
+          title: "Updated Dynamic Title",
+          description: "d".repeat(50),
+          items: ["Updated KR 1", "KR 2"],
+        },
+      }),
+      makeRouteParams(project.id),
+    );
+
+    const body = await readJson(res);
+    expect(body.success).toBe(true);
+
+    const updated = await db
+      .selectFrom("applications")
+      .select("details")
+      .where("id", "=", app.id)
+      .executeTakeFirstOrThrow();
+
+    const details = JSON.parse(updated.details as string);
+    expect(details.round[ELEMENT_UUID][0].title).toBe("Updated Dynamic Title");
+    expect(details.round[ELEMENT_UUID][0].items).toEqual([
+      "Updated KR 1",
+      "KR 2",
+    ]);
+    // Gap 4: title and description must persist exactly as sent
+    expect(details.round[ELEMENT_UUID][0].title).toBe("Updated Dynamic Title");
+    expect(details.round[ELEMENT_UUID][0].description).toBe("d".repeat(50));
+  });
+
+  // Gap 2: editsUnlocked=false rejection — dynamic path
+  it("rejects definition edit when editsUnlocked is false (dynamic)", async () => {
+    mockSession(TEST_MANAGER_ADDRESS);
+
+    const round = await seedRoundWithMilestoneSchema(
+      ELEMENT_UUID,
+      "Engineering Milestone",
+      "Key Result",
+    );
+
+    const project = await db
+      .insertInto("projects")
+      .values({ details: JSON.stringify({ name: "Locked Dynamic Project" }) })
+      .returning("id")
+      .executeTakeFirstOrThrow();
+
+    await db
+      .insertInto("projectManagers")
+      .values({ projectId: project.id, managerAddress: TEST_MANAGER_ADDRESS })
+      .execute();
+
+    const app = await seedLockedApplication(project.id, round.id, {
+      round: {
+        [ELEMENT_UUID]: [
+          {
+            title: "Locked Dynamic Milestone",
+            description: "x".repeat(50),
+            items: ["KR 1"],
+          },
+        ],
+      },
+    });
+
+    const res = await PATCH(
+      makePatchRequest(project.id, {
+        applicationId: app.id,
+        milestoneType: ELEMENT_UUID,
+        milestoneIndex: 0,
+        definition: {
+          title: "Should Be Blocked",
+          description: "b".repeat(50),
+          items: ["Blocked KR"],
+        },
+      }),
+      makeRouteParams(project.id),
+    );
+
+    // Route at milestones/route.ts:240 returns 403 when !editsUnlocked
+    expect(res.status).toBe(403);
+    const body = await readJson(res);
+    expect(body.success).toBe(false);
+    expect(body.error).toMatch(/edit|unlock/i);
+  });
+
+  it("stores the full UUID (>10 chars) in milestone_progress.milestone_type — validates VARCHAR(100) migration", async () => {
+    mockSession(TEST_MANAGER_ADDRESS);
+
+    const round = await seedRoundWithMilestoneSchema(
+      ELEMENT_UUID,
+      "Engineering Milestone",
+      "Key Result",
+    );
+
+    const project = await db
+      .insertInto("projects")
+      .values({ details: JSON.stringify({ name: "UUID Storage Project" }) })
+      .returning("id")
+      .executeTakeFirstOrThrow();
+
+    await db
+      .insertInto("projectManagers")
+      .values({ projectId: project.id, managerAddress: TEST_MANAGER_ADDRESS })
+      .execute();
+
+    const app = await seedDynamicApplication(project.id, round.id, ELEMENT_UUID, [
+      {
+        title: "UUID Milestone",
+        description: "x".repeat(50),
+        items: ["Item 1"],
+      },
+    ]);
+
+    // PATCH with a progress update (not a definition edit) so milestone_progress is written
+    const res = await PATCH(
+      makePatchRequest(project.id, {
+        applicationId: app.id,
+        milestoneType: ELEMENT_UUID,
+        milestoneIndex: 0,
+        progress: {
+          otherDetails: "",
+          items: [{ completion: 50, evidence: [] }],
+        },
+      }),
+      makeRouteParams(project.id),
+    );
+
+    const body = await readJson(res);
+    expect(body.success).toBe(true);
+
+    // Verify that the stored milestone_type is the full UUID (36 chars), not truncated
+    const progressRow = await db
+      .selectFrom("milestoneProgress")
+      .select("milestoneType")
+      .where("applicationId", "=", app.id)
+      .where("milestoneIndex", "=", 0)
+      .executeTakeFirst();
+
+    expect(progressRow).toBeDefined();
+    expect(progressRow!.milestoneType).toBe(ELEMENT_UUID);
+    expect(progressRow!.milestoneType.length).toBeGreaterThan(10);
+    expect(progressRow!.milestoneType.length).toBeLessThanOrEqual(100);
+  });
+
+  it("rejects out-of-range milestoneIndex for a dynamic milestone type with error body", async () => {
+    mockSession(TEST_MANAGER_ADDRESS);
+
+    const round = await seedRoundWithMilestoneSchema(
+      ELEMENT_UUID,
+      "Engineering Milestone",
+      "Key Result",
+    );
+
+    const project = await db
+      .insertInto("projects")
+      .values({ details: JSON.stringify({ name: "OOB Dynamic Project" }) })
+      .returning("id")
+      .executeTakeFirstOrThrow();
+
+    await db
+      .insertInto("projectManagers")
+      .values({ projectId: project.id, managerAddress: TEST_MANAGER_ADDRESS })
+      .execute();
+
+    const app = await seedDynamicApplication(project.id, round.id, ELEMENT_UUID, [
+      { title: "Only Milestone", description: "x".repeat(50), items: ["KR 1"] },
+    ]);
+
+    // milestoneIndex 5 is out of range (only index 0 exists)
+    const res = await PATCH(
+      makePatchRequest(project.id, {
+        applicationId: app.id,
+        milestoneType: ELEMENT_UUID,
+        milestoneIndex: 5,
+        definition: {
+          title: "Ghost Milestone",
+          description: "g".repeat(50),
+          items: ["item"],
+        },
+      }),
+      makeRouteParams(project.id),
+    );
+
+    const body = await readJson(res);
+    expect(body.success).toBe(false);
+    expect(body.error).toMatch(/out of range|invalid|index/i);
+  });
+
+  // Gap 3: Dual-channel feed assertion — both PUBLIC_PROJECT and PUBLIC_ROUND must be written
+  it("PATCH progress feed post includes the configured milestoneLabel from the round formSchema (not hardcoded 'Build'/'Growth') — in both PUBLIC_PROJECT and PUBLIC_ROUND channels", async () => {
+    mockSession(TEST_MANAGER_ADDRESS);
+
+    const round = await seedRoundWithMilestoneSchema(
+      ELEMENT_UUID,
+      "Engineering Milestone",
+      "Key Result",
+    );
+
+    const project = await db
+      .insertInto("projects")
+      .values({ details: JSON.stringify({ name: "Feed Label Project" }) })
+      .returning("id")
+      .executeTakeFirstOrThrow();
+
+    await db
+      .insertInto("projectManagers")
+      .values({ projectId: project.id, managerAddress: TEST_MANAGER_ADDRESS })
+      .execute();
+
+    const app = await seedDynamicApplication(project.id, round.id, ELEMENT_UUID, [
+      {
+        title: "Feed Milestone",
+        description: "f".repeat(50),
+        items: ["KR Feed"],
+      },
+    ]);
+
+    await PATCH(
+      makePatchRequest(project.id, {
+        applicationId: app.id,
+        milestoneType: ELEMENT_UUID,
+        milestoneIndex: 0,
+        progress: {
+          otherDetails: "Great progress this week",
+          items: [{ completion: 25, evidence: [] }],
+        },
+      }),
+      makeRouteParams(project.id),
+    );
+
+    // Both PUBLIC_PROJECT and PUBLIC_ROUND channels must have a message
+    const projectMessages = await db
+      .selectFrom("messages")
+      .select("content")
+      .where("projectId", "=", project.id)
+      .where("messageType", "=", "milestone_update")
+      .where("channelType", "=", "PUBLIC_PROJECT")
+      .execute();
+
+    const roundMessages = await db
+      .selectFrom("messages")
+      .select("content")
+      .where("projectId", "=", project.id)
+      .where("messageType", "=", "milestone_update")
+      .where("channelType", "=", "PUBLIC_ROUND")
+      .execute();
+
+    // Gap 3: both channels must be populated
+    expect(projectMessages.length).toBeGreaterThan(0);
+    expect(roundMessages.length).toBeGreaterThan(0);
+
+    // Both must contain the configured milestoneLabel, not legacy labels
+    const projectContent = projectMessages[0].content;
+    const roundContent = roundMessages[0].content;
+
+    expect(projectContent).toContain("Engineering Milestone");
+    expect(projectContent).not.toMatch(/\bBuild\b/);
+    expect(projectContent).not.toMatch(/\bGrowth\b/);
+
+    expect(roundContent).toContain("Engineering Milestone");
+    expect(roundContent).not.toMatch(/\bBuild\b/);
+    expect(roundContent).not.toMatch(/\bGrowth\b/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PATCH — milestoneType length validation
+// ---------------------------------------------------------------------------
+
+describe("PATCH — milestoneType length validation", () => {
+  it("accepts a 36-char UUID as milestoneType", async () => {
+    mockSession(TEST_MANAGER_ADDRESS);
+
+    const project = await db
+      .insertInto("projects")
+      .values({ details: JSON.stringify({ name: "UUID Len Accept Project" }) })
+      .returning("id")
+      .executeTakeFirstOrThrow();
+
+    await db
+      .insertInto("projectManagers")
+      .values({ projectId: project.id, managerAddress: TEST_MANAGER_ADDRESS })
+      .execute();
+
+    const round = await seedRoundWithMilestoneSchema(
+      ELEMENT_UUID,
+      "Engineering Milestone",
+      "Key Result",
+    );
+
+    const app = await seedDynamicApplication(project.id, round.id, ELEMENT_UUID, [
+      { title: "M1", description: "x".repeat(50), items: ["KR"] },
+    ]);
+
+    const res = await PATCH(
+      makePatchRequest(project.id, {
+        applicationId: app.id,
+        milestoneType: ELEMENT_UUID, // 36 chars — valid UUID
+        milestoneIndex: 0,
+        progress: {
+          otherDetails: "",
+          items: [{ completion: 0, evidence: [] }],
+        },
+      }),
+      makeRouteParams(project.id),
+    );
+
+    const body = await readJson(res);
+    expect(body.success).toBe(true);
+  });
+
+  it("rejects an empty string as milestoneType", async () => {
+    mockSession(TEST_MANAGER_ADDRESS);
+
+    const project = await db
+      .insertInto("projects")
+      .values({ details: JSON.stringify({ name: "UUID Len Empty Project" }) })
+      .returning("id")
+      .executeTakeFirstOrThrow();
+
+    await db
+      .insertInto("projectManagers")
+      .values({ projectId: project.id, managerAddress: TEST_MANAGER_ADDRESS })
+      .execute();
+
+    const app = await db
+      .insertInto("applications")
+      .values({
+        projectId: project.id,
+        roundId: fixture.roundId,
+        fundingAddress: TEST_MANAGER_ADDRESS,
+        status: "ACCEPTED",
+        editsUnlocked: true,
+        details: JSON.stringify({}),
+      })
+      .returning("id")
+      .executeTakeFirstOrThrow();
+
+    const res = await PATCH(
+      makePatchRequest(project.id, {
+        applicationId: app.id,
+        milestoneType: "",
+        milestoneIndex: 0,
+        progress: {
+          otherDetails: "",
+          items: [{ completion: 0, evidence: [] }],
+        },
+      }),
+      makeRouteParams(project.id),
+    );
+
+    const body = await readJson(res);
+    expect(body.success).toBe(false);
+  });
+
+  it("rejects a milestoneType string longer than 100 chars", async () => {
+    mockSession(TEST_MANAGER_ADDRESS);
+
+    const project = await db
+      .insertInto("projects")
+      .values({ details: JSON.stringify({ name: "UUID Len Long Project" }) })
+      .returning("id")
+      .executeTakeFirstOrThrow();
+
+    await db
+      .insertInto("projectManagers")
+      .values({ projectId: project.id, managerAddress: TEST_MANAGER_ADDRESS })
+      .execute();
+
+    const app = await db
+      .insertInto("applications")
+      .values({
+        projectId: project.id,
+        roundId: fixture.roundId,
+        fundingAddress: TEST_MANAGER_ADDRESS,
+        status: "ACCEPTED",
+        editsUnlocked: true,
+        details: JSON.stringify({}),
+      })
+      .returning("id")
+      .executeTakeFirstOrThrow();
+
+    const longType = "a".repeat(101);
+    const res = await PATCH(
+      makePatchRequest(project.id, {
+        applicationId: app.id,
+        milestoneType: longType,
+        milestoneIndex: 0,
+        progress: {
+          otherDetails: "",
+          items: [{ completion: 0, evidence: [] }],
+        },
+      }),
+      makeRouteParams(project.id),
+    );
+
+    const body = await readJson(res);
+    expect(body.success).toBe(false);
+  });
+});

--- a/src/app/api/flow-council/projects/milestones.integration.test.ts
+++ b/src/app/api/flow-council/projects/milestones.integration.test.ts
@@ -236,7 +236,10 @@ describe("GET /api/flow-council/projects/[projectId]/milestones — legacy", () 
 
     await seedLegacyApplication(project.id, fixture.roundId);
 
-    const res = await GET(makeGetRequest(project.id), makeRouteParams(project.id));
+    const res = await GET(
+      makeGetRequest(project.id),
+      makeRouteParams(project.id),
+    );
     const body = await readJson(res);
 
     expect(body.success).toBe(true);
@@ -252,7 +255,10 @@ describe("GET /api/flow-council/projects/[projectId]/milestones — legacy", () 
 
     expect(buildMilestone).toBeDefined();
     expect(buildMilestone.title).toBe("Build Milestone 1");
-    expect(buildMilestone.itemNames).toEqual(["Deliverable A", "Deliverable B"]);
+    expect(buildMilestone.itemNames).toEqual([
+      "Deliverable A",
+      "Deliverable B",
+    ]);
 
     expect(growthMilestone).toBeDefined();
     expect(growthMilestone.title).toBe("Growth Milestone 1");
@@ -273,7 +279,10 @@ describe("GET /api/flow-council/projects/[projectId]/milestones — legacy", () 
 
     await seedLegacyApplication(project.id, fixture.roundId);
 
-    const res = await GET(makeGetRequest(project.id), makeRouteParams(project.id));
+    const res = await GET(
+      makeGetRequest(project.id),
+      makeRouteParams(project.id),
+    );
     const body = await readJson(res);
 
     expect(body.success).toBe(true);
@@ -322,7 +331,10 @@ describe("GET /api/flow-council/projects/[projectId]/milestones — dynamic", ()
       },
     ]);
 
-    const res = await GET(makeGetRequest(project.id), makeRouteParams(project.id));
+    const res = await GET(
+      makeGetRequest(project.id),
+      makeRouteParams(project.id),
+    );
     const body = await readJson(res);
 
     expect(body.success).toBe(true);
@@ -373,15 +385,23 @@ describe("GET — legacy and dynamic applications do not cross-pollute", () => {
       .execute();
 
     const legacyApp = await seedLegacyApplication(project.id, legacyRound.id);
-    const dynamicApp = await seedDynamicApplication(project.id, round.id, ELEMENT_UUID, [
-      {
-        title: "Dynamic Milestone",
-        description: "z".repeat(50),
-        items: ["KR 1"],
-      },
-    ]);
+    const dynamicApp = await seedDynamicApplication(
+      project.id,
+      round.id,
+      ELEMENT_UUID,
+      [
+        {
+          title: "Dynamic Milestone",
+          description: "z".repeat(50),
+          items: ["KR 1"],
+        },
+      ],
+    );
 
-    const res = await GET(makeGetRequest(project.id), makeRouteParams(project.id));
+    const res = await GET(
+      makeGetRequest(project.id),
+      makeRouteParams(project.id),
+    );
     const body = await readJson(res);
 
     expect(body.success).toBe(true);
@@ -581,13 +601,18 @@ describe("PATCH /api/flow-council/projects/[projectId]/milestones — dynamic", 
       .values({ projectId: project.id, managerAddress: TEST_MANAGER_ADDRESS })
       .execute();
 
-    const app = await seedDynamicApplication(project.id, round.id, ELEMENT_UUID, [
-      {
-        title: "Original Title",
-        description: "x".repeat(50),
-        items: ["KR 1"],
-      },
-    ]);
+    const app = await seedDynamicApplication(
+      project.id,
+      round.id,
+      ELEMENT_UUID,
+      [
+        {
+          title: "Original Title",
+          description: "x".repeat(50),
+          items: ["KR 1"],
+        },
+      ],
+    );
 
     const res = await PATCH(
       makePatchRequest(project.id, {
@@ -697,13 +722,18 @@ describe("PATCH /api/flow-council/projects/[projectId]/milestones — dynamic", 
       .values({ projectId: project.id, managerAddress: TEST_MANAGER_ADDRESS })
       .execute();
 
-    const app = await seedDynamicApplication(project.id, round.id, ELEMENT_UUID, [
-      {
-        title: "UUID Milestone",
-        description: "x".repeat(50),
-        items: ["Item 1"],
-      },
-    ]);
+    const app = await seedDynamicApplication(
+      project.id,
+      round.id,
+      ELEMENT_UUID,
+      [
+        {
+          title: "UUID Milestone",
+          description: "x".repeat(50),
+          items: ["Item 1"],
+        },
+      ],
+    );
 
     // PATCH with a progress update (not a definition edit) so milestone_progress is written
     const res = await PATCH(
@@ -756,9 +786,18 @@ describe("PATCH /api/flow-council/projects/[projectId]/milestones — dynamic", 
       .values({ projectId: project.id, managerAddress: TEST_MANAGER_ADDRESS })
       .execute();
 
-    const app = await seedDynamicApplication(project.id, round.id, ELEMENT_UUID, [
-      { title: "Only Milestone", description: "x".repeat(50), items: ["KR 1"] },
-    ]);
+    const app = await seedDynamicApplication(
+      project.id,
+      round.id,
+      ELEMENT_UUID,
+      [
+        {
+          title: "Only Milestone",
+          description: "x".repeat(50),
+          items: ["KR 1"],
+        },
+      ],
+    );
 
     // milestoneIndex 5 is out of range (only index 0 exists)
     const res = await PATCH(
@@ -801,13 +840,18 @@ describe("PATCH /api/flow-council/projects/[projectId]/milestones — dynamic", 
       .values({ projectId: project.id, managerAddress: TEST_MANAGER_ADDRESS })
       .execute();
 
-    const app = await seedDynamicApplication(project.id, round.id, ELEMENT_UUID, [
-      {
-        title: "Feed Milestone",
-        description: "f".repeat(50),
-        items: ["KR Feed"],
-      },
-    ]);
+    const app = await seedDynamicApplication(
+      project.id,
+      round.id,
+      ELEMENT_UUID,
+      [
+        {
+          title: "Feed Milestone",
+          description: "f".repeat(50),
+          items: ["KR Feed"],
+        },
+      ],
+    );
 
     await PATCH(
       makePatchRequest(project.id, {
@@ -882,9 +926,12 @@ describe("PATCH — milestoneType length validation", () => {
       "Key Result",
     );
 
-    const app = await seedDynamicApplication(project.id, round.id, ELEMENT_UUID, [
-      { title: "M1", description: "x".repeat(50), items: ["KR"] },
-    ]);
+    const app = await seedDynamicApplication(
+      project.id,
+      round.id,
+      ELEMENT_UUID,
+      [{ title: "M1", description: "x".repeat(50), items: ["KR"] }],
+    );
 
     const res = await PATCH(
       makePatchRequest(project.id, {

--- a/src/app/api/flow-council/projects/milestones.integration.test.ts
+++ b/src/app/api/flow-council/projects/milestones.integration.test.ts
@@ -203,6 +203,7 @@ async function seedRoundWithMilestoneSchema(
               id: elementId,
               type: "milestone",
               label: "Engineering Milestones",
+              required: true,
               milestoneLabel,
               itemLabel,
               minCount,
@@ -268,7 +269,7 @@ describe("GET /api/flow-council/projects/[projectId]/milestones — legacy", () 
     expect(growthMilestone.itemNames).toEqual(["Activation 1"]);
   });
 
-  it("legacy milestones expose milestoneLabel 'Build'/'Growth' and itemLabel 'Deliverable'/'Activation'", async () => {
+  it("legacy milestones expose milestoneLabel 'Build Milestone'/'Growth Milestone' and itemLabel 'Deliverable'/'Activation'", async () => {
     const project = await db
       .insertInto("projects")
       .values({ details: JSON.stringify({ name: "Legacy Labels Project" }) })
@@ -296,9 +297,9 @@ describe("GET /api/flow-council/projects/[projectId]/milestones — legacy", () 
 
     // The feature spec states legacy milestones must expose these labels
     // so the UI can render them consistently alongside dynamic milestones.
-    expect(buildM.milestoneLabel).toBe("Build");
+    expect(buildM.milestoneLabel).toBe("Build Milestone");
     expect(buildM.itemLabel).toBe("Deliverable");
-    expect(growthM.milestoneLabel).toBe("Growth");
+    expect(growthM.milestoneLabel).toBe("Growth Milestone");
     expect(growthM.itemLabel).toBe("Activation");
   });
 });

--- a/src/app/api/flow-council/validation.milestone.test.ts
+++ b/src/app/api/flow-council/validation.milestone.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Unit tests for the "milestone" FormElement type and its validation logic.
+ * These tests define the behavioral contract for the feature described in
+ * "Configurable Milestone Question Type for Dynamic Form Builder".
+ *
+ * All tests are expected to FAIL until the feature is implemented.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  validateDynamicRoundDetails,
+  formElementSchema,
+  type FormElement,
+} from "./validation";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const MILESTONE_UUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+
+/** A fully-populated milestone element as it would appear in a round formSchema */
+function fullMilestoneElement() {
+  return {
+    id: MILESTONE_UUID,
+    type: "milestone" as const,
+    label: "Engineering Milestones",
+    milestoneLabel: "Build Milestone",
+    itemLabel: "Deliverable",
+    minCount: 3,
+    descriptionPlaceholder: "Describe what you will build.",
+    descriptionMinChars: 100,
+    descriptionMaxChars: 1000,
+  };
+}
+
+/** A milestone element with only required fields */
+function minimalMilestoneElement() {
+  return {
+    id: MILESTONE_UUID,
+    type: "milestone" as const,
+    label: "Milestones",
+  };
+}
+
+/** A valid milestone data entry */
+function validMilestoneEntry({
+  title = "Ship the feature",
+  description = "x".repeat(100),
+  items = ["Deliverable A"],
+}: {
+  title?: string;
+  description?: string;
+  items?: string[];
+} = {}) {
+  return { title, description, items };
+}
+
+// ---------------------------------------------------------------------------
+// Section 1: formElementSchema — milestone type acceptance
+// ---------------------------------------------------------------------------
+
+describe("formElementSchema — milestone type", () => {
+  it("accepts a milestone element with all fields populated", () => {
+    // The implementation must add "milestone" to the formElementSchema type
+    // enum and its milestone-specific fields.
+    // formElementSchema.safeParse MUST succeed — this will fail pre-impl because
+    // "milestone" is not in the type enum at validation.ts:325.
+    const schemaResult = formElementSchema.safeParse(fullMilestoneElement());
+    expect(schemaResult.success).toBe(true);
+
+    const result = validateDynamicRoundDetails(
+      {
+        round: {
+          [MILESTONE_UUID]: [validMilestoneEntry(), validMilestoneEntry(), validMilestoneEntry()],
+        },
+      },
+      [fullMilestoneElement() as FormElement],
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a milestone element with only required fields (id, type, label)", () => {
+    // minCount defaults to 1 when not provided
+    // formElementSchema.safeParse MUST succeed — will fail pre-impl.
+    const schemaResult = formElementSchema.safeParse(minimalMilestoneElement());
+    expect(schemaResult.success).toBe(true);
+
+    const result = validateDynamicRoundDetails(
+      {
+        round: {
+          [MILESTONE_UUID]: [validMilestoneEntry()],
+        },
+      },
+      [minimalMilestoneElement() as FormElement],
+    );
+    expect(result.success).toBe(true);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Gap 5: minCount boundary via formElementSchema (converted from validateDynamicRoundDetails)
+  // ---------------------------------------------------------------------------
+
+  it("rejects minCount of 0 via formElementSchema (below the 1–5 range)", () => {
+    // formElementSchema must reject minCount:0. Pre-impl: formElementSchema rejects
+    // ALL milestone elements because "milestone" is not in the type enum.
+    // Post-impl: it must specifically reject minCount:0 (out of valid 1–5 range).
+    const elementWithZeroMin = { ...fullMilestoneElement(), minCount: 0 };
+    const schemaResult = formElementSchema.safeParse(elementWithZeroMin);
+    expect(schemaResult.success).toBe(false);
+    // The Zod error must reference the range constraint
+    const messages = schemaResult.success
+      ? []
+      : schemaResult.error.issues.map((i) => i.message).join(" ");
+    expect(messages).toMatch(/min|range|1|greater/i);
+  });
+
+  it("rejects minCount of 6 via formElementSchema (above the 1–5 range)", () => {
+    // formElementSchema must reject minCount:6.
+    const elementWithSixMin = { ...fullMilestoneElement(), minCount: 6 };
+    const schemaResult = formElementSchema.safeParse(elementWithSixMin);
+    expect(schemaResult.success).toBe(false);
+    const messages = schemaResult.success
+      ? []
+      : schemaResult.error.issues.map((i) => i.message).join(" ");
+    expect(messages).toMatch(/max|range|5|less/i);
+  });
+
+  it("accepts minCount of 1 via formElementSchema (lower boundary)", () => {
+    const elementWithMinOne = { ...fullMilestoneElement(), minCount: 1 };
+    const schemaResult = formElementSchema.safeParse(elementWithMinOne);
+    expect(schemaResult.success).toBe(true);
+  });
+
+  it("accepts minCount of 5 via formElementSchema (upper boundary)", () => {
+    const elementWithMinFive = { ...fullMilestoneElement(), minCount: 5 };
+    const schemaResult = formElementSchema.safeParse(elementWithMinFive);
+    expect(schemaResult.success).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Section 2: validateDynamicRoundDetails — milestone array count validation
+// ---------------------------------------------------------------------------
+
+describe("validateDynamicRoundDetails — milestone minCount enforcement", () => {
+  it("rejects when the submitted milestone array length is below minCount", () => {
+    const element = { ...fullMilestoneElement(), minCount: 3 };
+    // Only 2 milestones submitted, minCount is 3
+    const result = validateDynamicRoundDetails(
+      {
+        round: {
+          [MILESTONE_UUID]: [validMilestoneEntry(), validMilestoneEntry()],
+        },
+      },
+      [element as FormElement],
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts when the submitted milestone array length equals minCount", () => {
+    const element = { ...fullMilestoneElement(), minCount: 3 };
+    const result = validateDynamicRoundDetails(
+      {
+        round: {
+          [MILESTONE_UUID]: [
+            validMilestoneEntry(),
+            validMilestoneEntry(),
+            validMilestoneEntry(),
+          ],
+        },
+      },
+      [element as FormElement],
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts when the submitted milestone array length exceeds minCount", () => {
+    const element = { ...fullMilestoneElement(), minCount: 2 };
+    const result = validateDynamicRoundDetails(
+      {
+        round: {
+          [MILESTONE_UUID]: [
+            validMilestoneEntry(),
+            validMilestoneEntry(),
+            validMilestoneEntry(),
+          ],
+        },
+      },
+      [element as FormElement],
+    );
+    expect(result.success).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Section 3: per-milestone entry validation — empty fields
+// ---------------------------------------------------------------------------
+
+describe("validateDynamicRoundDetails — milestone entry field presence", () => {
+  it("rejects a milestone entry with an empty title", () => {
+    const element = { ...fullMilestoneElement(), minCount: 1 };
+    const result = validateDynamicRoundDetails(
+      {
+        round: {
+          [MILESTONE_UUID]: [validMilestoneEntry({ title: "" })],
+        },
+      },
+      [element as FormElement],
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a milestone entry with an empty description", () => {
+    const element = { ...fullMilestoneElement(), minCount: 1, descriptionMinChars: 1 };
+    const result = validateDynamicRoundDetails(
+      {
+        round: {
+          [MILESTONE_UUID]: [validMilestoneEntry({ description: "" })],
+        },
+      },
+      [element as FormElement],
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a milestone entry with an empty items array", () => {
+    const element = { ...fullMilestoneElement(), minCount: 1 };
+    const result = validateDynamicRoundDetails(
+      {
+        round: {
+          [MILESTONE_UUID]: [validMilestoneEntry({ items: [] })],
+        },
+      },
+      [element as FormElement],
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a milestone entry where an item string is empty", () => {
+    const element = { ...fullMilestoneElement(), minCount: 1 };
+    const result = validateDynamicRoundDetails(
+      {
+        round: {
+          [MILESTONE_UUID]: [validMilestoneEntry({ items: ["Valid item", ""] })],
+        },
+      },
+      [element as FormElement],
+    );
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Section 4: descriptionMinChars / descriptionMaxChars
+// ---------------------------------------------------------------------------
+
+describe("validateDynamicRoundDetails — milestone description length constraints", () => {
+  const DESCRIPTION_MIN = 100;
+  const DESCRIPTION_MAX = 1000;
+
+  it("rejects a description shorter than descriptionMinChars", () => {
+    const element = {
+      ...fullMilestoneElement(),
+      minCount: 1,
+      descriptionMinChars: DESCRIPTION_MIN,
+      descriptionMaxChars: DESCRIPTION_MAX,
+    };
+    const shortDesc = "x".repeat(DESCRIPTION_MIN - 1);
+    const result = validateDynamicRoundDetails(
+      {
+        round: {
+          [MILESTONE_UUID]: [validMilestoneEntry({ description: shortDesc })],
+        },
+      },
+      [element as FormElement],
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a description longer than descriptionMaxChars", () => {
+    const element = {
+      ...fullMilestoneElement(),
+      minCount: 1,
+      descriptionMinChars: DESCRIPTION_MIN,
+      descriptionMaxChars: DESCRIPTION_MAX,
+    };
+    const longDesc = "x".repeat(DESCRIPTION_MAX + 1);
+    const result = validateDynamicRoundDetails(
+      {
+        round: {
+          [MILESTONE_UUID]: [validMilestoneEntry({ description: longDesc })],
+        },
+      },
+      [element as FormElement],
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a description exactly at descriptionMinChars", () => {
+    const element = {
+      ...fullMilestoneElement(),
+      minCount: 1,
+      descriptionMinChars: DESCRIPTION_MIN,
+      descriptionMaxChars: DESCRIPTION_MAX,
+    };
+    const desc = "x".repeat(DESCRIPTION_MIN);
+    const result = validateDynamicRoundDetails(
+      {
+        round: {
+          [MILESTONE_UUID]: [validMilestoneEntry({ description: desc })],
+        },
+      },
+      [element as FormElement],
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a description exactly at descriptionMaxChars", () => {
+    const element = {
+      ...fullMilestoneElement(),
+      minCount: 1,
+      descriptionMinChars: DESCRIPTION_MIN,
+      descriptionMaxChars: DESCRIPTION_MAX,
+    };
+    const desc = "x".repeat(DESCRIPTION_MAX);
+    const result = validateDynamicRoundDetails(
+      {
+        round: {
+          [MILESTONE_UUID]: [validMilestoneEntry({ description: desc })],
+        },
+      },
+      [element as FormElement],
+    );
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/app/api/flow-council/validation.milestone.test.ts
+++ b/src/app/api/flow-council/validation.milestone.test.ts
@@ -25,6 +25,7 @@ function fullMilestoneElement() {
     id: MILESTONE_UUID,
     type: "milestone" as const,
     label: "Engineering Milestones",
+    required: true,
     milestoneLabel: "Build Milestone",
     itemLabel: "Deliverable",
     minCount: 3,
@@ -40,6 +41,7 @@ function minimalMilestoneElement() {
     id: MILESTONE_UUID,
     type: "milestone" as const,
     label: "Milestones",
+    required: true,
   };
 }
 

--- a/src/app/api/flow-council/validation.milestone.test.ts
+++ b/src/app/api/flow-council/validation.milestone.test.ts
@@ -261,6 +261,23 @@ describe("validateDynamicRoundDetails — milestone entry field presence", () =>
     );
     expect(result.success).toBe(false);
   });
+
+  it("rejects a milestone entry with more than 50 items", () => {
+    const element = { ...fullMilestoneElement(), minCount: 1 };
+    const tooMany = Array.from({ length: 51 }, (_, i) => `Item ${i + 1}`);
+    const result = validateDynamicRoundDetails(
+      {
+        round: {
+          [MILESTONE_UUID]: [validMilestoneEntry({ items: tooMany })],
+        },
+      },
+      [element as FormElement],
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toMatch(/at most 50/i);
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/app/api/flow-council/validation.milestone.test.ts
+++ b/src/app/api/flow-council/validation.milestone.test.ts
@@ -72,7 +72,11 @@ describe("formElementSchema — milestone type", () => {
     const result = validateDynamicRoundDetails(
       {
         round: {
-          [MILESTONE_UUID]: [validMilestoneEntry(), validMilestoneEntry(), validMilestoneEntry()],
+          [MILESTONE_UUID]: [
+            validMilestoneEntry(),
+            validMilestoneEntry(),
+            validMilestoneEntry(),
+          ],
         },
       },
       [fullMilestoneElement() as FormElement],
@@ -212,7 +216,11 @@ describe("validateDynamicRoundDetails — milestone entry field presence", () =>
   });
 
   it("rejects a milestone entry with an empty description", () => {
-    const element = { ...fullMilestoneElement(), minCount: 1, descriptionMinChars: 1 };
+    const element = {
+      ...fullMilestoneElement(),
+      minCount: 1,
+      descriptionMinChars: 1,
+    };
     const result = validateDynamicRoundDetails(
       {
         round: {
@@ -242,7 +250,9 @@ describe("validateDynamicRoundDetails — milestone entry field presence", () =>
     const result = validateDynamicRoundDetails(
       {
         round: {
-          [MILESTONE_UUID]: [validMilestoneEntry({ items: ["Valid item", ""] })],
+          [MILESTONE_UUID]: [
+            validMilestoneEntry({ items: ["Valid item", ""] }),
+          ],
         },
       },
       [element as FormElement],

--- a/src/app/api/flow-council/validation.ts
+++ b/src/app/api/flow-council/validation.ts
@@ -376,7 +376,10 @@ export const formElementSchema = z
       el.descriptionMaxChars === undefined ||
       el.descriptionMinChars <= el.descriptionMaxChars,
     { message: "descriptionMinChars must be ≤ descriptionMaxChars" },
-  );
+  )
+  .refine((el) => el.type !== "milestone" || el.required === true, {
+    message: "milestone elements must have required: true",
+  });
 
 const formSchemaSchema = z.object({
   round: z.array(formElementSchema).max(100),
@@ -561,9 +564,7 @@ function validateFormSection(
       }
     }
 
-    if (val === undefined || val === null || val === "") {
-      if (el.type !== "milestone") continue;
-    }
+    if (val === undefined || val === null || val === "") continue;
 
     const validator = VALIDATORS[el.type];
     if (validator) {

--- a/src/app/api/flow-council/validation.ts
+++ b/src/app/api/flow-council/validation.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { isAddress } from "viem";
-import { CHARACTER_LIMITS } from "@/app/flow-councils/constants";
+import { CHARACTER_LIMITS, MAX_MILESTONES } from "@/app/flow-councils/constants";
 import { ALLOWED_REACTIONS } from "@/app/flow-councils/lib/constants";
 import { STRUCTURAL_TYPES } from "@/app/flow-councils/types/formSchema";
 import { normalizeUrl } from "@/app/flow-councils/utils/normalizeUrl";
@@ -427,7 +427,6 @@ export function validateFormSchema(
 export type FormElement = z.infer<typeof formElementSchema>;
 
 export const MAX_DETAILS_SIZE = 512_000; // 512 KB
-export const MAX_MILESTONES = 20;
 
 type FieldValidator = (val: unknown, el: FormElement) => string | null;
 

--- a/src/app/api/flow-council/validation.ts
+++ b/src/app/api/flow-council/validation.ts
@@ -219,7 +219,7 @@ export const milestoneProgressSchema = z.object({
 });
 
 export const milestoneDefinitionSchema = z.object({
-  title: z.string().min(1, "Title is required"),
+  title: z.string().min(1, "Title is required").max(200),
   description: z
     .string()
     .min(
@@ -228,7 +228,8 @@ export const milestoneDefinitionSchema = z.object({
     )
     .max(CHARACTER_LIMITS.milestoneDescription.max),
   items: z
-    .array(z.string())
+    .array(z.string().max(500))
+    .max(50)
     .refine((items) => items.some((item) => item.trim() !== ""), {
       message: "At least one item is required",
     }),
@@ -319,7 +320,7 @@ export function validateRoundDetails(
   return { success: true, data: details };
 }
 
-const formElementSchema = z
+export const formElementSchema = z
   .object({
     id: z.string().min(1),
     type: z.enum([
@@ -335,6 +336,7 @@ const formElementSchema = z
       "boolean",
       "telegram",
       "ethAddress",
+      "milestone",
       "divider",
     ]),
     label: z.string().max(500),
@@ -348,6 +350,12 @@ const formElementSchema = z
     min: z.number().optional(),
     max: z.number().optional(),
     options: z.array(z.string().max(200)).max(50).optional(),
+    milestoneLabel: z.string().max(100).optional(),
+    itemLabel: z.string().max(100).optional(),
+    minCount: z.number().int().min(1).max(5).optional(),
+    descriptionPlaceholder: z.string().max(500).optional(),
+    descriptionMinChars: z.number().int().nonnegative().optional(),
+    descriptionMaxChars: z.number().int().positive().optional(),
   })
   .refine(
     (el) =>
@@ -361,6 +369,13 @@ const formElementSchema = z
       (el.type !== "select" && el.type !== "multiSelect") ||
       (Array.isArray(el.options) && el.options.length > 0),
     { message: "select and multiSelect require at least one option" },
+  )
+  .refine(
+    (el) =>
+      el.descriptionMinChars === undefined ||
+      el.descriptionMaxChars === undefined ||
+      el.descriptionMinChars <= el.descriptionMaxChars,
+    { message: "descriptionMinChars must be ≤ descriptionMaxChars" },
   );
 
 const formSchemaSchema = z.object({
@@ -381,7 +396,7 @@ export function validateFormSchema(
   return { success: true, data: result.data };
 }
 
-type FormElement = z.infer<typeof formElementSchema>;
+export type FormElement = z.infer<typeof formElementSchema>;
 
 const MAX_STRING_LENGTH = 10_000;
 export const MAX_DETAILS_SIZE = 512_000; // 512 KB
@@ -460,6 +475,64 @@ const VALIDATORS: Partial<Record<FormElement["type"], FieldValidator>> = {
       : null,
   boolean: (val, el) =>
     typeof val !== "boolean" ? `"${el.label}" must be true or false` : null,
+  milestone: (val, el) => {
+    const minCount = el.minCount ?? 1;
+    const milestoneLabel = el.milestoneLabel ?? el.label ?? "Milestone";
+    if (!Array.isArray(val)) {
+      return `"${el.label}" must be a list of milestones`;
+    }
+    if (val.length < minCount) {
+      return `"${el.label}" requires at least ${minCount} milestone${minCount === 1 ? "" : "s"}`;
+    }
+    if (val.length > 20) {
+      return `"${el.label}" allows at most 20 milestones`;
+    }
+    for (let i = 0; i < val.length; i++) {
+      const m = val[i] as {
+        title?: unknown;
+        description?: unknown;
+        items?: unknown;
+      };
+      if (!m || typeof m !== "object") {
+        return `${milestoneLabel} ${i + 1} is malformed`;
+      }
+      if (typeof m.title !== "string" || m.title.trim() === "") {
+        return `${milestoneLabel} ${i + 1} title is required`;
+      }
+      if (m.title.length > 200) {
+        return `${milestoneLabel} ${i + 1} title exceeds 200 characters`;
+      }
+      if (typeof m.description !== "string" || m.description.trim() === "") {
+        return `${milestoneLabel} ${i + 1} description is required`;
+      }
+      if (
+        typeof el.descriptionMinChars === "number" &&
+        m.description.length < el.descriptionMinChars
+      ) {
+        return `${milestoneLabel} ${i + 1} description must be at least ${el.descriptionMinChars} characters`;
+      }
+      const descMax =
+        typeof el.descriptionMaxChars === "number"
+          ? el.descriptionMaxChars
+          : MAX_STRING_LENGTH;
+      if (m.description.length > descMax) {
+        return `${milestoneLabel} ${i + 1} description exceeds ${descMax} characters`;
+      }
+      if (!Array.isArray(m.items) || m.items.length === 0) {
+        return `${milestoneLabel} ${i + 1} requires at least one ${el.itemLabel ?? "item"}`;
+      }
+      for (let j = 0; j < m.items.length; j++) {
+        const item = m.items[j];
+        if (typeof item !== "string" || item.trim() === "") {
+          return `${milestoneLabel} ${i + 1} ${el.itemLabel ?? "item"} ${j + 1} is required`;
+        }
+        if (item.length > 500) {
+          return `${milestoneLabel} ${i + 1} ${el.itemLabel ?? "item"} ${j + 1} exceeds 500 characters`;
+        }
+      }
+    }
+    return null;
+  },
 };
 
 function validateFormSection(
@@ -479,12 +552,18 @@ function validateFormSection(
       if (val === undefined || val === null || val === "") {
         return { success: false, error: `"${el.label}" is required` };
       }
-      if (el.type === "multiSelect" && Array.isArray(val) && val.length === 0) {
+      if (
+        (el.type === "multiSelect" || el.type === "milestone") &&
+        Array.isArray(val) &&
+        val.length === 0
+      ) {
         return { success: false, error: `"${el.label}" is required` };
       }
     }
 
-    if (val === undefined || val === null || val === "") continue;
+    if (val === undefined || val === null || val === "") {
+      if (el.type !== "milestone") continue;
+    }
 
     const validator = VALIDATORS[el.type];
     if (validator) {

--- a/src/app/api/flow-council/validation.ts
+++ b/src/app/api/flow-council/validation.ts
@@ -218,21 +218,34 @@ export const milestoneProgressSchema = z.object({
   items: z.array(deliverableProgressSchema),
 });
 
-export const milestoneDefinitionSchema = z.object({
-  title: z.string().min(1, "Title is required").max(200),
-  description: z
-    .string()
-    .min(
-      CHARACTER_LIMITS.milestoneDescription.min,
-      `Description must be at least ${CHARACTER_LIMITS.milestoneDescription.min} characters`,
-    )
-    .max(CHARACTER_LIMITS.milestoneDescription.max),
-  items: z
-    .array(z.string().max(500))
-    .max(50)
-    .refine((items) => items.some((item) => item.trim() !== ""), {
-      message: "At least one item is required",
-    }),
+export function makeMilestoneDefinitionSchema(opts: {
+  descriptionMinChars: number;
+  descriptionMaxChars: number;
+}) {
+  return z.object({
+    title: z.string().min(1, "Title is required").max(200),
+    description: z
+      .string()
+      .min(
+        opts.descriptionMinChars,
+        `Description must be at least ${opts.descriptionMinChars} characters`,
+      )
+      .max(
+        opts.descriptionMaxChars,
+        `Description must be at most ${opts.descriptionMaxChars} characters`,
+      ),
+    items: z
+      .array(z.string().max(500))
+      .max(50)
+      .refine((items) => items.some((item) => item.trim() !== ""), {
+        message: "At least one item is required",
+      }),
+  });
+}
+
+export const milestoneDefinitionSchema = makeMilestoneDefinitionSchema({
+  descriptionMinChars: CHARACTER_LIMITS.milestoneDescription.min,
+  descriptionMaxChars: CHARACTER_LIMITS.milestoneDescription.max,
 });
 
 export const reactionEmojiSchema = z.enum(ALLOWED_REACTIONS);
@@ -351,7 +364,7 @@ export const formElementSchema = z
     max: z.number().optional(),
     options: z.array(z.string().max(200)).max(50).optional(),
     milestoneLabel: z.string().max(100).optional(),
-    itemLabel: z.string().max(100).optional(),
+    itemLabel: z.enum(["Deliverable", "Activation"]).optional(),
     minCount: z.number().int().min(1).max(5).optional(),
     descriptionPlaceholder: z.string().max(500).optional(),
     descriptionMinChars: z.number().int().nonnegative().optional(),
@@ -401,7 +414,7 @@ export function validateFormSchema(
 
 export type FormElement = z.infer<typeof formElementSchema>;
 
-const MAX_STRING_LENGTH = 10_000;
+export const MAX_STRING_LENGTH = 10_000;
 export const MAX_DETAILS_SIZE = 512_000; // 512 KB
 
 type FieldValidator = (val: unknown, el: FormElement) => string | null;

--- a/src/app/api/flow-council/validation.ts
+++ b/src/app/api/flow-council/validation.ts
@@ -12,6 +12,8 @@ import type {
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+export const MAX_STRING_LENGTH = 10_000;
+
 export function isValidEmail(value: string): boolean {
   return EMAIL_REGEX.test(value);
 }
@@ -367,8 +369,18 @@ export const formElementSchema = z
     itemLabel: z.enum(["Deliverable", "Activation"]).optional(),
     minCount: z.number().int().min(1).max(5).optional(),
     descriptionPlaceholder: z.string().max(500).optional(),
-    descriptionMinChars: z.number().int().nonnegative().optional(),
-    descriptionMaxChars: z.number().int().positive().optional(),
+    descriptionMinChars: z
+      .number()
+      .int()
+      .nonnegative()
+      .max(MAX_STRING_LENGTH)
+      .optional(),
+    descriptionMaxChars: z
+      .number()
+      .int()
+      .positive()
+      .max(MAX_STRING_LENGTH)
+      .optional(),
   })
   .refine(
     (el) =>
@@ -414,7 +426,6 @@ export function validateFormSchema(
 
 export type FormElement = z.infer<typeof formElementSchema>;
 
-export const MAX_STRING_LENGTH = 10_000;
 export const MAX_DETAILS_SIZE = 512_000; // 512 KB
 export const MAX_MILESTONES = 20;
 

--- a/src/app/api/flow-council/validation.ts
+++ b/src/app/api/flow-council/validation.ts
@@ -505,7 +505,7 @@ const VALIDATORS: Partial<Record<FormElement["type"], FieldValidator>> = {
     typeof val !== "boolean" ? `"${el.label}" must be true or false` : null,
   milestone: (val, el) => {
     const minCount = el.minCount ?? 1;
-    const milestoneLabel = el.milestoneLabel ?? el.label ?? "Milestone";
+    const milestoneLabel = el.milestoneLabel || el.label || "Milestone";
     if (!Array.isArray(val)) {
       return `"${el.label}" must be a list of milestones`;
     }

--- a/src/app/api/flow-council/validation.ts
+++ b/src/app/api/flow-council/validation.ts
@@ -416,6 +416,7 @@ export type FormElement = z.infer<typeof formElementSchema>;
 
 export const MAX_STRING_LENGTH = 10_000;
 export const MAX_DETAILS_SIZE = 512_000; // 512 KB
+export const MAX_MILESTONES = 20;
 
 type FieldValidator = (val: unknown, el: FormElement) => string | null;
 
@@ -500,8 +501,8 @@ const VALIDATORS: Partial<Record<FormElement["type"], FieldValidator>> = {
     if (val.length < minCount) {
       return `"${el.label}" requires at least ${minCount} milestone${minCount === 1 ? "" : "s"}`;
     }
-    if (val.length > 20) {
-      return `"${el.label}" allows at most 20 milestones`;
+    if (val.length > MAX_MILESTONES) {
+      return `"${el.label}" allows at most ${MAX_MILESTONES} milestones`;
     }
     for (let i = 0; i < val.length; i++) {
       const m = val[i] as {

--- a/src/app/api/flow-council/validation.ts
+++ b/src/app/api/flow-council/validation.ts
@@ -524,6 +524,9 @@ const VALIDATORS: Partial<Record<FormElement["type"], FieldValidator>> = {
       if (!Array.isArray(m.items) || m.items.length === 0) {
         return `${milestoneLabel} ${i + 1} requires at least one ${el.itemLabel ?? "item"}`;
       }
+      if (m.items.length > 50) {
+        return `${milestoneLabel} ${i + 1} allows at most 50 ${el.itemLabel ?? "item"}s`;
+      }
       for (let j = 0; j < m.items.length; j++) {
         const item = m.items[j];
         if (typeof item !== "string" || item.trim() === "") {

--- a/src/app/flow-councils/application/[chainId]/[councilId]/[projectId]/application.tsx
+++ b/src/app/flow-councils/application/[chainId]/[councilId]/[projectId]/application.tsx
@@ -536,6 +536,7 @@ export default function Application(props: ApplicationProps) {
                     values={dynamicRoundValues}
                     onChange={handleDynamicRoundChange}
                     validated={dynamicValidated}
+                    lockBlockCount={isInLockedStatus && editsUnlocked}
                     profileData={profileData}
                   />
                   {dynamicError && (
@@ -618,6 +619,7 @@ export default function Application(props: ApplicationProps) {
                     values={dynamicAttestationValues}
                     onChange={handleDynamicAttestationChange}
                     validated={dynamicValidated}
+                    lockBlockCount={isInLockedStatus && editsUnlocked}
                     profileData={profileData}
                   />
                   {dynamicError && (

--- a/src/app/flow-councils/components/DynamicFormSection.tsx
+++ b/src/app/flow-councils/components/DynamicFormSection.tsx
@@ -7,6 +7,9 @@ import Stack from "react-bootstrap/Stack";
 import Markdown from "@/components/Markdown";
 import MarkdownEditor from "@/components/MarkdownEditor";
 import CharacterCounter from "@/app/flow-councils/components/CharacterCounter";
+import DynamicMilestoneInput, {
+  type DynamicMilestoneValue,
+} from "@/app/flow-councils/components/DynamicMilestoneInput";
 import { normalizeUrl } from "@/app/flow-councils/utils/normalizeUrl";
 import type { FormElement } from "@/app/flow-councils/types/formSchema";
 
@@ -16,6 +19,7 @@ type Props = {
   onChange?: (id: string, value: unknown) => void;
   validated?: boolean;
   readOnly?: boolean;
+  lockBlockCount?: boolean;
   profileData?: { email?: string; telegram?: string };
 };
 
@@ -25,6 +29,7 @@ export default function DynamicFormSection({
   onChange,
   validated = false,
   readOnly = false,
+  lockBlockCount = false,
   profileData,
 }: Props) {
   const getValue = (id: string) => values[id] ?? "";
@@ -436,6 +441,24 @@ export default function DynamicFormSection({
                   </Form.Text>
                 )}
               </Form.Group>
+            );
+          }
+          case "milestone": {
+            const raw = values[el.id];
+            const milestoneValues: DynamicMilestoneValue[] = Array.isArray(raw)
+              ? (raw as DynamicMilestoneValue[])
+              : [];
+            return (
+              <DynamicMilestoneInput
+                key={el.id}
+                element={el}
+                values={milestoneValues}
+                onChange={(v) => handleChange(el.id, v)}
+                validated={validated}
+                readOnly={readOnly}
+                lockBlockCount={lockBlockCount}
+                numberPrefix={num(el.id)}
+              />
             );
           }
         }

--- a/src/app/flow-councils/components/DynamicMilestoneInput.tsx
+++ b/src/app/flow-councils/components/DynamicMilestoneInput.tsx
@@ -7,6 +7,7 @@ import Button from "react-bootstrap/Button";
 import Image from "react-bootstrap/Image";
 import MarkdownEditor from "@/components/MarkdownEditor";
 import Markdown from "@/components/Markdown";
+import { MAX_MILESTONES } from "@/app/api/flow-council/validation";
 import type { MilestoneQuestion } from "@/app/flow-councils/types/formSchema";
 
 export type DynamicMilestoneValue = {
@@ -94,7 +95,7 @@ export default function DynamicMilestoneInput(props: Props) {
     });
   };
 
-  const canAdd = !readOnly && !lockBlockCount;
+  const canAdd = !readOnly && !lockBlockCount && blocks.length < MAX_MILESTONES;
   const canRemoveBlock = (i: number) =>
     !readOnly && !lockBlockCount && i >= minCount;
 

--- a/src/app/flow-councils/components/DynamicMilestoneInput.tsx
+++ b/src/app/flow-councils/components/DynamicMilestoneInput.tsx
@@ -51,10 +51,11 @@ export default function DynamicMilestoneInput(props: Props) {
       while (padded.length < minCount) padded.push(emptyMilestone());
       onChange(padded);
     }
-    // values.length (not values) — the array identity changes on every parent
-    // render via spread updates, which would cause an infinite re-render loop.
+    // Deps intentionally exclude `values` (array identity flips every parent
+    // render and would loop) and `onChange` (its identity flips every parent
+    // render and would fire wasted no-op cycles).
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [values.length, minCount, readOnly, onChange]);
+  }, [values.length, minCount, readOnly]);
 
   const updateMilestone = (index: number, next: DynamicMilestoneValue) => {
     const copy = [...values];

--- a/src/app/flow-councils/components/DynamicMilestoneInput.tsx
+++ b/src/app/flow-councils/components/DynamicMilestoneInput.tsx
@@ -7,7 +7,7 @@ import Button from "react-bootstrap/Button";
 import Image from "react-bootstrap/Image";
 import MarkdownEditor from "@/components/MarkdownEditor";
 import Markdown from "@/components/Markdown";
-import { MAX_MILESTONES } from "@/app/api/flow-council/validation";
+import { MAX_MILESTONES } from "@/app/flow-councils/constants";
 import type { MilestoneQuestion } from "@/app/flow-councils/types/formSchema";
 
 export type DynamicMilestoneValue = {

--- a/src/app/flow-councils/components/DynamicMilestoneInput.tsx
+++ b/src/app/flow-councils/components/DynamicMilestoneInput.tsx
@@ -94,10 +94,13 @@ export default function DynamicMilestoneInput(props: Props) {
     });
   };
 
-  const blocks = values.length >= minCount ? values : [
-    ...values,
-    ...Array.from({ length: minCount - values.length }, emptyMilestone),
-  ];
+  const blocks =
+    values.length >= minCount
+      ? values
+      : [
+          ...values,
+          ...Array.from({ length: minCount - values.length }, emptyMilestone),
+        ];
 
   const canAdd = !readOnly && !lockBlockCount;
   const canRemoveBlock = (i: number) =>

--- a/src/app/flow-councils/components/DynamicMilestoneInput.tsx
+++ b/src/app/flow-councils/components/DynamicMilestoneInput.tsx
@@ -1,0 +1,270 @@
+"use client";
+
+import { useEffect } from "react";
+import Form from "react-bootstrap/Form";
+import Stack from "react-bootstrap/Stack";
+import Button from "react-bootstrap/Button";
+import Image from "react-bootstrap/Image";
+import MarkdownEditor from "@/components/MarkdownEditor";
+import Markdown from "@/components/Markdown";
+import type { MilestoneQuestion } from "@/app/flow-councils/types/formSchema";
+
+export type DynamicMilestoneValue = {
+  title: string;
+  description: string;
+  items: string[];
+};
+
+type Props = {
+  element: MilestoneQuestion;
+  values: DynamicMilestoneValue[];
+  onChange: (values: DynamicMilestoneValue[]) => void;
+  validated: boolean;
+  readOnly?: boolean;
+  lockBlockCount?: boolean;
+  numberPrefix?: string;
+};
+
+function emptyMilestone(): DynamicMilestoneValue {
+  return { title: "", description: "", items: [""] };
+}
+
+export default function DynamicMilestoneInput(props: Props) {
+  const {
+    element,
+    values,
+    onChange,
+    validated,
+    readOnly = false,
+    lockBlockCount = false,
+    numberPrefix = "",
+  } = props;
+
+  const minCount = Math.max(1, Math.min(5, element.minCount ?? 1));
+  const milestoneLabel = element.milestoneLabel || "Milestone";
+  const itemLabel = element.itemLabel || "Deliverable";
+
+  useEffect(() => {
+    if (readOnly) return;
+    if (values.length < minCount) {
+      const padded = [...values];
+      while (padded.length < minCount) padded.push(emptyMilestone());
+      onChange(padded);
+    }
+    // values.length (not values) — the array identity changes on every parent
+    // render via spread updates, which would cause an infinite re-render loop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [values.length, minCount, readOnly, onChange]);
+
+  const updateMilestone = (index: number, next: DynamicMilestoneValue) => {
+    const copy = [...values];
+    copy[index] = next;
+    onChange(copy);
+  };
+
+  const addMilestone = () => {
+    onChange([...values, emptyMilestone()]);
+  };
+
+  const removeMilestone = (index: number) => {
+    onChange(values.filter((_, i) => i !== index));
+  };
+
+  const updateItem = (mIndex: number, iIndex: number, value: string) => {
+    const milestone = values[mIndex];
+    const newItems = [...milestone.items];
+    newItems[iIndex] = value;
+    updateMilestone(mIndex, { ...milestone, items: newItems });
+  };
+
+  const addItem = (mIndex: number) => {
+    const milestone = values[mIndex];
+    updateMilestone(mIndex, {
+      ...milestone,
+      items: [...milestone.items, ""],
+    });
+  };
+
+  const removeItem = (mIndex: number, iIndex: number) => {
+    const milestone = values[mIndex];
+    const newItems = milestone.items.filter((_, i) => i !== iIndex);
+    updateMilestone(mIndex, {
+      ...milestone,
+      items: newItems.length > 0 ? newItems : [""],
+    });
+  };
+
+  const blocks = values.length >= minCount ? values : [
+    ...values,
+    ...Array.from({ length: minCount - values.length }, emptyMilestone),
+  ];
+
+  const canAdd = !readOnly && !lockBlockCount;
+  const canRemoveBlock = (i: number) =>
+    !readOnly && !lockBlockCount && i >= minCount;
+
+  return (
+    <Form.Group className="mb-4">
+      {element.label && (
+        <Form.Label className="fs-lg fw-bold">
+          {numberPrefix}
+          {element.label}
+          {element.required && "*"}
+        </Form.Label>
+      )}
+      {blocks.map((milestone, i) => {
+        const descTooShort =
+          typeof element.descriptionMinChars === "number" &&
+          milestone.description.length > 0 &&
+          milestone.description.length < element.descriptionMinChars;
+        const descTooLong =
+          typeof element.descriptionMaxChars === "number" &&
+          milestone.description.length > element.descriptionMaxChars;
+        const descInvalid =
+          validated &&
+          (!milestone.description.trim() || descTooShort || descTooLong);
+        const titleInvalid = validated && !milestone.title.trim();
+        const hasValidItem = milestone.items.some((it) => it.trim() !== "");
+        const itemsInvalid = validated && !hasValidItem;
+
+        return (
+          <div
+            key={i}
+            className="border border-2 border-dark rounded-4 p-4 mb-3"
+          >
+            <Stack
+              direction="horizontal"
+              className="justify-content-between align-items-start mb-3"
+            >
+              <span className="fs-lg fw-bold">
+                {milestoneLabel} {i + 1}
+                {element.required && "*"}
+              </span>
+              {canRemoveBlock(i) && (
+                <Button
+                  variant="link"
+                  className="d-flex align-items-center justify-content-center p-0"
+                  onClick={() => removeMilestone(i)}
+                  aria-label={`Remove ${milestoneLabel} ${i + 1}`}
+                >
+                  <Image src="/close.svg" alt="Remove" width={28} height={28} />
+                </Button>
+              )}
+            </Stack>
+
+            <Form.Group className="mb-3">
+              <Form.Label className="fw-bold">Title*</Form.Label>
+              <Form.Control
+                type="text"
+                value={milestone.title}
+                disabled={readOnly}
+                placeholder="Title"
+                className={`bg-white border border-2 rounded-4 py-3 px-3 ${titleInvalid ? "border-danger" : "border-dark"}`}
+                isInvalid={titleInvalid}
+                onChange={(e) =>
+                  updateMilestone(i, { ...milestone, title: e.target.value })
+                }
+              />
+            </Form.Group>
+
+            <Form.Group className="mb-3">
+              <Form.Label className="fw-bold">Description*</Form.Label>
+              {readOnly ? (
+                milestone.description.trim() ? (
+                  <div className="bg-light rounded-4 py-3 px-3">
+                    <Markdown>{milestone.description}</Markdown>
+                  </div>
+                ) : (
+                  <Form.Control
+                    as="textarea"
+                    rows={3}
+                    value=""
+                    disabled
+                    className="bg-light border-0 rounded-4 py-3 px-3"
+                  />
+                )
+              ) : (
+                <MarkdownEditor
+                  value={milestone.description}
+                  onChange={(e) =>
+                    updateMilestone(i, {
+                      ...milestone,
+                      description: e.target.value,
+                    })
+                  }
+                  placeholder={element.descriptionPlaceholder}
+                  rows={4}
+                  resizable
+                  isInvalid={descInvalid}
+                  characterCounter={
+                    typeof element.descriptionMinChars === "number" ||
+                    typeof element.descriptionMaxChars === "number"
+                      ? {
+                          value: milestone.description,
+                          min: element.descriptionMinChars,
+                          max: element.descriptionMaxChars,
+                        }
+                      : undefined
+                  }
+                />
+              )}
+            </Form.Group>
+
+            <Form.Group>
+              <Form.Label className="fw-bold">{itemLabel}s*</Form.Label>
+              <Stack direction="vertical" gap={2}>
+                {milestone.items.map((item, iIndex) => (
+                  <Stack key={iIndex} direction="horizontal" gap={2}>
+                    <Form.Control
+                      type="text"
+                      value={item}
+                      disabled={readOnly}
+                      placeholder={`${itemLabel} ${iIndex + 1}`}
+                      className={`bg-white border border-2 rounded-4 py-3 px-3 ${itemsInvalid && iIndex === 0 ? "border-danger" : "border-dark"}`}
+                      isInvalid={itemsInvalid && iIndex === 0}
+                      onChange={(e) => updateItem(i, iIndex, e.target.value)}
+                    />
+                    {!readOnly && milestone.items.length > 1 && (
+                      <Button
+                        variant="link"
+                        className="d-flex align-items-center justify-content-center p-0"
+                        onClick={() => removeItem(i, iIndex)}
+                        aria-label={`Remove ${itemLabel} ${iIndex + 1}`}
+                      >
+                        <Image
+                          src="/close.svg"
+                          alt="Remove"
+                          width={28}
+                          height={28}
+                        />
+                      </Button>
+                    )}
+                  </Stack>
+                ))}
+                {!readOnly && (
+                  <Button
+                    variant="link"
+                    className="p-0 text-start text-decoration-underline fw-semi-bold text-primary"
+                    onClick={() => addItem(i)}
+                  >
+                    Add {itemLabel}
+                  </Button>
+                )}
+              </Stack>
+            </Form.Group>
+          </div>
+        );
+      })}
+
+      {canAdd && (
+        <Button
+          variant="link"
+          className="p-0 text-start text-decoration-underline fw-semi-bold text-primary"
+          onClick={addMilestone}
+        >
+          Add {milestoneLabel}
+        </Button>
+      )}
+    </Form.Group>
+  );
+}

--- a/src/app/flow-councils/components/DynamicMilestoneInput.tsx
+++ b/src/app/flow-councils/components/DynamicMilestoneInput.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useMemo } from "react";
 import Form from "react-bootstrap/Form";
 import Stack from "react-bootstrap/Stack";
 import Button from "react-bootstrap/Button";
@@ -44,42 +44,41 @@ export default function DynamicMilestoneInput(props: Props) {
   const milestoneLabel = element.milestoneLabel || "Milestone";
   const itemLabel = element.itemLabel || "Deliverable";
 
-  useEffect(() => {
-    if (readOnly) return;
-    if (values.length < minCount) {
-      const padded = [...values];
-      while (padded.length < minCount) padded.push(emptyMilestone());
-      onChange(padded);
-    }
-    // Deps intentionally exclude `values` (array identity flips every parent
-    // render and would loop) and `onChange` (its identity flips every parent
-    // render and would fire wasted no-op cycles).
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [values.length, minCount, readOnly]);
+  // Pad to minCount synchronously during render so the rendered blocks and the
+  // array used by update handlers always agree. User edits commit the padded
+  // shape back to parent state via onChange, so we never need an effect to
+  // sync — and there's no intermediate render with a mismatched array.
+  const blocks = useMemo(() => {
+    if (values.length >= minCount) return values;
+    return [
+      ...values,
+      ...Array.from({ length: minCount - values.length }, emptyMilestone),
+    ];
+  }, [values, minCount]);
 
   const updateMilestone = (index: number, next: DynamicMilestoneValue) => {
-    const copy = [...values];
+    const copy = [...blocks];
     copy[index] = next;
     onChange(copy);
   };
 
   const addMilestone = () => {
-    onChange([...values, emptyMilestone()]);
+    onChange([...blocks, emptyMilestone()]);
   };
 
   const removeMilestone = (index: number) => {
-    onChange(values.filter((_, i) => i !== index));
+    onChange(blocks.filter((_, i) => i !== index));
   };
 
   const updateItem = (mIndex: number, iIndex: number, value: string) => {
-    const milestone = values[mIndex];
+    const milestone = blocks[mIndex];
     const newItems = [...milestone.items];
     newItems[iIndex] = value;
     updateMilestone(mIndex, { ...milestone, items: newItems });
   };
 
   const addItem = (mIndex: number) => {
-    const milestone = values[mIndex];
+    const milestone = blocks[mIndex];
     updateMilestone(mIndex, {
       ...milestone,
       items: [...milestone.items, ""],
@@ -87,21 +86,13 @@ export default function DynamicMilestoneInput(props: Props) {
   };
 
   const removeItem = (mIndex: number, iIndex: number) => {
-    const milestone = values[mIndex];
+    const milestone = blocks[mIndex];
     const newItems = milestone.items.filter((_, i) => i !== iIndex);
     updateMilestone(mIndex, {
       ...milestone,
       items: newItems.length > 0 ? newItems : [""],
     });
   };
-
-  const blocks =
-    values.length >= minCount
-      ? values
-      : [
-          ...values,
-          ...Array.from({ length: minCount - values.length }, emptyMilestone),
-        ];
 
   const canAdd = !readOnly && !lockBlockCount;
   const canRemoveBlock = (i: number) =>

--- a/src/app/flow-councils/constants.ts
+++ b/src/app/flow-councils/constants.ts
@@ -4,3 +4,5 @@ export const CHARACTER_LIMITS = {
   milestoneDescription: { min: 500, max: 5000 },
   ecosystemImpact: { max: 4000 },
 } as const;
+
+export const MAX_MILESTONES = 20;

--- a/src/app/flow-councils/form-builder/[chainId]/[councilId]/form-builder.tsx
+++ b/src/app/flow-councils/form-builder/[chainId]/[councilId]/form-builder.tsx
@@ -118,6 +118,7 @@ const STRUCTURE_TYPES: { value: FormElement["type"]; label: string }[] = [
 
 const COLOR_STANDARD = "#3c655b";
 const COLOR_COMMS = "#056589";
+const COLOR_MILESTONE = "#d95d39";
 const COLOR_STRUCTURAL = "#888888";
 
 const TYPE_COLORS: Record<FormElement["type"], string> = {
@@ -127,7 +128,7 @@ const TYPE_COLORS: Record<FormElement["type"], string> = {
   select: COLOR_STANDARD,
   multiSelect: COLOR_STANDARD,
   boolean: COLOR_STANDARD,
-  milestone: COLOR_STANDARD,
+  milestone: COLOR_MILESTONE,
   url: COLOR_COMMS,
   email: COLOR_COMMS,
   telegram: COLOR_COMMS,

--- a/src/app/flow-councils/form-builder/[chainId]/[councilId]/form-builder.tsx
+++ b/src/app/flow-councils/form-builder/[chainId]/[councilId]/form-builder.tsx
@@ -549,15 +549,23 @@ function ElementCard({
                   <Form.Control
                     type="number"
                     className="rounded-3"
+                    min={0}
                     value={element.descriptionMinChars ?? ""}
-                    onChange={(e) =>
+                    onChange={(e) => {
+                      if (!e.target.value) {
+                        onUpdate({
+                          ...element,
+                          descriptionMinChars: undefined,
+                        });
+                        return;
+                      }
+                      const n = Number(e.target.value);
+                      if (!Number.isFinite(n)) return;
                       onUpdate({
                         ...element,
-                        descriptionMinChars: e.target.value
-                          ? Number(e.target.value)
-                          : undefined,
-                      })
-                    }
+                        descriptionMinChars: Math.max(0, Math.round(n)),
+                      });
+                    }}
                     placeholder="None"
                   />
                 </Form.Group>
@@ -568,15 +576,23 @@ function ElementCard({
                   <Form.Control
                     type="number"
                     className="rounded-3"
+                    min={1}
                     value={element.descriptionMaxChars ?? ""}
-                    onChange={(e) =>
+                    onChange={(e) => {
+                      if (!e.target.value) {
+                        onUpdate({
+                          ...element,
+                          descriptionMaxChars: undefined,
+                        });
+                        return;
+                      }
+                      const n = Number(e.target.value);
+                      if (!Number.isFinite(n)) return;
                       onUpdate({
                         ...element,
-                        descriptionMaxChars: e.target.value
-                          ? Number(e.target.value)
-                          : undefined,
-                      })
-                    }
+                        descriptionMaxChars: Math.max(1, Math.round(n)),
+                      });
+                    }}
                     placeholder="None"
                   />
                 </Form.Group>

--- a/src/app/flow-councils/form-builder/[chainId]/[councilId]/form-builder.tsx
+++ b/src/app/flow-councils/form-builder/[chainId]/[councilId]/form-builder.tsx
@@ -494,15 +494,19 @@ function ElementCard({
                   <Form.Label className="fs-sm fw-semi-bold">
                     Sub-item Label
                   </Form.Label>
-                  <Form.Control
-                    type="text"
+                  <Form.Select
                     className="rounded-3"
-                    value={element.itemLabel ?? ""}
+                    value={element.itemLabel ?? "Deliverable"}
                     onChange={(e) =>
-                      onUpdate({ ...element, itemLabel: e.target.value })
+                      onUpdate({
+                        ...element,
+                        itemLabel: e.target.value as "Deliverable" | "Activation",
+                      })
                     }
-                    placeholder="Deliverable"
-                  />
+                  >
+                    <option value="Deliverable">Deliverable</option>
+                    <option value="Activation">Activation</option>
+                  </Form.Select>
                 </Form.Group>
               </Stack>
               <Form.Group className="mb-3">

--- a/src/app/flow-councils/form-builder/[chainId]/[councilId]/form-builder.tsx
+++ b/src/app/flow-councils/form-builder/[chainId]/[councilId]/form-builder.tsx
@@ -500,7 +500,9 @@ function ElementCard({
                     onChange={(e) =>
                       onUpdate({
                         ...element,
-                        itemLabel: e.target.value as "Deliverable" | "Activation",
+                        itemLabel: e.target.value as
+                          | "Deliverable"
+                          | "Activation",
                       })
                     }
                   >
@@ -513,19 +515,22 @@ function ElementCard({
                 <Form.Label className="fs-sm fw-semi-bold">
                   Minimum Count
                 </Form.Label>
-                <Form.Control
-                  type="number"
+                <Form.Select
                   className="rounded-3"
-                  min={1}
-                  max={5}
                   value={element.minCount ?? 1}
-                  onChange={(e) => {
-                    const n = Number(e.target.value);
-                    if (!Number.isFinite(n)) return;
-                    const clamped = Math.max(1, Math.min(5, Math.round(n)));
-                    onUpdate({ ...element, minCount: clamped });
-                  }}
-                />
+                  onChange={(e) =>
+                    onUpdate({
+                      ...element,
+                      minCount: Number(e.target.value),
+                    })
+                  }
+                >
+                  <option value={1}>1</option>
+                  <option value={2}>2</option>
+                  <option value={3}>3</option>
+                  <option value={4}>4</option>
+                  <option value={5}>5</option>
+                </Form.Select>
                 <Form.Text className="text-muted">
                   Applicants must complete at least this many milestones (1–5).
                 </Form.Text>
@@ -1205,13 +1210,16 @@ export default function FormBuilder({ chainId, councilId }: Props) {
         </Alert>
       )}
       {success && (
-        <Alert
-          variant="success"
-          dismissible
-          onClose={() => setSuccess("")}
-          className="mb-3"
-        >
-          {success}
+        <Alert variant="success" className="mb-3 d-flex align-items-center">
+          <span className="flex-grow-1">{success}</span>
+          <Button
+            variant="transparent"
+            className="p-0 border-0 lh-1"
+            onClick={() => setSuccess("")}
+            aria-label="Close"
+          >
+            <Image src="/close.svg" alt="Close" width={24} height={24} />
+          </Button>
         </Alert>
       )}
     </>

--- a/src/app/flow-councils/form-builder/[chainId]/[councilId]/form-builder.tsx
+++ b/src/app/flow-councils/form-builder/[chainId]/[councilId]/form-builder.tsx
@@ -82,6 +82,15 @@ function newQuestion(type: FormElement["type"]): FormElement {
       return { ...base, type, required: false };
     case "ethAddress":
       return { ...base, type, required: false, placeholder: "0x..." };
+    case "milestone":
+      return {
+        ...base,
+        type,
+        required: true,
+        milestoneLabel: "Milestone",
+        itemLabel: "Deliverable",
+        minCount: 1,
+      };
     default:
       return { ...base, type, required: false } as FormElement;
   }
@@ -98,6 +107,7 @@ const QUESTION_TYPES: { value: FormElement["type"]; label: string }[] = [
   { value: "email", label: "Email" },
   { value: "telegram", label: "Telegram" },
   { value: "ethAddress", label: "ETH Address" },
+  { value: "milestone", label: "Milestone" },
 ];
 
 const STRUCTURE_TYPES: { value: FormElement["type"]; label: string }[] = [
@@ -117,6 +127,7 @@ const TYPE_COLORS: Record<FormElement["type"], string> = {
   select: COLOR_STANDARD,
   multiSelect: COLOR_STANDARD,
   boolean: COLOR_STANDARD,
+  milestone: COLOR_STANDARD,
   url: COLOR_COMMS,
   email: COLOR_COMMS,
   telegram: COLOR_COMMS,
@@ -139,6 +150,7 @@ const TYPE_DISPLAY_NAMES: Record<FormElement["type"], string> = {
   boolean: "Yes/No",
   telegram: "Telegram",
   ethAddress: "ETH Address",
+  milestone: "Milestone",
   divider: "Dividing Line",
 };
 
@@ -454,6 +466,121 @@ function ElementCard({
                 }
                 className="mb-3"
               />
+            </>
+          )}
+
+          {element.type === "milestone" && (
+            <>
+              <Stack direction="horizontal" gap={3} className="mb-3">
+                <Form.Group className="flex-grow-1">
+                  <Form.Label className="fs-sm fw-semi-bold">
+                    Milestone Label
+                  </Form.Label>
+                  <Form.Control
+                    type="text"
+                    className="rounded-3"
+                    value={element.milestoneLabel ?? ""}
+                    onChange={(e) =>
+                      onUpdate({
+                        ...element,
+                        milestoneLabel: e.target.value,
+                      })
+                    }
+                    placeholder="Milestone"
+                  />
+                </Form.Group>
+                <Form.Group className="flex-grow-1">
+                  <Form.Label className="fs-sm fw-semi-bold">
+                    Sub-item Label
+                  </Form.Label>
+                  <Form.Control
+                    type="text"
+                    className="rounded-3"
+                    value={element.itemLabel ?? ""}
+                    onChange={(e) =>
+                      onUpdate({ ...element, itemLabel: e.target.value })
+                    }
+                    placeholder="Deliverable"
+                  />
+                </Form.Group>
+              </Stack>
+              <Form.Group className="mb-3">
+                <Form.Label className="fs-sm fw-semi-bold">
+                  Minimum Count
+                </Form.Label>
+                <Form.Control
+                  type="number"
+                  className="rounded-3"
+                  min={1}
+                  max={5}
+                  value={element.minCount ?? 1}
+                  onChange={(e) => {
+                    const n = Number(e.target.value);
+                    if (!Number.isFinite(n)) return;
+                    const clamped = Math.max(1, Math.min(5, Math.round(n)));
+                    onUpdate({ ...element, minCount: clamped });
+                  }}
+                />
+                <Form.Text className="text-muted">
+                  Applicants must complete at least this many milestones (1–5).
+                </Form.Text>
+              </Form.Group>
+              <Form.Group className="mb-3">
+                <Form.Label className="fs-sm fw-semi-bold">
+                  Description Placeholder
+                </Form.Label>
+                <Form.Control
+                  type="text"
+                  className="rounded-3"
+                  value={element.descriptionPlaceholder ?? ""}
+                  onChange={(e) =>
+                    onUpdate({
+                      ...element,
+                      descriptionPlaceholder: e.target.value || undefined,
+                    })
+                  }
+                />
+              </Form.Group>
+              <Stack direction="horizontal" gap={3} className="mb-3">
+                <Form.Group className="flex-grow-1">
+                  <Form.Label className="fs-sm fw-semi-bold">
+                    Description Min Characters
+                  </Form.Label>
+                  <Form.Control
+                    type="number"
+                    className="rounded-3"
+                    value={element.descriptionMinChars ?? ""}
+                    onChange={(e) =>
+                      onUpdate({
+                        ...element,
+                        descriptionMinChars: e.target.value
+                          ? Number(e.target.value)
+                          : undefined,
+                      })
+                    }
+                    placeholder="None"
+                  />
+                </Form.Group>
+                <Form.Group className="flex-grow-1">
+                  <Form.Label className="fs-sm fw-semi-bold">
+                    Description Max Characters
+                  </Form.Label>
+                  <Form.Control
+                    type="number"
+                    className="rounded-3"
+                    value={element.descriptionMaxChars ?? ""}
+                    onChange={(e) =>
+                      onUpdate({
+                        ...element,
+                        descriptionMaxChars: e.target.value
+                          ? Number(e.target.value)
+                          : undefined,
+                      })
+                    }
+                    placeholder="None"
+                  />
+                </Form.Group>
+              </Stack>
             </>
           )}
 
@@ -1468,6 +1595,57 @@ function FormPreview({
                 </Stack>
               </Form.Group>
             );
+          case "milestone": {
+            const minCount = Math.max(1, Math.min(5, el.minCount ?? 1));
+            const milestoneLabel = el.milestoneLabel || "Milestone";
+            const itemLabel = el.itemLabel || "Deliverable";
+            return (
+              <Form.Group
+                key={el.id}
+                className="mb-3"
+                style={errorStyle(el.id)}
+              >
+                <Form.Label className="fs-sm fw-semi-bold">
+                  {num(el.id)}
+                  {el.label || "(Untitled)"}
+                  {el.required && "*"}
+                </Form.Label>
+                {Array.from({ length: minCount }).map((_, i) => (
+                  <div
+                    key={i}
+                    className="border rounded-3 p-2 mb-2"
+                    style={{ backgroundColor: "#fafafa" }}
+                  >
+                    <span className="fw-semi-bold fs-sm d-block mb-1">
+                      {milestoneLabel} {i + 1}
+                    </span>
+                    <Form.Control
+                      type="text"
+                      disabled
+                      className="rounded-3 mb-2"
+                      placeholder="Title"
+                    />
+                    <Form.Control
+                      as="textarea"
+                      rows={2}
+                      disabled
+                      className="rounded-3 mb-2"
+                      placeholder={el.descriptionPlaceholder ?? "Description"}
+                    />
+                    <Form.Control
+                      type="text"
+                      disabled
+                      className="rounded-3"
+                      placeholder={itemLabel}
+                    />
+                  </div>
+                ))}
+                <Form.Text className="text-muted">
+                  Minimum {minCount}; applicants can add more.
+                </Form.Text>
+              </Form.Group>
+            );
+          }
         }
       })}
     </Form>

--- a/src/app/flow-councils/form-builder/[chainId]/[councilId]/form-builder.tsx
+++ b/src/app/flow-councils/form-builder/[chainId]/[councilId]/form-builder.tsx
@@ -368,7 +368,7 @@ function ElementCard({
             </Form.Group>
           )}
 
-          {"required" in element && (
+          {"required" in element && element.type !== "milestone" && (
             <Form.Check
               type="checkbox"
               label="Required"

--- a/src/app/flow-councils/types/formSchema.ts
+++ b/src/app/flow-councils/types/formSchema.ts
@@ -78,6 +78,17 @@ type EthAddressQuestion = FormElementBase & {
   placeholder?: string;
 };
 
+export type MilestoneQuestion = FormElementBase & {
+  type: "milestone";
+  required?: boolean;
+  milestoneLabel?: string;
+  itemLabel?: string;
+  minCount?: number;
+  descriptionPlaceholder?: string;
+  descriptionMinChars?: number;
+  descriptionMaxChars?: number;
+};
+
 export type FormElement =
   | SectionElement
   | DescriptionElement
@@ -91,6 +102,7 @@ export type FormElement =
   | BooleanQuestion
   | TelegramQuestion
   | EthAddressQuestion
+  | MilestoneQuestion
   | DividerElement;
 
 export type FormSchema = {

--- a/src/app/flow-councils/types/formSchema.ts
+++ b/src/app/flow-councils/types/formSchema.ts
@@ -78,11 +78,13 @@ type EthAddressQuestion = FormElementBase & {
   placeholder?: string;
 };
 
+export type MilestoneItemLabel = "Deliverable" | "Activation";
+
 export type MilestoneQuestion = FormElementBase & {
   type: "milestone";
   required?: boolean;
   milestoneLabel?: string;
-  itemLabel?: string;
+  itemLabel?: MilestoneItemLabel;
   minCount?: number;
   descriptionPlaceholder?: string;
   descriptionMinChars?: number;

--- a/src/app/projects/[id]/milestones/MilestoneCard.tsx
+++ b/src/app/projects/[id]/milestones/MilestoneCard.tsx
@@ -392,7 +392,7 @@ export default function MilestoneCard({
   const isProgressEditing = editingItemIndex !== null || editingOtherDetails;
 
   const badgeLabel = `${milestone.milestoneLabel} ${milestone.index + 1}`;
-  const itemLabel = `${milestone.itemLabel}s`;
+  const itemLabel = milestone.itemLabel;
 
   const handleEditDeliverableClick = (index: number) => {
     requireAuth(() => setEditingItemIndex(index));
@@ -617,7 +617,7 @@ export default function MilestoneCard({
                           className="fs-xs text-muted text-uppercase fw-semi-bold"
                           style={{ letterSpacing: "0.05em" }}
                         >
-                          {itemLabel.slice(0, -1)} {i + 1}
+                          {itemLabel} {i + 1}
                         </span>
                         <div className="fw-semi-bold mt-1">{name}</div>
                       </div>

--- a/src/app/projects/[id]/milestones/MilestoneCard.tsx
+++ b/src/app/projects/[id]/milestones/MilestoneCard.tsx
@@ -391,7 +391,7 @@ export default function MilestoneCard({
 
   const isProgressEditing = editingItemIndex !== null || editingOtherDetails;
 
-  const badgeLabel = `${milestone.milestoneLabel} Milestone ${milestone.index + 1}`;
+  const badgeLabel = `${milestone.milestoneLabel} ${milestone.index + 1}`;
   const itemLabel = `${milestone.itemLabel}s`;
 
   const handleEditDeliverableClick = (index: number) => {

--- a/src/app/projects/[id]/milestones/MilestoneCard.tsx
+++ b/src/app/projects/[id]/milestones/MilestoneCard.tsx
@@ -11,7 +11,6 @@ import Markdown from "@/components/Markdown";
 import MarkdownEditor from "@/components/MarkdownEditor";
 import InfoTooltip from "@/components/InfoTooltip";
 import CharacterCounter from "@/app/flow-councils/components/CharacterCounter";
-import { CHARACTER_LIMITS } from "@/app/flow-councils/constants";
 import useRequireAuth from "@/hooks/requireAuth";
 import { normalizeUrl } from "@/app/flow-councils/utils/normalizeUrl";
 import type {
@@ -234,12 +233,12 @@ function DefinitionEditForm({
   const [validated, setValidated] = useState(false);
 
   const itemLabel = milestone.itemLabel;
+  const descMin = milestone.descriptionMinChars;
+  const descMax = milestone.descriptionMaxChars;
 
   const isTitleEmpty = !title.trim();
-  const isDescriptionShort =
-    description.length < CHARACTER_LIMITS.milestoneDescription.min;
-  const isDescriptionLong =
-    description.length > CHARACTER_LIMITS.milestoneDescription.max;
+  const isDescriptionShort = description.length < descMin;
+  const isDescriptionLong = description.length > descMax;
   const hasValidItem = items.some((item) => item.trim() !== "");
 
   const titleInvalid = validated && isTitleEmpty;
@@ -300,11 +299,7 @@ function DefinitionEditForm({
           placeholder="Describe the outcomes you aim to achieve"
           isInvalid={descriptionInvalid}
         />
-        <CharacterCounter
-          value={description}
-          min={CHARACTER_LIMITS.milestoneDescription.min}
-          max={CHARACTER_LIMITS.milestoneDescription.max}
-        />
+        <CharacterCounter value={description} min={descMin} max={descMax} />
       </Form.Group>
       <Form.Group>
         <Form.Label className="fw-semi-bold">{itemLabel}s*</Form.Label>

--- a/src/app/projects/[id]/milestones/MilestoneCard.tsx
+++ b/src/app/projects/[id]/milestones/MilestoneCard.tsx
@@ -35,11 +35,6 @@ type EditingDeliverable = {
   evidence: EvidenceLink[];
 };
 
-const TYPE_LABELS: Record<string, string> = {
-  build: "Build",
-  growth: "Growth",
-};
-
 function CompletionBar({ completion }: { completion: number }) {
   const variant =
     completion === 100 ? "success" : completion >= 50 ? "primary" : "info";
@@ -238,7 +233,7 @@ function DefinitionEditForm({
   );
   const [validated, setValidated] = useState(false);
 
-  const itemLabel = milestone.type === "build" ? "Deliverable" : "Activation";
+  const itemLabel = milestone.itemLabel;
 
   const isTitleEmpty = !title.trim();
   const isDescriptionShort =
@@ -396,8 +391,8 @@ export default function MilestoneCard({
 
   const isProgressEditing = editingItemIndex !== null || editingOtherDetails;
 
-  const badgeLabel = `${TYPE_LABELS[milestone.type]} Milestone ${milestone.index + 1}`;
-  const itemLabel = milestone.type === "build" ? "Deliverables" : "Activations";
+  const badgeLabel = `${milestone.milestoneLabel} Milestone ${milestone.index + 1}`;
+  const itemLabel = `${milestone.itemLabel}s`;
 
   const handleEditDeliverableClick = (index: number) => {
     requireAuth(() => setEditingItemIndex(index));

--- a/src/app/projects/[id]/milestones/types.ts
+++ b/src/app/projects/[id]/milestones/types.ts
@@ -22,6 +22,8 @@ export type MilestoneWithProgress = {
   description: string;
   itemNames: string[];
   progress: MilestoneProgressData;
+  descriptionMinChars: number;
+  descriptionMaxChars: number;
 };
 
 export type ApplicationMilestones = {

--- a/src/app/projects/[id]/milestones/types.ts
+++ b/src/app/projects/[id]/milestones/types.ts
@@ -14,7 +14,9 @@ export type MilestoneProgressData = {
 };
 
 export type MilestoneWithProgress = {
-  type: "build" | "growth";
+  type: string;
+  milestoneLabel: string;
+  itemLabel: string;
   index: number;
   title: string;
   description: string;

--- a/src/generated/kysely.ts
+++ b/src/generated/kysely.ts
@@ -1,142 +1,144 @@
 import type { ColumnType } from "kysely";
-export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
-  ? ColumnType<S, I | undefined, U>
-  : ColumnType<T, T | undefined, T>;
+export type Generated<T> =
+  T extends ColumnType<infer S, infer I, infer U>
+    ? ColumnType<S, I | undefined, U>
+    : ColumnType<T, T | undefined, T>;
 export type Timestamp = ColumnType<Date, Date | string, Date | string>;
 
 export const ApplicationStatus = {
-    INCOMPLETE: "INCOMPLETE",
-    SUBMITTED: "SUBMITTED",
-    ACCEPTED: "ACCEPTED",
-    CHANGES_REQUESTED: "CHANGES_REQUESTED",
-    REJECTED: "REJECTED",
-    REMOVED: "REMOVED",
-    GRADUATED: "GRADUATED"
+  INCOMPLETE: "INCOMPLETE",
+  SUBMITTED: "SUBMITTED",
+  ACCEPTED: "ACCEPTED",
+  CHANGES_REQUESTED: "CHANGES_REQUESTED",
+  REJECTED: "REJECTED",
+  REMOVED: "REMOVED",
+  GRADUATED: "GRADUATED",
 } as const;
-export type ApplicationStatus = (typeof ApplicationStatus)[keyof typeof ApplicationStatus];
+export type ApplicationStatus =
+  (typeof ApplicationStatus)[keyof typeof ApplicationStatus];
 export const ChannelType = {
-    INTERNAL_APPLICATION: "INTERNAL_APPLICATION",
-    GROUP_ANNOUNCEMENTS: "GROUP_ANNOUNCEMENTS",
-    GROUP_APPLICANTS: "GROUP_APPLICANTS",
-    GROUP_GRANTEES: "GROUP_GRANTEES",
-    GROUP_ROUND_ADMINS: "GROUP_ROUND_ADMINS",
-    GROUP_PROJECT: "GROUP_PROJECT",
-    PUBLIC_ROUND: "PUBLIC_ROUND",
-    PUBLIC_PROJECT: "PUBLIC_PROJECT"
+  INTERNAL_APPLICATION: "INTERNAL_APPLICATION",
+  GROUP_ANNOUNCEMENTS: "GROUP_ANNOUNCEMENTS",
+  GROUP_APPLICANTS: "GROUP_APPLICANTS",
+  GROUP_GRANTEES: "GROUP_GRANTEES",
+  GROUP_ROUND_ADMINS: "GROUP_ROUND_ADMINS",
+  GROUP_PROJECT: "GROUP_PROJECT",
+  PUBLIC_ROUND: "PUBLIC_ROUND",
+  PUBLIC_PROJECT: "PUBLIC_PROJECT",
 } as const;
 export type ChannelType = (typeof ChannelType)[keyof typeof ChannelType];
 export type Application = {
-    id: Generated<number>;
-    projectId: number;
-    roundId: number;
-    fundingAddress: string;
-    status: Generated<ApplicationStatus>;
-    details: unknown | null;
-    editsUnlocked: Generated<boolean>;
-    createdAt: Generated<Timestamp>;
-    updatedAt: Generated<Timestamp>;
+  id: Generated<number>;
+  projectId: number;
+  roundId: number;
+  fundingAddress: string;
+  status: Generated<ApplicationStatus>;
+  details: unknown | null;
+  editsUnlocked: Generated<boolean>;
+  createdAt: Generated<Timestamp>;
+  updatedAt: Generated<Timestamp>;
 };
 export type Message = {
-    id: Generated<number>;
-    channelType: ChannelType;
-    roundId: number | null;
-    projectId: number | null;
-    applicationId: number | null;
-    authorAddress: string;
-    content: string;
-    messageType: Generated<string>;
-    pinnedAt: Timestamp | null;
-    pinnedBy: string | null;
-    createdAt: Generated<Timestamp>;
-    updatedAt: Generated<Timestamp>;
+  id: Generated<number>;
+  channelType: ChannelType;
+  roundId: number | null;
+  projectId: number | null;
+  applicationId: number | null;
+  authorAddress: string;
+  content: string;
+  messageType: Generated<string>;
+  pinnedAt: Timestamp | null;
+  pinnedBy: string | null;
+  createdAt: Generated<Timestamp>;
+  updatedAt: Generated<Timestamp>;
 };
 export type MessageReaction = {
-    id: Generated<number>;
-    messageId: number;
-    authorAddress: string;
-    emoji: string;
-    createdAt: Generated<Timestamp>;
+  id: Generated<number>;
+  messageId: number;
+  authorAddress: string;
+  emoji: string;
+  createdAt: Generated<Timestamp>;
 };
 export type MilestoneProgress = {
-    id: Generated<number>;
-    applicationId: number;
-    milestoneType: string;
-    milestoneIndex: number;
-    progress: unknown | null;
-    createdAt: Generated<Timestamp>;
-    updatedAt: Generated<Timestamp>;
+  id: Generated<number>;
+  applicationId: number;
+  milestoneType: string;
+  milestoneIndex: number;
+  progress: unknown | null;
+  createdAt: Generated<Timestamp>;
+  updatedAt: Generated<Timestamp>;
 };
 export type Project = {
-    id: Generated<number>;
-    details: unknown | null;
-    createdAt: Generated<Timestamp>;
-    updatedAt: Generated<Timestamp>;
+  id: Generated<number>;
+  details: unknown | null;
+  createdAt: Generated<Timestamp>;
+  updatedAt: Generated<Timestamp>;
 };
 export type ProjectEmail = {
-    id: Generated<number>;
-    projectId: number;
-    email: string;
-    managerAddress: string | null;
-    createdAt: Generated<Timestamp>;
+  id: Generated<number>;
+  projectId: number;
+  email: string;
+  managerAddress: string | null;
+  createdAt: Generated<Timestamp>;
 };
 export type ProjectManager = {
-    id: Generated<number>;
-    projectId: number;
-    managerAddress: string;
-    createdAt: Generated<Timestamp>;
+  id: Generated<number>;
+  projectId: number;
+  managerAddress: string;
+  createdAt: Generated<Timestamp>;
 };
 export type Recipient = {
-    id: Generated<number>;
-    applicationId: number;
-    createdAt: Generated<Timestamp>;
+  id: Generated<number>;
+  applicationId: number;
+  createdAt: Generated<Timestamp>;
 };
 export type Round = {
-    id: Generated<number>;
-    chainId: number;
-    flowCouncilAddress: string;
-    superappSplitterAddress: string | null;
-    applicationsClosed: Generated<boolean>;
-    details: unknown | null;
-    createdAt: Generated<Timestamp>;
-    updatedAt: Generated<Timestamp>;
+  id: Generated<number>;
+  chainId: number;
+  flowCouncilAddress: string;
+  superappSplitterAddress: string | null;
+  applicationsClosed: Generated<boolean>;
+  details: unknown | null;
+  createdAt: Generated<Timestamp>;
+  updatedAt: Generated<Timestamp>;
 };
 export type RoundAdmin = {
-    id: Generated<number>;
-    roundId: number;
-    adminAddress: string;
-    createdAt: Generated<Timestamp>;
+  id: Generated<number>;
+  roundId: number;
+  adminAddress: string;
+  createdAt: Generated<Timestamp>;
 };
 export type RoundAdminEmail = {
-    id: Generated<number>;
-    roundAdminId: number;
-    email: string;
-    createdAt: Generated<Timestamp>;
+  id: Generated<number>;
+  roundAdminId: number;
+  email: string;
+  createdAt: Generated<Timestamp>;
 };
 export type UserProfile = {
-    id: Generated<number>;
-    address: string;
-    displayName: string;
-    bio: string | null;
-    twitter: string | null;
-    github: string | null;
-    linkedin: string | null;
-    farcaster: string | null;
-    email: string | null;
-    telegram: string | null;
-    createdAt: Generated<Timestamp>;
-    updatedAt: Generated<Timestamp>;
+  id: Generated<number>;
+  address: string;
+  displayName: string;
+  bio: string | null;
+  twitter: string | null;
+  github: string | null;
+  linkedin: string | null;
+  farcaster: string | null;
+  email: string | null;
+  telegram: string | null;
+  createdAt: Generated<Timestamp>;
+  updatedAt: Generated<Timestamp>;
 };
 export type DB = {
-    applications: Application;
-    messageReactions: MessageReaction;
-    messages: Message;
-    milestoneProgress: MilestoneProgress;
-    projectEmails: ProjectEmail;
-    projectManagers: ProjectManager;
-    projects: Project;
-    recipients: Recipient;
-    roundAdminEmails: RoundAdminEmail;
-    roundAdmins: RoundAdmin;
-    rounds: Round;
-    userProfiles: UserProfile;
+  applications: Application;
+  messageReactions: MessageReaction;
+  messages: Message;
+  milestoneProgress: MilestoneProgress;
+  projectEmails: ProjectEmail;
+  projectManagers: ProjectManager;
+  projects: Project;
+  recipients: Recipient;
+  roundAdminEmails: RoundAdminEmail;
+  roundAdmins: RoundAdmin;
+  rounds: Round;
+  userProfiles: UserProfile;
 };

--- a/src/generated/kysely.ts
+++ b/src/generated/kysely.ts
@@ -1,144 +1,142 @@
 import type { ColumnType } from "kysely";
-export type Generated<T> =
-  T extends ColumnType<infer S, infer I, infer U>
-    ? ColumnType<S, I | undefined, U>
-    : ColumnType<T, T | undefined, T>;
+export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
+  ? ColumnType<S, I | undefined, U>
+  : ColumnType<T, T | undefined, T>;
 export type Timestamp = ColumnType<Date, Date | string, Date | string>;
 
 export const ApplicationStatus = {
-  INCOMPLETE: "INCOMPLETE",
-  SUBMITTED: "SUBMITTED",
-  ACCEPTED: "ACCEPTED",
-  CHANGES_REQUESTED: "CHANGES_REQUESTED",
-  REJECTED: "REJECTED",
-  REMOVED: "REMOVED",
-  GRADUATED: "GRADUATED",
+    INCOMPLETE: "INCOMPLETE",
+    SUBMITTED: "SUBMITTED",
+    ACCEPTED: "ACCEPTED",
+    CHANGES_REQUESTED: "CHANGES_REQUESTED",
+    REJECTED: "REJECTED",
+    REMOVED: "REMOVED",
+    GRADUATED: "GRADUATED"
 } as const;
-export type ApplicationStatus =
-  (typeof ApplicationStatus)[keyof typeof ApplicationStatus];
+export type ApplicationStatus = (typeof ApplicationStatus)[keyof typeof ApplicationStatus];
 export const ChannelType = {
-  INTERNAL_APPLICATION: "INTERNAL_APPLICATION",
-  GROUP_ANNOUNCEMENTS: "GROUP_ANNOUNCEMENTS",
-  GROUP_APPLICANTS: "GROUP_APPLICANTS",
-  GROUP_GRANTEES: "GROUP_GRANTEES",
-  GROUP_ROUND_ADMINS: "GROUP_ROUND_ADMINS",
-  GROUP_PROJECT: "GROUP_PROJECT",
-  PUBLIC_ROUND: "PUBLIC_ROUND",
-  PUBLIC_PROJECT: "PUBLIC_PROJECT",
+    INTERNAL_APPLICATION: "INTERNAL_APPLICATION",
+    GROUP_ANNOUNCEMENTS: "GROUP_ANNOUNCEMENTS",
+    GROUP_APPLICANTS: "GROUP_APPLICANTS",
+    GROUP_GRANTEES: "GROUP_GRANTEES",
+    GROUP_ROUND_ADMINS: "GROUP_ROUND_ADMINS",
+    GROUP_PROJECT: "GROUP_PROJECT",
+    PUBLIC_ROUND: "PUBLIC_ROUND",
+    PUBLIC_PROJECT: "PUBLIC_PROJECT"
 } as const;
 export type ChannelType = (typeof ChannelType)[keyof typeof ChannelType];
 export type Application = {
-  id: Generated<number>;
-  projectId: number;
-  roundId: number;
-  fundingAddress: string;
-  status: Generated<ApplicationStatus>;
-  details: unknown | null;
-  editsUnlocked: Generated<boolean>;
-  createdAt: Generated<Timestamp>;
-  updatedAt: Generated<Timestamp>;
+    id: Generated<number>;
+    projectId: number;
+    roundId: number;
+    fundingAddress: string;
+    status: Generated<ApplicationStatus>;
+    details: unknown | null;
+    editsUnlocked: Generated<boolean>;
+    createdAt: Generated<Timestamp>;
+    updatedAt: Generated<Timestamp>;
 };
 export type Message = {
-  id: Generated<number>;
-  channelType: ChannelType;
-  roundId: number | null;
-  projectId: number | null;
-  applicationId: number | null;
-  authorAddress: string;
-  content: string;
-  messageType: Generated<string>;
-  pinnedAt: Timestamp | null;
-  pinnedBy: string | null;
-  createdAt: Generated<Timestamp>;
-  updatedAt: Generated<Timestamp>;
+    id: Generated<number>;
+    channelType: ChannelType;
+    roundId: number | null;
+    projectId: number | null;
+    applicationId: number | null;
+    authorAddress: string;
+    content: string;
+    messageType: Generated<string>;
+    pinnedAt: Timestamp | null;
+    pinnedBy: string | null;
+    createdAt: Generated<Timestamp>;
+    updatedAt: Generated<Timestamp>;
 };
 export type MessageReaction = {
-  id: Generated<number>;
-  messageId: number;
-  authorAddress: string;
-  emoji: string;
-  createdAt: Generated<Timestamp>;
+    id: Generated<number>;
+    messageId: number;
+    authorAddress: string;
+    emoji: string;
+    createdAt: Generated<Timestamp>;
 };
 export type MilestoneProgress = {
-  id: Generated<number>;
-  applicationId: number;
-  milestoneType: string;
-  milestoneIndex: number;
-  progress: unknown | null;
-  createdAt: Generated<Timestamp>;
-  updatedAt: Generated<Timestamp>;
+    id: Generated<number>;
+    applicationId: number;
+    milestoneType: string;
+    milestoneIndex: number;
+    progress: unknown | null;
+    createdAt: Generated<Timestamp>;
+    updatedAt: Generated<Timestamp>;
 };
 export type Project = {
-  id: Generated<number>;
-  details: unknown | null;
-  createdAt: Generated<Timestamp>;
-  updatedAt: Generated<Timestamp>;
+    id: Generated<number>;
+    details: unknown | null;
+    createdAt: Generated<Timestamp>;
+    updatedAt: Generated<Timestamp>;
 };
 export type ProjectEmail = {
-  id: Generated<number>;
-  projectId: number;
-  email: string;
-  managerAddress: string | null;
-  createdAt: Generated<Timestamp>;
+    id: Generated<number>;
+    projectId: number;
+    email: string;
+    managerAddress: string | null;
+    createdAt: Generated<Timestamp>;
 };
 export type ProjectManager = {
-  id: Generated<number>;
-  projectId: number;
-  managerAddress: string;
-  createdAt: Generated<Timestamp>;
+    id: Generated<number>;
+    projectId: number;
+    managerAddress: string;
+    createdAt: Generated<Timestamp>;
 };
 export type Recipient = {
-  id: Generated<number>;
-  applicationId: number;
-  createdAt: Generated<Timestamp>;
+    id: Generated<number>;
+    applicationId: number;
+    createdAt: Generated<Timestamp>;
 };
 export type Round = {
-  id: Generated<number>;
-  chainId: number;
-  flowCouncilAddress: string;
-  superappSplitterAddress: string | null;
-  applicationsClosed: Generated<boolean>;
-  details: unknown | null;
-  createdAt: Generated<Timestamp>;
-  updatedAt: Generated<Timestamp>;
+    id: Generated<number>;
+    chainId: number;
+    flowCouncilAddress: string;
+    superappSplitterAddress: string | null;
+    applicationsClosed: Generated<boolean>;
+    details: unknown | null;
+    createdAt: Generated<Timestamp>;
+    updatedAt: Generated<Timestamp>;
 };
 export type RoundAdmin = {
-  id: Generated<number>;
-  roundId: number;
-  adminAddress: string;
-  createdAt: Generated<Timestamp>;
+    id: Generated<number>;
+    roundId: number;
+    adminAddress: string;
+    createdAt: Generated<Timestamp>;
 };
 export type RoundAdminEmail = {
-  id: Generated<number>;
-  roundAdminId: number;
-  email: string;
-  createdAt: Generated<Timestamp>;
+    id: Generated<number>;
+    roundAdminId: number;
+    email: string;
+    createdAt: Generated<Timestamp>;
 };
 export type UserProfile = {
-  id: Generated<number>;
-  address: string;
-  displayName: string;
-  bio: string | null;
-  twitter: string | null;
-  github: string | null;
-  linkedin: string | null;
-  farcaster: string | null;
-  email: string | null;
-  telegram: string | null;
-  createdAt: Generated<Timestamp>;
-  updatedAt: Generated<Timestamp>;
+    id: Generated<number>;
+    address: string;
+    displayName: string;
+    bio: string | null;
+    twitter: string | null;
+    github: string | null;
+    linkedin: string | null;
+    farcaster: string | null;
+    email: string | null;
+    telegram: string | null;
+    createdAt: Generated<Timestamp>;
+    updatedAt: Generated<Timestamp>;
 };
 export type DB = {
-  applications: Application;
-  messageReactions: MessageReaction;
-  messages: Message;
-  milestoneProgress: MilestoneProgress;
-  projectEmails: ProjectEmail;
-  projectManagers: ProjectManager;
-  projects: Project;
-  recipients: Recipient;
-  roundAdminEmails: RoundAdminEmail;
-  roundAdmins: RoundAdmin;
-  rounds: Round;
-  userProfiles: UserProfile;
+    applications: Application;
+    messageReactions: MessageReaction;
+    messages: Message;
+    milestoneProgress: MilestoneProgress;
+    projectEmails: ProjectEmail;
+    projectManagers: ProjectManager;
+    projects: Project;
+    recipients: Recipient;
+    roundAdminEmails: RoundAdminEmail;
+    roundAdmins: RoundAdmin;
+    rounds: Round;
+    userProfiles: UserProfile;
 };


### PR DESCRIPTION
## Summary
- New `"milestone"` FormElement type with configurable label, sub-item label, min count (1–5), and description char limits
- Multiple milestone questions per form, each independently configured
- Dynamic milestones flow into the existing project Milestones tab, evidence tracking, and feed system
- Hybrid key strategy: FormElement UUID stored as `milestoneType` in DB, human-readable label resolved from `formSchema` and returned in API responses
- DB migration widens `milestone_progress.milestone_type` from VARCHAR(10) to VARCHAR(100); already deployed to dev + prod

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm test:unit` — 70/70 passing (17 new milestone validation tests)
- [ ] `pnpm test:integration` — 15 new tests; require `TEST_DATABASE_URL` (CI)
- [X] Manual smoke: form builder — add milestone question, configure labels + minCount + char limits, verify preview reflects config
- [x] Manual smoke: applicant flow — see minCount initial blocks, add/remove beyond minimum, all fields required
- [x] Manual smoke: post-acceptance edit unlock — definitions editable, blocks NOT addable/removable
- [x] Manual smoke: Milestones tab — dynamic milestones render with configured labels; evidence updates post to feed with the configured `milestoneLabel`
- [x] Manual smoke: legacy GoodBuilders S3 round — Milestones tab unchanged (badge says "Build Milestone 1" / "Growth Milestone 1")

## Notes
- Security: `milestoneType` validated against `formSchema.round` milestone elements server-side to prevent arbitrary key probing in `appDetails.round`
- Milestone array capped at 20 entries; sub-items capped at 50; title capped at 200 chars
- `DynamicMilestoneInput` `useEffect` dep array uses `values.length` (not `values`) to avoid an infinite re-render — intentional, ESLint-suppressed with comment