### PR TITLE
feat: warn + top-up option when stream exceeds splitter funding cap

### DIFF
--- a/src/app/flow-councils/components/DistributionPoolFunding.tsx
+++ b/src/app/flow-councils/components/DistributionPoolFunding.tsx
@@ -3,6 +3,7 @@ import {
   Address,
   isAddress,
   erc20Abi,
+  encodeFunctionData,
   parseEther,
   parseUnits,
   formatUnits,
@@ -10,6 +11,7 @@ import {
 import { useAccount, useBalance, useReadContract } from "wagmi";
 import dayjs from "dayjs";
 import { useQuery, gql } from "@apollo/client";
+import { superTokenAbi } from "@sfpro/sdk/abi";
 import { hostAddress } from "@sfpro/sdk/abi/core";
 import duration from "dayjs/plugin/duration";
 import Offcanvas from "react-bootstrap/Offcanvas";
@@ -46,7 +48,11 @@ import {
   formatNumberWithCommas,
   roundWeiAmount,
 } from "@/lib/utils";
-import { SECONDS_IN_MONTH, MAX_FLOW_RATE } from "@/lib/constants";
+import {
+  SECONDS_IN_MONTH,
+  SUPERFLUID_LIQUIDATION_PERIOD_SECONDS,
+  MAX_FLOW_RATE,
+} from "@/lib/constants";
 import { getSocialShare } from "../lib/socialShare";
 
 const SF_ACCOUNT_QUERY = gql`
@@ -125,6 +131,19 @@ export default function DistributionPoolFunding(props: {
       address,
       chainId: network.id,
     });
+  const {
+    balanceUntilUpdatedAt: splitterBalanceUntilUpdatedAt,
+    updatedAtTimestamp: splitterUpdatedAtTimestamp,
+  } = useSuperTokenBalanceOfNow({
+    token: distributionTokenAddress,
+    address: splitterAddress ?? undefined,
+    chainId: network.id,
+  });
+  const splitterBalanceNow = useFlowingAmount(
+    BigInt(splitterBalanceUntilUpdatedAt ?? 0),
+    splitterUpdatedAtTimestamp ?? 0,
+    BigInt(superAppFunderData?.totalInflowRate ?? 0),
+  );
   const { data: ethBalance } = useBalance({
     address,
     chainId: network.id,
@@ -201,6 +220,23 @@ export default function DistributionPoolFunding(props: {
   }, [address, splitterAddress, superfluidQueryRes]);
 
   const flowRateToReceiver = outflowToReceiver?.currentFlowRate ?? "0";
+
+  const maxFundingRate =
+    splitterBalanceNow / BigInt(SUPERFLUID_LIQUIDATION_PERIOD_SECONDS);
+  const requiredTransferWei = newFlowRate
+    ? BigInt(newFlowRate) * BigInt(SUPERFLUID_LIQUIDATION_PERIOD_SECONDS)
+    : BigInt(0);
+  const exceedsSplitterCap =
+    !!splitterAddress &&
+    !!newFlowRate &&
+    BigInt(newFlowRate) > BigInt(flowRateToReceiver) &&
+    BigInt(newFlowRate) > maxFundingRate;
+  const wrapAmountForTransferCheck = parseEther(
+    wrapAmount?.replace(/,/g, "") ?? "0",
+  );
+  const hasSufficientBalanceForTransfer =
+    !exceedsSplitterCap ||
+    superTokenBalance + wrapAmountForTransferCheck >= requiredTransferWei;
 
   const suggestedTokenBalance = newFlowRate
     ? BigInt(newFlowRate) * BigInt(SECONDS_IN_MONTH) * BigInt(3)
@@ -319,10 +355,12 @@ export default function DistributionPoolFunding(props: {
     const needsApproval =
       isSuperTokenWrapper &&
       wrapAmountUnits > BigInt(underlyingTokenAllowance ?? 0);
+    const hasWrap = !!wrapAmount && Number(wrapAmount.replace(/,/g, "")) > 0;
     const newCalls: TransactionCall[] = [];
-    const batchOps = [];
+    const wrapBatchOps = [];
+    const flowBatchOps = [];
 
-    if (wrapAmount && Number(wrapAmount?.replace(/,/g, "")) > 0) {
+    if (hasWrap) {
       const wrap = buildWrapCalls({
         tokenAddress: distributionTokenAddress,
         wrapAmountWei,
@@ -334,7 +372,7 @@ export default function DistributionPoolFunding(props: {
       });
 
       newCalls.push(...wrap.calls);
-      batchOps.push(...wrap.batchOps);
+      wrapBatchOps.push(...wrap.batchOps);
     }
 
     const flowParams = {
@@ -345,19 +383,48 @@ export default function DistributionPoolFunding(props: {
     };
 
     if (BigInt(newFlowRate) === BigInt(0) && BigInt(flowRateToReceiver) > 0) {
-      batchOps.push(
+      flowBatchOps.push(
         buildDeleteFlowBatchOp({ ...flowParams, senderAddress: address }),
       );
     } else if (BigInt(flowRateToReceiver) > 0) {
-      batchOps.push(buildUpdateFlowBatchOp(flowParams));
+      flowBatchOps.push(buildUpdateFlowBatchOp(flowParams));
     } else if (BigInt(newFlowRate) > 0) {
-      batchOps.push(buildCreateFlowBatchOp(flowParams));
+      flowBatchOps.push(buildCreateFlowBatchOp(flowParams));
     }
 
-    const batchCall = buildBatchCall(batchOps, chainId);
+    const shouldIncludeTransfer =
+      exceedsSplitterCap && requiredTransferWei > BigInt(0);
 
-    if (batchCall) {
-      newCalls.push(batchCall);
+    if (shouldIncludeTransfer) {
+      const wrapBatchCall = buildBatchCall(wrapBatchOps, chainId);
+
+      if (wrapBatchCall) {
+        newCalls.push(wrapBatchCall);
+      }
+
+      newCalls.push({
+        to: distributionTokenAddress,
+        data: encodeFunctionData({
+          abi: superTokenAbi,
+          functionName: "transfer",
+          args: [splitterAddress as Address, requiredTransferWei],
+        }),
+      });
+
+      const flowBatchCall = buildBatchCall(flowBatchOps, chainId);
+
+      if (flowBatchCall) {
+        newCalls.push(flowBatchCall);
+      }
+    } else {
+      const batchCall = buildBatchCall(
+        [...wrapBatchOps, ...flowBatchOps],
+        chainId,
+      );
+
+      if (batchCall) {
+        newCalls.push(batchCall);
+      }
     }
 
     return newCalls;
@@ -374,6 +441,8 @@ export default function DistributionPoolFunding(props: {
     tokenUnderlyingAddress,
     underlyingTokenBalance?.decimals,
     network.id,
+    exceedsSplitterCap,
+    requiredTransferWei,
   ]);
 
   useEffect(() => {
@@ -573,6 +642,11 @@ export default function DistributionPoolFunding(props: {
                 isSuperTokenPure={isSuperTokenPure ?? false}
                 superTokenBalance={superTokenBalance}
                 underlyingTokenBalance={underlyingTokenBalance}
+                exceedsSplitterCap={exceedsSplitterCap}
+                requiredTransferWei={requiredTransferWei}
+                hasSufficientBalanceForTransfer={
+                  hasSufficientBalanceForTransfer
+                }
               />
               <Success
                 step={step}

--- a/src/app/flow-councils/components/DistributionPoolFunding.tsx
+++ b/src/app/flow-councils/components/DistributionPoolFunding.tsx
@@ -142,7 +142,7 @@ export default function DistributionPoolFunding(props: {
   const splitterBalanceNow = useFlowingAmount(
     BigInt(splitterBalanceUntilUpdatedAt ?? 0),
     splitterUpdatedAtTimestamp ?? 0,
-    BigInt(superAppFunderData?.totalInflowRate ?? 0),
+    BigInt(superAppFunderData?.totalNetFlowRate ?? 0),
   );
   const { data: ethBalance } = useBalance({
     address,
@@ -223,14 +223,15 @@ export default function DistributionPoolFunding(props: {
 
   const maxFundingRate =
     splitterBalanceNow / BigInt(SUPERFLUID_LIQUIDATION_PERIOD_SECONDS);
-  const requiredTransferWei = newFlowRate
-    ? BigInt(newFlowRate) * BigInt(SUPERFLUID_LIQUIDATION_PERIOD_SECONDS)
-    : BigInt(0);
   const exceedsSplitterCap =
     !!splitterAddress &&
     !!newFlowRate &&
     BigInt(newFlowRate) > BigInt(flowRateToReceiver) &&
     BigInt(newFlowRate) > maxFundingRate;
+  const requiredTransferWei = exceedsSplitterCap
+    ? BigInt(newFlowRate) * BigInt(SUPERFLUID_LIQUIDATION_PERIOD_SECONDS) -
+      splitterBalanceNow
+    : BigInt(0);
   const wrapAmountForTransferCheck = parseEther(
     wrapAmount?.replace(/,/g, "") ?? "0",
   );

--- a/src/app/flow-councils/hooks/superAppFundersQuery.ts
+++ b/src/app/flow-councils/hooks/superAppFundersQuery.ts
@@ -4,6 +4,7 @@ import { getApolloClient } from "@/lib/apollo";
 
 export type SuperAppFunderData = {
   totalInflowRate: string;
+  totalNetFlowRate: string;
   totalAmountStreamedInUntilUpdatedAt: string;
   updatedAtTimestamp: number;
   funderCount: number;
@@ -14,6 +15,7 @@ const SUPER_APP_FUNDERS_QUERY = gql`
     account(id: $superApp) {
       accountTokenSnapshots(where: { token: $token }) {
         totalInflowRate
+        totalNetFlowRate
         totalAmountStreamedInUntilUpdatedAt
         updatedAtTimestamp
       }
@@ -54,6 +56,7 @@ export default function useSuperAppFundersQuery(
 
   return {
     totalInflowRate: snapshot.totalInflowRate,
+    totalNetFlowRate: snapshot.totalNetFlowRate,
     totalAmountStreamedInUntilUpdatedAt:
       snapshot.totalAmountStreamedInUntilUpdatedAt,
     updatedAtTimestamp: Number(snapshot.updatedAtTimestamp),

--- a/src/components/checkout/Review.tsx
+++ b/src/components/checkout/Review.tsx
@@ -619,8 +619,8 @@ export default function Review(props: ReviewProps) {
             <Stack direction="vertical">
               <Card.Text className="text-danger small">
                 Your stream exceeds the current funding rate cap for this round.
-                You can raise the cap by including a one-time transfer equal to
-                4 hours of your proposed stream rate.
+                You can raise the cap by including a one-time transfer to cover
+                the gap between the current cap and your proposed stream rate.
               </Card.Text>
               <Stack
                 direction="horizontal"

--- a/src/components/checkout/Review.tsx
+++ b/src/components/checkout/Review.tsx
@@ -619,8 +619,8 @@ export default function Review(props: ReviewProps) {
             <Stack direction="vertical">
               <Card.Text className="text-danger small">
                 Your stream exceeds the current funding rate cap for this round.
-                You can raise the cap by including a one-time transfer to cover
-                the gap between the current cap and your proposed stream rate.
+                You can raise it by including a one-time transfer to cover the
+                gap between the current cap and your proposed stream rate.
               </Card.Text>
               <Stack
                 direction="horizontal"

--- a/src/components/checkout/Review.tsx
+++ b/src/components/checkout/Review.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { useAccount, useSwitchChain } from "wagmi";
 import { formatEther, parseEther } from "viem";
 import dayjs from "dayjs";
@@ -127,9 +127,15 @@ export default function Review(props: ReviewProps) {
   const streamLetter =
     hasWrap && hasTransfer ? "C" : hasWrap || hasTransfer ? "B" : "A";
   const transferShortfallWei =
-    requiredTransferWei -
-    superTokenBalance -
-    parseEther(wrapAmount?.replace(/,/g, "") ?? "0");
+    areTransactionsLoading && transactionDetailsSnapshot
+      ? BigInt(0)
+      : requiredTransferWei -
+        superTokenBalance -
+        parseEther(wrapAmount?.replace(/,/g, "") ?? "0");
+
+  useEffect(() => {
+    setHasAcceptedSplitterCapWarning(false);
+  }, [newFlowRate]);
 
   const { address, chain: connectedChain } = useAccount();
   const { switchChain } = useSwitchChain();

--- a/src/components/checkout/Review.tsx
+++ b/src/components/checkout/Review.tsx
@@ -51,6 +51,9 @@ export type ReviewProps = {
     symbol: string;
   };
   showQfMultiplier?: boolean;
+  exceedsSplitterCap?: boolean;
+  requiredTransferWei?: bigint;
+  hasSufficientBalanceForTransfer?: boolean;
 };
 
 type TransactionDetailsSnapshot = {
@@ -63,6 +66,8 @@ type TransactionDetailsSnapshot = {
   matchingMultiplier: number | null;
   newFlowRate: string;
   flowRateToReceiver: string;
+  exceedsSplitterCap: boolean;
+  requiredTransferWei: bigint;
 };
 
 export default function Review(props: ReviewProps) {
@@ -89,6 +94,9 @@ export default function Review(props: ReviewProps) {
     superTokenBalance,
     underlyingTokenBalance,
     showQfMultiplier,
+    exceedsSplitterCap = false,
+    requiredTransferWei = BigInt(0),
+    hasSufficientBalanceForTransfer = true,
   } = props;
 
   const [transactionDetailsSnapshot, setTransactionDetailsSnapshot] =
@@ -97,6 +105,31 @@ export default function Review(props: ReviewProps) {
     hasAcceptedCloseLiquidationWarning,
     setHasAcceptedCloseLiquidationWarning,
   ] = useState(false);
+  const [
+    hasAcceptedSplitterCapWarning,
+    setHasAcceptedSplitterCapWarning,
+  ] = useState(false);
+
+  const wrapAmountForDisplay =
+    areTransactionsLoading && transactionDetailsSnapshot
+      ? transactionDetailsSnapshot.wrapAmount
+      : wrapAmount?.replace(/,/g, "");
+  const hasWrap = Number(wrapAmountForDisplay ?? "0") > 0;
+  const hasTransfer =
+    areTransactionsLoading && transactionDetailsSnapshot
+      ? transactionDetailsSnapshot.exceedsSplitterCap
+      : exceedsSplitterCap;
+  const transferWeiForDisplay =
+    areTransactionsLoading && transactionDetailsSnapshot
+      ? transactionDetailsSnapshot.requiredTransferWei
+      : requiredTransferWei;
+  const transferLetter = hasWrap ? "B" : "A";
+  const streamLetter =
+    hasWrap && hasTransfer ? "C" : hasWrap || hasTransfer ? "B" : "A";
+  const transferShortfallWei =
+    requiredTransferWei -
+    superTokenBalance -
+    parseEther(wrapAmount?.replace(/,/g, "") ?? "0");
 
   const { address, chain: connectedChain } = useAccount();
   const { switchChain } = useSwitchChain();
@@ -134,6 +167,8 @@ export default function Review(props: ReviewProps) {
       netImpact,
       newFlowRate,
       flowRateToReceiver,
+      exceedsSplitterCap,
+      requiredTransferWei,
     });
 
     try {
@@ -302,15 +337,30 @@ export default function Review(props: ReviewProps) {
               </Card.Text>
             </Stack>
           )}
+          {hasTransfer && (
+            <Stack direction="vertical" gap={1}>
+              <Card.Text className="border-bottom border-secondary mb-2 pb-1">
+                {transferLetter}. One-Time Transfer
+              </Card.Text>
+              <Stack
+                direction="vertical"
+                gap={2}
+                className="justify-content-center align-items-center bg-white p-4 rounded-4"
+              >
+                <Image src={token.icon} alt="" width={28} height={28} />
+                <Card.Text className="m-0 border-0 text-center fs-lg fw-semi-bold">
+                  {formatNumber(Number(formatEther(transferWeiForDisplay)))}{" "}
+                  {token.symbol}
+                </Card.Text>
+                <Card.Text className="border-0 text-center text-secondary small mb-0">
+                  Sent to round pool to raise the funding rate cap
+                </Card.Text>
+              </Stack>
+            </Stack>
+          )}
           <Stack direction="vertical" gap={1}>
             <Card.Text className="border-bottom border-secondary m-0 pb-1">
-              {Number(
-                areTransactionsLoading && transactionDetailsSnapshot
-                  ? transactionDetailsSnapshot.wrapAmount
-                  : wrapAmount?.replace(/,/g, ""),
-              ) > 0
-                ? "B."
-                : "A."}{" "}
+              {streamLetter}.{" "}
               {isFundingDistributionPool
                 ? "Edit Matching Stream"
                 : "Edit Grantee Stream"}
@@ -559,6 +609,41 @@ export default function Review(props: ReviewProps) {
               </Card.Text>
             </Stack>
           )}
+          {exceedsSplitterCap && (
+            <Stack direction="vertical">
+              <Card.Text className="text-danger small">
+                Your stream exceeds the current funding rate cap for this round.
+                You can raise the cap by including a one-time transfer equal to
+                4 hours of your proposed stream rate.
+              </Card.Text>
+              <Stack
+                direction="horizontal"
+                gap={2}
+                className="align-items-center"
+              >
+                <FormCheckInput
+                  checked={hasAcceptedSplitterCapWarning}
+                  disabled={!hasSufficientBalanceForTransfer}
+                  className="border-black"
+                  onChange={() =>
+                    setHasAcceptedSplitterCapWarning(
+                      !hasAcceptedSplitterCapWarning,
+                    )
+                  }
+                />
+                <Card.Text className="text-danger small mb-0">
+                  Continue?
+                </Card.Text>
+              </Stack>
+              {!hasSufficientBalanceForTransfer && transferShortfallWei > 0 && (
+                <Card.Text className="text-danger small mt-1 mb-0">
+                  Top up an additional{" "}
+                  {formatNumber(Number(formatEther(transferShortfallWei)))}{" "}
+                  {token.symbol} to enable.
+                </Card.Text>
+              )}
+            </Stack>
+          )}
           {isLiquidationClose && (
             <Stack direction="vertical">
               <Card.Text className="text-danger small">
@@ -592,7 +677,8 @@ export default function Review(props: ReviewProps) {
             disabled={
               calls.length === 0 ||
               step === Step.SUCCESS ||
-              (isLiquidationClose && !hasAcceptedCloseLiquidationWarning)
+              (isLiquidationClose && !hasAcceptedCloseLiquidationWarning) ||
+              (exceedsSplitterCap && !hasAcceptedSplitterCapWarning)
             }
             className="d-flex justify-content-center mt-4 py-4 rounded-4 fw-semi-bold text-light"
             onClick={

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -3,6 +3,7 @@ import { Address } from "viem";
 export const DEFAULT_CHAIN_ID = 8453;
 export const DEFAULT_POOL_ID = "63";
 export const SECONDS_IN_MONTH = 2628000;
+export const SUPERFLUID_LIQUIDATION_PERIOD_SECONDS = 4 * 60 * 60;
 export const SUPERFLUID_CALL_AGREEMENT_OPERATION = 201;
 export const MAX_FLOW_RATE = BigInt("0x7fffffffffffffffffffffff"); //  96bit signed int max
 export const UINT256_MAX = BigInt(


### PR DESCRIPTION
## Summary
- Detect when proposed stream rate × 4h exceeds the splitter's available SuperToken balance and surface a warning + "Continue?" checkbox at the Review step.
- Batch a one-time `superToken.transfer(splitter, 4h × flowRate)` between the wrap and the createFlow batchCall, gating submit until the user acknowledges.
- Disable the checkbox (with a "top up X more" hint) when the user's combined SuperToken + wrap can't cover the transfer.

## Test plan
- [x] `pnpm lint && pnpm typecheck`
- [x] `pnpm test` (168/168)
- [x] Manual: low-balance splitter → warning + checkbox visible, submit disabled until checked
- [x] Manual: sufficient balance → sign and verify the wallet preview shows `superToken.transfer` between wrap and createFlow
- [x] Manual: rate below cap → none of the new UI appears