### PR TITLE
fix: email preferences follow-ups

### DIFF
--- a/prisma/migrations/20260520000000_drop_user_profiles_email_unique/migration.sql
+++ b/prisma/migrations/20260520000000_drop_user_profiles_email_unique/migration.sql
@@ -1,0 +1,4 @@
+-- Drop the partial unique index on user_profiles.email.
+-- Multiple wallet addresses are allowed to share an email; the SES bounce
+-- handler already suspends every row matching a bounced address.
+DROP INDEX IF EXISTS "user_profiles_email_unique";

--- a/src/app/api/flow-council/inbox/route.ts
+++ b/src/app/api/flow-council/inbox/route.ts
@@ -72,10 +72,18 @@ export async function GET(request: Request) {
     // Join applications → rounds so application-linked items can build a
     // valid deep link (/flow-councils/review/[chainId]/[councilId]). The
     // inbox_items table only carries the application_id FK, not chain/council.
+    // Also join projectManagers (scoped to this recipient) so the client can
+    // route project managers to the comms channel instead of the admin-only
+    // recipient review page.
     let query = db
       .selectFrom("inboxItems")
       .leftJoin("applications", "applications.id", "inboxItems.applicationId")
       .leftJoin("rounds", "rounds.id", "applications.roundId")
+      .leftJoin("projectManagers", (join) =>
+        join
+          .onRef("projectManagers.projectId", "=", "applications.projectId")
+          .on("projectManagers.managerAddress", "=", address),
+      )
       .select([
         "inboxItems.id",
         "inboxItems.recipientAddress",
@@ -88,6 +96,8 @@ export async function GET(request: Request) {
         "inboxItems.createdAt",
         "rounds.chainId as reviewChainId",
         "rounds.flowCouncilAddress as reviewCouncilId",
+        "applications.projectId as reviewProjectId",
+        sql<boolean>`project_managers.id IS NOT NULL`.as("isProjectManager"),
       ])
       .where("inboxItems.recipientAddress", "=", address)
       .orderBy("inboxItems.id", "desc")

--- a/src/app/api/flow-council/preferences/route.ts
+++ b/src/app/api/flow-council/preferences/route.ts
@@ -51,6 +51,8 @@ function buildPreferencesPayload(row: {
   notifyPlatform: boolean;
   emailSuspendedAt: Date | null;
   emailSuspensionReason: string | null;
+  email?: string | null;
+  displayName?: string | null;
 }) {
   return {
     success: true,
@@ -63,6 +65,8 @@ function buildPreferencesPayload(row: {
     },
     emailSuspendedAt: row.emailSuspendedAt,
     emailSuspensionReason: row.emailSuspensionReason,
+    email: row.email ?? null,
+    displayName: row.displayName ?? null,
   };
 }
 
@@ -92,6 +96,8 @@ export async function GET(request: Request) {
         "notifyPlatform",
         "emailSuspendedAt",
         "emailSuspensionReason",
+        "email",
+        "displayName",
       ])
       .where("address", "=", address)
       .executeTakeFirst();

--- a/src/app/api/flow-council/preferences/unsubscribe/one-click/route.ts
+++ b/src/app/api/flow-council/preferences/unsubscribe/one-click/route.ts
@@ -11,8 +11,8 @@ export const dynamic = "force-dynamic";
 // `List-Unsubscribe=One-Click` form field.
 //
 // This path takes no user confirmation — that is the point of one-click —
-// so it is deliberately separate from the body-link flow on
-// /preferences?action=unsubscribe, which now renders a confirmation card.
+// so it is deliberately separate from the in-app preferences page where
+// the user can selectively manage subscriptions.
 
 const MAX_BODY_SIZE = 1_000;
 

--- a/src/app/api/flow-council/profile/route.integration.test.ts
+++ b/src/app/api/flow-council/profile/route.integration.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+
+vi.mock("next-auth/next", () => ({
+  getServerSession: vi.fn(),
+}));
+
+vi.mock("@/app/api/auth/[...nextauth]/route", () => ({ authOptions: {} }));
+
+vi.mock("../db", async () => {
+  const { getTestDb } = await import("@tests/helpers/db");
+  return { db: getTestDb() };
+});
+
+import { PUT } from "./route";
+import { getTestDb, resetDb } from "@tests/helpers/db";
+import { mockSession } from "@tests/helpers/session";
+
+const db = getTestDb();
+
+const ADDRESS = "0x2228e3cf25283be159643976665384215875f6a8";
+
+afterAll(async () => {
+  await resetDb(db);
+  await db.destroy();
+});
+
+beforeEach(async () => {
+  await resetDb(db);
+});
+
+async function readJson(res: Response) {
+  return JSON.parse(await res.text());
+}
+
+describe("PUT /api/flow-council/profile — reproduce graven 500", () => {
+  it("upserts first-time email + consent + prefs on a row that already exists with email=null", async () => {
+    // Seed the row in the same shape we observed in prod for 0x2228...:
+    // an existing user_profiles row with email=null, consentConfirmedAt=null,
+    // and a display name set.
+    await db
+      .insertInto("userProfiles")
+      .values({
+        address: ADDRESS,
+        displayName: "Testing Wallet 2",
+      })
+      .execute();
+
+    mockSession(ADDRESS);
+
+    const payload = {
+      displayName: "Testing Wallet 2",
+      bio: "",
+      twitter: "",
+      github: "",
+      linkedin: "",
+      farcaster: "",
+      email: "graven@flowstate.network",
+      telegram: "",
+      consentConfirmedAt: new Date().toISOString(),
+      consentVersion: "2026-05-13",
+      notifyApplicationEligibility: true,
+      notifyProjectChannels: true,
+      notifyRoundAnnouncements: true,
+      notifyInternalReview: true,
+      notifyPlatform: true,
+    };
+
+    const res = await PUT(
+      new Request("http://localhost/api/flow-council/profile", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      }),
+    );
+
+    const body = await readJson(res);
+    expect({ status: res.status, body }).toEqual({
+      status: 200,
+      body: expect.objectContaining({ success: true }),
+    });
+  });
+});

--- a/src/app/api/flow-council/profile/route.ts
+++ b/src/app/api/flow-council/profile/route.ts
@@ -216,11 +216,12 @@ export async function PUT(request: Request) {
     }
 
     if (shouldBumpEmailVersion) {
-      // Use a raw SQL expression so the increment is atomic at the SQL
-      // level (rather than computing `current + 1` in JS). The cast is
-      // necessary because Updateable narrows to the column type — Kysely
-      // accepts the raw expression at runtime via doUpdateSet.
-      updateSet.emailVersion = sql<number>`email_version + 1` as unknown as number;
+      // Atomic increment at the SQL level. The column must be qualified —
+      // inside `ON CONFLICT ... DO UPDATE SET`, an unqualified `email_version`
+      // is ambiguous (target row vs. EXCLUDED tuple) and Postgres aborts with
+      // 42702. `user_profiles.email_version` is the pre-update value, which
+      // is what we want to increment.
+      updateSet.emailVersion = sql<number>`user_profiles.email_version + 1` as unknown as number;
     }
 
     const profile = await db

--- a/src/app/api/flow-council/ses.ts
+++ b/src/app/api/flow-council/ses.ts
@@ -33,17 +33,9 @@ export function buildPrefsLink(
   return `${baseUrl}/preferences?address=${encodeURIComponent(address)}&token=${encodeURIComponent(token)}`;
 }
 
-export function buildUnsubscribeLink(
-  baseUrl: string,
-  address: string,
-  token: string,
-): string {
-  return `${baseUrl}/preferences?address=${encodeURIComponent(address)}&token=${encodeURIComponent(token)}&action=unsubscribe`;
-}
-
 // RFC 8058 one-click target. Mail clients POST here server-to-server (no
 // browser), so it's immune to the prefetch/scanner footgun that the
-// in-page confirmation card guards against for the body link.
+// in-page Unsubscribe-from-all button guards against.
 export function buildOneClickUnsubscribeLink(
   baseUrl: string,
   address: string,
@@ -61,11 +53,6 @@ export async function sendPersonalizedEmail(
   const data = {
     ...templateData,
     prefsLink: buildPrefsLink(baseUrl, recipient.address, recipient.token),
-    unsubscribeLink: buildUnsubscribeLink(
-      baseUrl,
-      recipient.address,
-      recipient.token,
-    ),
   };
 
   const oneClickLink = buildOneClickUnsubscribeLink(

--- a/src/app/api/flow-council/validation.ts
+++ b/src/app/api/flow-council/validation.ts
@@ -4,19 +4,16 @@ import { CHARACTER_LIMITS, MAX_MILESTONES } from "@/app/flow-councils/constants"
 import { ALLOWED_REACTIONS } from "@/app/flow-councils/lib/constants";
 import { STRUCTURAL_TYPES } from "@/app/flow-councils/types/formSchema";
 import { normalizeUrl } from "@/app/flow-councils/utils/normalizeUrl";
+import { isValidEmail } from "@/lib/email";
 import type {
   TeamMember,
   BuildMilestone,
   GrowthMilestone,
 } from "@/app/flow-councils/types/round";
 
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+export { isValidEmail } from "@/lib/email";
 
 export const MAX_STRING_LENGTH = 10_000;
-
-export function isValidEmail(value: string): boolean {
-  return EMAIL_REGEX.test(value);
-}
 
 const smartContractSchema = z.object({
   type: z.enum(["projectAddress", "goodCollectivePool"]),

--- a/src/app/flow-councils/communications/[chainId]/[councilId]/communications.tsx
+++ b/src/app/flow-councils/communications/[chainId]/[councilId]/communications.tsx
@@ -295,13 +295,6 @@ export default function Communications(props: CommunicationsProps) {
           </Stack>
         </>
       )}
-      <Button
-        variant="secondary"
-        className="py-4 rounded-4 fs-lg fw-semi-bold mt-4"
-        onClick={() => router.push(`/flow-councils/${chainId}/${councilId}`)}
-      >
-        Next
-      </Button>
     </Stack>
   );
 }

--- a/src/app/flow-councils/components/AttestationTab.tsx
+++ b/src/app/flow-councils/components/AttestationTab.tsx
@@ -9,7 +9,7 @@ import Button from "react-bootstrap/Button";
 import Spinner from "react-bootstrap/Spinner";
 import Toast from "react-bootstrap/Toast";
 import useRequireAuth from "@/hooks/requireAuth";
-import { isValidEmail } from "@/app/api/flow-council/validation";
+import { isValidEmail } from "@/lib/email";
 import {
   type RoundForm,
   type AttestationForm,

--- a/src/app/inbox/InboxPage.tsx
+++ b/src/app/inbox/InboxPage.tsx
@@ -33,6 +33,8 @@ type InboxItem = {
   createdAt: string;
   reviewChainId: number | null;
   reviewCouncilId: string | null;
+  reviewProjectId: number | null;
+  isProjectManager: boolean;
 };
 
 type InboxResponse = {
@@ -77,11 +79,13 @@ function formatTimestamp(value: string): string {
 }
 
 function getItemHref(item: InboxItem): string | null {
-  if (
-    item.applicationId != null &&
-    item.reviewChainId != null &&
-    item.reviewCouncilId != null
-  ) {
+  if (item.reviewChainId == null || item.reviewCouncilId == null) return null;
+  // Project managers can't access the admin-only recipient review page —
+  // send them to their project's comms channel instead.
+  if (item.isProjectManager && item.reviewProjectId != null) {
+    return `/flow-councils/communications/${item.reviewChainId}/${item.reviewCouncilId}?channel=${item.reviewProjectId}`;
+  }
+  if (item.applicationId != null) {
     return `/flow-councils/review/${item.reviewChainId}/${item.reviewCouncilId}?applicationId=${item.applicationId}`;
   }
   return null;

--- a/src/app/preferences/PreferencesPage.tsx
+++ b/src/app/preferences/PreferencesPage.tsx
@@ -23,6 +23,8 @@ type PreferencesResponse = {
   preferences: Preferences;
   emailSuspendedAt: string | null;
   emailSuspensionReason: string | null;
+  email: string | null;
+  displayName: string | null;
   // POST responses rotate the token (email_version bumps on every
   // mutation). GET responses omit it.
   token?: string;
@@ -54,6 +56,25 @@ const ALL_OFF: Preferences = {
   notifyPlatform: false,
 };
 
+function redactAddress(address: string): string {
+  return `***${address.slice(-4)}`;
+}
+
+function redactEmail(email: string): string {
+  const atIdx = email.indexOf("@");
+  if (atIdx <= 0) return "***";
+  const local = email.slice(0, atIdx);
+  const domain = email.slice(atIdx);
+  const visible = local.slice(0, Math.min(2, local.length));
+  return `${visible}***${domain}`;
+}
+
+function redactName(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) return "";
+  return `${trimmed.slice(0, Math.min(2, trimmed.length))}***`;
+}
+
 export default function PreferencesPage() {
   const searchParams = useSearchParams();
   const address = searchParams.get("address");
@@ -62,12 +83,12 @@ export default function PreferencesPage() {
   // mutations so an open page keeps working; the GET on mount still uses
   // the immutable URL token (it runs before any mutation).
   const urlToken = searchParams.get("token");
-  const action = searchParams.get("action");
-  const isUnsubscribeAction = action === "unsubscribe";
 
   const [currentToken, setCurrentToken] = useState<string | null>(urlToken);
-  const [isLoading, setIsLoading] = useState(!isUnsubscribeAction);
+  const [isLoading, setIsLoading] = useState(true);
   const [preferences, setPreferences] = useState<Preferences | null>(null);
+  const [email, setEmail] = useState<string | null>(null);
+  const [displayName, setDisplayName] = useState<string | null>(null);
   const [emailSuspendedAt, setEmailSuspendedAt] = useState<string | null>(null);
   const [errorKind, setErrorKind] = useState<ErrorKind>(null);
   const [savingField, setSavingField] = useState<keyof Preferences | null>(
@@ -75,7 +96,6 @@ export default function PreferencesPage() {
   );
   const [isUnsubscribing, setIsUnsubscribing] = useState(false);
   const [unsubscribed, setUnsubscribed] = useState(false);
-  const [showDetails, setShowDetails] = useState(false);
   const [actionError, setActionError] = useState<string>("");
 
   const fetchPreferences = useCallback(
@@ -107,6 +127,8 @@ export default function PreferencesPage() {
         const data = (await res.json()) as PreferencesResponse;
         setPreferences(data.preferences);
         setEmailSuspendedAt(data.emailSuspendedAt);
+        setEmail(data.email);
+        setDisplayName(data.displayName);
         setErrorKind(null);
       } catch (err) {
         console.error(err);
@@ -118,58 +140,9 @@ export default function PreferencesPage() {
     [address],
   );
 
-  // Unsubscribe-action flow: do NOT auto-POST on mount. Auto-unsubscribing
-  // here is the classic RFC 8058 footgun — link prefetchers, scanners and
-  // mail-security detonation chambers would silently fire the POST. We only
-  // validate params; the actual unsubscribe happens on explicit click of
-  // the confirmation button. Native mail-client "Unsubscribe" buttons go to
-  // the dedicated one-click endpoint instead (see ses.ts headers).
   useEffect(() => {
-    if (!isUnsubscribeAction) return;
-    if (!address || !urlToken) {
-      setErrorKind("missing");
-    }
-  }, [isUnsubscribeAction, address, urlToken]);
-
-  // Default flow: fetch preferences on mount.
-  useEffect(() => {
-    if (isUnsubscribeAction) return;
     fetchPreferences(urlToken);
-  }, [isUnsubscribeAction, fetchPreferences, urlToken]);
-
-  const confirmUnsubscribe = async () => {
-    if (!address || !currentToken) return;
-    setActionError("");
-    setIsUnsubscribing(true);
-    try {
-      const res = await fetch("/api/flow-council/preferences/unsubscribe", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ token: currentToken, address }),
-      });
-      if (res.status === 403) {
-        setErrorKind("invalid");
-        return;
-      }
-      if (res.status === 404) {
-        setErrorKind("notfound");
-        return;
-      }
-      if (!res.ok) {
-        setActionError("Failed to unsubscribe. Please try again.");
-        return;
-      }
-      const data = (await res.json()) as UnsubscribeResponse;
-      setCurrentToken(data.token);
-      setUnsubscribed(true);
-      setPreferences(ALL_OFF);
-    } catch (err) {
-      console.error(err);
-      setActionError("Failed to unsubscribe. Please try again.");
-    } finally {
-      setIsUnsubscribing(false);
-    }
-  };
+  }, [fetchPreferences, urlToken]);
 
   const handleToggle = async (field: keyof Preferences, newValue: boolean) => {
     if (!address || !currentToken || !preferences) return;
@@ -248,7 +221,7 @@ export default function PreferencesPage() {
 
   if (errorKind === "missing") {
     return (
-      <Container className="py-5" style={{ maxWidth: 600 }}>
+      <Container className="py-5" style={{ maxWidth: 800 }}>
         <h2 className="mb-4">Email Preferences</h2>
         <Alert variant="danger">
           This preferences link is missing required parameters.
@@ -259,7 +232,7 @@ export default function PreferencesPage() {
 
   if (errorKind === "invalid") {
     return (
-      <Container className="py-5" style={{ maxWidth: 600 }}>
+      <Container className="py-5" style={{ maxWidth: 800 }}>
         <h2 className="mb-4">Email Preferences</h2>
         <Alert variant="danger">
           This preferences link is invalid or has expired. Please request a new
@@ -271,7 +244,7 @@ export default function PreferencesPage() {
 
   if (errorKind === "notfound") {
     return (
-      <Container className="py-5" style={{ maxWidth: 600 }}>
+      <Container className="py-5" style={{ maxWidth: 800 }}>
         <h2 className="mb-4">Email Preferences</h2>
         <Alert variant="danger">No profile found for this address.</Alert>
       </Container>
@@ -280,7 +253,7 @@ export default function PreferencesPage() {
 
   if (errorKind === "server") {
     return (
-      <Container className="py-5" style={{ maxWidth: 600 }}>
+      <Container className="py-5" style={{ maxWidth: 800 }}>
         <h2 className="mb-4">Email Preferences</h2>
         <Alert variant="danger">
           Something went wrong. Please try again later.
@@ -289,61 +262,6 @@ export default function PreferencesPage() {
     );
   }
 
-  // Unsubscribe-action: explicit confirmation before any POST (RFC 8058).
-  if (isUnsubscribeAction && !unsubscribed) {
-    return (
-      <Container className="py-5" style={{ maxWidth: 600 }}>
-        <h2 className="mb-4">Email Preferences</h2>
-        <Card className="bg-lace-100 rounded-4 border-0 p-4">
-          <h5 className="fw-bold mb-3">Unsubscribe from all notifications?</h5>
-          <p className="text-muted mb-4">
-            You&apos;ll stop receiving all email notifications from Flow State.
-            You can re-enable individual notification types afterwards.
-          </p>
-          {actionError && (
-            <Alert variant="danger" className="mb-3">
-              {actionError}
-            </Alert>
-          )}
-          <Button
-            variant="danger"
-            className="rounded-3"
-            onClick={confirmUnsubscribe}
-          >
-            Confirm unsubscribe
-          </Button>
-        </Card>
-      </Container>
-    );
-  }
-
-  // Unsubscribe confirmation (before user opts to view details).
-  if (isUnsubscribeAction && unsubscribed && !showDetails) {
-    return (
-      <Container className="py-5" style={{ maxWidth: 600 }}>
-        <h2 className="mb-4">Email Preferences</h2>
-        <Alert variant="success">
-          You&apos;ve been unsubscribed from all notifications.
-        </Alert>
-        <Button
-          variant="outline-primary"
-          className="rounded-3"
-          onClick={() => {
-            setShowDetails(true);
-            // Re-fetch so the displayed state (incl. emailSuspendedAt) is
-            // authoritative rather than assumed from ALL_OFF. The URL token
-            // is stale post-unsubscribe (email_version bumped), so use the
-            // rotated currentToken.
-            fetchPreferences(currentToken);
-          }}
-        >
-          View detailed preferences
-        </Button>
-      </Container>
-    );
-  }
-
-  // Detailed preferences view (default flow or after unsubscribe confirmation)
   if (!preferences) {
     return (
       <Container className="py-5 d-flex justify-content-center">
@@ -352,9 +270,20 @@ export default function PreferencesPage() {
     );
   }
 
+  const redactedParts = [
+    address ? redactAddress(address) : null,
+    email ? redactEmail(email) : null,
+    displayName ? redactName(displayName) : null,
+  ].filter((part): part is string => Boolean(part));
+
   return (
-    <Container className="py-5" style={{ maxWidth: 600 }}>
-      <h2 className="mb-4">Email Preferences</h2>
+    <Container className="py-5" style={{ maxWidth: 800 }}>
+      <h2 className="mb-2">Email Preferences</h2>
+      {redactedParts.length > 0 && (
+        <p className="text-muted small mb-4">
+          Editing preferences for {redactedParts.join(" · ")}
+        </p>
+      )}
 
       {unsubscribed && (
         <Alert variant="success">

--- a/src/components/AccountDropdown.tsx
+++ b/src/components/AccountDropdown.tsx
@@ -1,6 +1,9 @@
+import { useEffect, useRef, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { useDisconnect } from "wagmi";
+import { useSession } from "next-auth/react";
 import Dropdown from "react-bootstrap/Dropdown";
 import Stack from "react-bootstrap/Stack";
 import { useMediaQuery } from "@/hooks/mediaQuery";
@@ -16,6 +19,46 @@ export default function AccountDropdown({
   const { disconnect } = useDisconnect();
   const { isMobile } = useMediaQuery();
   const { displayName: profileDisplayName } = useProfileDisplayName();
+  const { status: sessionStatus } = useSession();
+  const isAuthenticated = sessionStatus === "authenticated";
+  const pathname = usePathname();
+
+  const [inboxUnreadCount, setInboxUnreadCount] = useState(0);
+  const lastUnreadFetchRef = useRef(0);
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      setInboxUnreadCount(0);
+      lastUnreadFetchRef.current = 0;
+      return;
+    }
+    let cancelled = false;
+    const refetch = async (force = false) => {
+      // Throttle navigation-triggered re-syncs: pathname is a dep so the
+      // effect re-runs on every client-side navigation. The
+      // inbox:unread-changed event passes force=true to bypass the window.
+      const now = Date.now();
+      if (!force && now - lastUnreadFetchRef.current < 30_000) return;
+      lastUnreadFetchRef.current = now;
+      try {
+        const res = await fetch("/api/flow-council/inbox/unread-count");
+        if (!res.ok) return;
+        const data = await res.json();
+        if (!cancelled && typeof data?.unreadCount === "number") {
+          setInboxUnreadCount(data.unreadCount);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    refetch();
+    const onUnreadChanged = () => refetch(true);
+    window.addEventListener("inbox:unread-changed", onUnreadChanged);
+    return () => {
+      cancelled = true;
+      window.removeEventListener("inbox:unread-changed", onUnreadChanged);
+    };
+  }, [isAuthenticated, pathname]);
 
   const nameElement = (
     <span className="fw-semi-bold sensitive">
@@ -23,31 +66,64 @@ export default function AccountDropdown({
     </span>
   );
 
+  const hasUnread = inboxUnreadCount > 0;
+
   return (
     <Dropdown align={{ md: "start" }}>
       <Dropdown.Toggle
         bsPrefix="dropdown"
         variant="outline-dark"
-        className="d-flex align-items-center gap-1 px-10 py-4 border-4 rounded-4"
+        className="d-flex align-items-center gap-2 px-10 py-4 border-4 rounded-4"
         style={{ whiteSpace: "nowrap" }}
       >
-        <span
-          className="icon-currentcolor"
-          role="img"
-          aria-label="account"
-          style={{
-            width: 18,
-            height: 18,
-            WebkitMaskImage: "url(/account-circle.svg)",
-            maskImage: "url(/account-circle.svg)",
-          }}
-        />
+        {hasUnread ? (
+          <span
+            className="d-inline-flex align-items-center justify-content-center fw-bold text-white bg-danger rounded-circle"
+            style={{ width: 22, height: 22, fontSize: 12, lineHeight: 1 }}
+            aria-label={`${inboxUnreadCount} unread`}
+          >
+            {inboxUnreadCount > 99 ? "99+" : inboxUnreadCount}
+          </span>
+        ) : (
+          <span
+            className="icon-currentcolor"
+            role="img"
+            aria-label="account"
+            style={{
+              width: 18,
+              height: 18,
+              WebkitMaskImage: "url(/account-circle.svg)",
+              maskImage: "url(/account-circle.svg)",
+            }}
+          />
+        )}
         {(!hideNameOnMobile || !isMobile) && nameElement}
       </Dropdown.Toggle>
       <Dropdown.Menu className="py-0 border-4 border-dark overflow-hidden">
         <Link href="/profile" className="text-decoration-none">
           <Dropdown.Item as="span" className="p-3 fw-semi-bold text-dark">
             Profile
+          </Dropdown.Item>
+        </Link>
+        <Link href="/inbox" className="text-decoration-none">
+          <Dropdown.Item
+            as="span"
+            className="p-3 fw-semi-bold text-dark d-flex align-items-center gap-2"
+          >
+            Inbox
+            {hasUnread && (
+              <span
+                className="d-inline-flex align-items-center justify-content-center fw-bold text-white bg-danger rounded-circle"
+                style={{
+                  width: 22,
+                  height: 22,
+                  fontSize: 12,
+                  lineHeight: 1,
+                }}
+              >
+                {inboxUnreadCount > 99 ? "99+" : inboxUnreadCount}
+              </span>
+            )}
           </Dropdown.Item>
         </Link>
         <Link href="/projects" className="text-decoration-none">

--- a/src/components/AccountDropdown.tsx
+++ b/src/components/AccountDropdown.tsx
@@ -9,6 +9,24 @@ import Stack from "react-bootstrap/Stack";
 import { useMediaQuery } from "@/hooks/mediaQuery";
 import { useProfileDisplayName } from "@/hooks/useProfileDisplayName";
 
+function UnreadBadge({
+  count,
+  ariaLabel,
+}: {
+  count: number;
+  ariaLabel?: string;
+}) {
+  return (
+    <span
+      className="d-inline-flex align-items-center justify-content-center fw-bold text-white bg-danger rounded-circle"
+      style={{ width: 22, height: 22, fontSize: 12, lineHeight: 1 }}
+      aria-label={ariaLabel}
+    >
+      {count > 99 ? "99+" : count}
+    </span>
+  );
+}
+
 export default function AccountDropdown({
   fallbackDisplayName,
   hideNameOnMobile,
@@ -77,13 +95,10 @@ export default function AccountDropdown({
         style={{ whiteSpace: "nowrap" }}
       >
         {hasUnread ? (
-          <span
-            className="d-inline-flex align-items-center justify-content-center fw-bold text-white bg-danger rounded-circle"
-            style={{ width: 22, height: 22, fontSize: 12, lineHeight: 1 }}
-            aria-label={`${inboxUnreadCount} unread`}
-          >
-            {inboxUnreadCount > 99 ? "99+" : inboxUnreadCount}
-          </span>
+          <UnreadBadge
+            count={inboxUnreadCount}
+            ariaLabel={`${inboxUnreadCount} unread`}
+          />
         ) : (
           <span
             className="icon-currentcolor"
@@ -111,19 +126,7 @@ export default function AccountDropdown({
             className="p-3 fw-semi-bold text-dark d-flex align-items-center gap-2"
           >
             Inbox
-            {hasUnread && (
-              <span
-                className="d-inline-flex align-items-center justify-content-center fw-bold text-white bg-danger rounded-circle"
-                style={{
-                  width: 22,
-                  height: 22,
-                  fontSize: 12,
-                  lineHeight: 1,
-                }}
-              >
-                {inboxUnreadCount > 99 ? "99+" : inboxUnreadCount}
-              </span>
-            )}
+            {hasUnread && <UnreadBadge count={inboxUnreadCount} />}
           </Dropdown.Item>
         </Link>
         <Link href="/projects" className="text-decoration-none">

--- a/src/components/ConsentGate.tsx
+++ b/src/components/ConsentGate.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useSession } from "next-auth/react";
 import { Modal, Button, Form } from "react-bootstrap";
 import { CONSENT_TEXT, CONSENT_VERSION } from "@/lib/consent";
+import { isValidEmail } from "@/app/api/flow-council/validation";
 
 // Shape of the profile returned by GET /api/flow-council/profile?includePrivate=true
 // for the authenticated owner. `emailVersion` is intentionally excluded server-side
@@ -37,6 +38,7 @@ export default function ConsentGate() {
 
   const [show, setShow] = useState(false);
   const [profile, setProfile] = useState<ProfileShape | null>(null);
+  const [email, setEmail] = useState("");
   const [consentChecked, setConsentChecked] = useState(false);
   const [notifyApplicationEligibility, setNotifyApplicationEligibility] =
     useState(true);
@@ -81,11 +83,12 @@ export default function ConsentGate() {
 
         const p = json.profile;
 
-        // Only prompt when user has an email on file but hasn't confirmed
-        // consent yet. No email → handled inline on Profile page. Already
-        // consented → nothing to do.
-        if (p.email !== null && p.consentConfirmedAt === null) {
+        // Prompt whenever consent hasn't been recorded yet. If the user has
+        // no email on file, the modal collects it inline; otherwise the
+        // field is pre-filled and editable.
+        if (p.consentConfirmedAt === null) {
           setProfile(p);
+          setEmail(p.email ?? "");
           setShow(true);
         }
       } catch {
@@ -111,22 +114,34 @@ export default function ConsentGate() {
   const handleSave = async () => {
     if (!profile || !consentChecked) return;
 
+    const trimmedEmail = email.trim();
+    if (!trimmedEmail) {
+      setError("Please enter your email address.");
+      return;
+    }
+    if (!isValidEmail(trimmedEmail)) {
+      setError("Please enter a valid email address.");
+      return;
+    }
+
     setSaving(true);
     setError(null);
 
     try {
       // PUT is a full upsert — pass existing identity/social fields through
       // unchanged so they aren't cleared. Server-managed fields (`address`,
-      // `emailSuspendedAt`, `emailSuspensionReason`) are not sent.
+      // `emailSuspendedAt`, `emailSuspensionReason`) are not sent. The Zod
+      // schema rejects null for string fields, so empty/missing values are
+      // sent as "" rather than null.
       const body = {
         displayName: profile.displayName,
-        bio: profile.bio,
-        twitter: profile.twitter,
-        github: profile.github,
-        linkedin: profile.linkedin,
-        farcaster: profile.farcaster,
-        email: profile.email,
-        telegram: profile.telegram,
+        bio: profile.bio ?? "",
+        twitter: profile.twitter ?? "",
+        github: profile.github ?? "",
+        linkedin: profile.linkedin ?? "",
+        farcaster: profile.farcaster ?? "",
+        email: trimmedEmail,
+        telegram: profile.telegram ?? "",
         consentConfirmedAt: new Date().toISOString(),
         consentVersion: CONSENT_VERSION,
         notifyApplicationEligibility,
@@ -173,14 +188,25 @@ export default function ConsentGate() {
 
   return (
     <Modal show={show} backdrop="static" keyboard={false} centered>
-      <Modal.Header>
+      <Modal.Header className="px-4 pt-4 pb-2 border-0">
         <Modal.Title>Email notification preferences</Modal.Title>
       </Modal.Header>
-      <Modal.Body>
+      <Modal.Body className="px-4 py-3">
         <p>
           We&apos;ve updated how email notifications work. Please confirm your
           email and choose what you want to hear about.
         </p>
+        <Form.Group className="mb-3" controlId="consent-modal-email">
+          <Form.Label>Email address</Form.Label>
+          <Form.Control
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="your@email.com"
+            autoComplete="email"
+            required
+          />
+        </Form.Group>
         <Form.Check
           type="checkbox"
           id="consent-modal-checkbox"
@@ -230,7 +256,7 @@ export default function ConsentGate() {
           </div>
         )}
       </Modal.Body>
-      <Modal.Footer>
+      <Modal.Footer className="px-4 pb-4 pt-2 border-0">
         <Button variant="link" onClick={handleNotNow} disabled={saving}>
           Not now
         </Button>

--- a/src/components/ConsentGate.tsx
+++ b/src/components/ConsentGate.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { useSession } from "next-auth/react";
 import { Modal, Button, Form } from "react-bootstrap";
 import { CONSENT_TEXT, CONSENT_VERSION } from "@/lib/consent";
-import { isValidEmail } from "@/app/api/flow-council/validation";
+import { isValidEmail } from "@/lib/email";
 
 // Shape of the profile returned by GET /api/flow-council/profile?includePrivate=true
 // for the authenticated owner. `emailVersion` is intentionally excluded server-side

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,68 +1,24 @@
 "use client";
 
-import { Suspense, useEffect, useRef, useState } from "react";
+import { Suspense, useState } from "react";
 import Link from "next/link";
 import { useRouter, usePathname, useParams } from "next/navigation";
-import { useSession } from "next-auth/react";
 import ConnectWallet from "@/components/ConnectWallet";
 import FlowCouncilWallet from "@/app/flow-councils/components/FlowCouncilWallet";
 import Nav from "react-bootstrap/Nav";
 import Stack from "react-bootstrap/Stack";
 import Button from "react-bootstrap/Button";
-import Badge from "react-bootstrap/Badge";
 import Image from "react-bootstrap/Image";
 import Offcanvas from "react-bootstrap/Offcanvas";
 import { useMediaQuery } from "@/hooks/mediaQuery";
 
 export default function Header() {
   const [showMobileMenu, setShowMobileMenu] = useState(false);
-  const [inboxUnreadCount, setInboxUnreadCount] = useState(0);
-  const lastUnreadFetchRef = useRef(0);
 
   const router = useRouter();
   const pathname = usePathname();
   const params = useParams();
   const { isMobile, isTablet, isSmallScreen } = useMediaQuery();
-  const { status: sessionStatus } = useSession();
-  const isAuthenticated = sessionStatus === "authenticated";
-
-  useEffect(() => {
-    if (!isAuthenticated) {
-      setInboxUnreadCount(0);
-      lastUnreadFetchRef.current = 0;
-      return;
-    }
-    let cancelled = false;
-    const refetch = async (force = false) => {
-      // Throttle navigation-triggered re-syncs: without this, a session
-      // with frequent client-side navigations would hammer the endpoint
-      // (it's a dep so the effect re-runs on every pathname change). The
-      // inbox:unread-changed event passes force=true to bypass the window.
-      const now = Date.now();
-      if (!force && now - lastUnreadFetchRef.current < 30_000) return;
-      lastUnreadFetchRef.current = now;
-      try {
-        const res = await fetch("/api/flow-council/inbox/unread-count");
-        if (!res.ok) return;
-        const data = await res.json();
-        if (!cancelled && typeof data?.unreadCount === "number") {
-          setInboxUnreadCount(data.unreadCount);
-        }
-      } catch (err) {
-        console.error(err);
-      }
-    };
-    refetch();
-    // Refresh when the inbox marks items read (same tab) so the badge
-    // doesn't go stale until a hard reload.
-    const onUnreadChanged = () => refetch(true);
-    window.addEventListener("inbox:unread-changed", onUnreadChanged);
-    return () => {
-      cancelled = true;
-      window.removeEventListener("inbox:unread-changed", onUnreadChanged);
-    };
-    // pathname dep: also re-sync on client navigation as a safety net.
-  }, [isAuthenticated, pathname]);
 
   return (
     <header className="w-100">
@@ -147,19 +103,6 @@ export default function Header() {
                   >
                     Flow Caster
                   </Button>
-                  {isAuthenticated && (
-                    <Button
-                      variant="transparent"
-                      className={`${isSmallScreen ? "px-6" : "px-10"} py-4 fs-lg fw-bold border-0 d-inline-flex align-items-center gap-2`}
-                      style={{ whiteSpace: "nowrap" }}
-                      onClick={() => router.push("/inbox")}
-                    >
-                      Inbox
-                      {inboxUnreadCount > 0 && (
-                        <Badge bg="primary">{inboxUnreadCount}</Badge>
-                      )}
-                    </Button>
-                  )}
                 </Stack>
               )}
               <Stack direction="horizontal" gap={isSmallScreen ? 4 : 6}>
@@ -320,21 +263,6 @@ export default function Header() {
               >
                 Flow Caster
               </Button>
-              {isAuthenticated && (
-                <Button
-                  variant="transparent"
-                  className="px-10 py-4 fs-lg fw-bold border-0 d-inline-flex align-items-center gap-2"
-                  onClick={() => {
-                    router.push("/inbox");
-                    setShowMobileMenu(false);
-                  }}
-                >
-                  Inbox
-                  {inboxUnreadCount > 0 && (
-                    <Badge bg="primary">{inboxUnreadCount}</Badge>
-                  )}
-                </Button>
-              )}
             </>
           )}
           <Stack

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,0 +1,5 @@
+export const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function isValidEmail(value: string): boolean {
+  return EMAIL_REGEX.test(value);
+}


### PR DESCRIPTION
## Summary
- ConsentGate now collects an email inline, triggers for users without an email on file, validates before save, and has more padding so the dialog doesn't crowd its edges
- Inbox moved into the profile dropdown; unread items show a red counter that replaces the account icon on the dropdown button
- Preferences page shows a redacted "Editing preferences for ***4823 · gp***@gmail.com · gr***" line so users know which account they're editing (relevant when signed in with a different wallet); container widened so the heading fits one line
- SES templates (all 6) updated in AWS to a single footer link: "Manage your notification preferences or unsubscribe" → `{{prefsLink}}`. Separate `unsubscribeLink` builder dropped from `ses.ts`; List-Unsubscribe MIME header still ships, so mail-client one-click unsubscribe is unaffected
- Profile PUT: qualify `email_version` in the ON CONFLICT increment (was tripping Postgres 42702)
- Inbox routes project managers to their comms channel instead of the admin-only recipient review page
- Removed the trailing "Next" button on the Communications page

## Test plan
- [ ] Sign in with no email on file → ConsentGate appears with email field; save without email shows inline error; save with valid email persists and dismisses
- [ ] Sign in with email on file but no consent → ConsentGate pre-fills email; save persists consent
- [ ] Open `/inbox` directly and via profile dropdown; verify unread counter on dropdown turns red and replaces icon; click an item as a project manager → routes to comms channel; as admin → routes to review page
- [ ] Open a preferences link signed in with a different wallet → see redacted identity line under "Email Preferences"; toggle a preference; click Unsubscribe from all
- [ ] Trigger a real email (any flow) → confirm footer reads "Manage your notification preferences or unsubscribe" and links to the prefs page; mail client's native Unsubscribe still works
- [ ] Communications page no longer has a "Next" button