### PR TITLE
fix: email notifications follow-ups — inbox links, wallet-switch SIWE, consent toggles

### DIFF
--- a/src/app/api/flow-council/inbox/route.ts
+++ b/src/app/api/flow-council/inbox/route.ts
@@ -69,16 +69,20 @@ export async function GET(request: Request) {
       beforeId = parsed;
     }
 
-    // Join applications → rounds so application-linked items can build a
-    // valid deep link (/flow-councils/review/[chainId]/[councilId]). The
-    // inbox_items table only carries the application_id FK, not chain/council.
-    // Also join projectManagers (scoped to this recipient) so the client can
-    // route project managers to the comms channel instead of the admin-only
-    // recipient review page.
+    // Resolve chain/council/project so each item can build a valid deep link.
+    // inbox_items only carries application_id and/or message_id FKs, not
+    // chain/council. Application-linked items (applications, internal review)
+    // resolve via applications → rounds; message-linked items with no
+    // application (project channels, round announcements) resolve via
+    // messages → rounds instead. Also join projectManagers (scoped to this
+    // recipient) so the client can route project managers to the comms
+    // channel instead of the admin-only recipient review page.
     let query = db
       .selectFrom("inboxItems")
       .leftJoin("applications", "applications.id", "inboxItems.applicationId")
       .leftJoin("rounds", "rounds.id", "applications.roundId")
+      .leftJoin("messages", "messages.id", "inboxItems.messageId")
+      .leftJoin("rounds as messageRounds", "messageRounds.id", "messages.roundId")
       .leftJoin("projectManagers", (join) =>
         join
           .onRef("projectManagers.projectId", "=", "applications.projectId")
@@ -94,9 +98,12 @@ export async function GET(request: Request) {
         "inboxItems.snippet",
         "inboxItems.readAt",
         "inboxItems.createdAt",
-        "rounds.chainId as reviewChainId",
-        "rounds.flowCouncilAddress as reviewCouncilId",
-        "applications.projectId as reviewProjectId",
+        "rounds.chainId as appChainId",
+        "rounds.flowCouncilAddress as appCouncilId",
+        "applications.projectId as appProjectId",
+        "messageRounds.chainId as msgChainId",
+        "messageRounds.flowCouncilAddress as msgCouncilId",
+        "messages.projectId as msgProjectId",
         sql<boolean>`project_managers.id IS NOT NULL`.as("isProjectManager"),
       ])
       .where("inboxItems.recipientAddress", "=", address)
@@ -110,11 +117,25 @@ export async function GET(request: Request) {
       query = query.where("inboxItems.id", "<", beforeId);
     }
 
-    const items = await query.execute();
+    const rows = await query.execute();
+    const items = rows.map(
+      ({
+        appChainId,
+        appCouncilId,
+        appProjectId,
+        msgChainId,
+        msgCouncilId,
+        msgProjectId,
+        ...rest
+      }) => ({
+        ...rest,
+        reviewChainId: appChainId ?? msgChainId,
+        reviewCouncilId: appCouncilId ?? msgCouncilId,
+        reviewProjectId: appProjectId ?? msgProjectId,
+      }),
+    );
     const nextCursor =
-      items.length === limit
-        ? String(items[items.length - 1].id)
-        : null;
+      items.length === limit ? String(items[items.length - 1].id) : null;
 
     const unreadCountRow = await db
       .selectFrom("inboxItems")

--- a/src/app/api/flow-council/inbox/route.ts
+++ b/src/app/api/flow-council/inbox/route.ts
@@ -118,6 +118,8 @@ export async function GET(request: Request) {
     }
 
     const rows = await query.execute();
+    // Application path wins when an item has both an application and a message
+    // (internal review) — in practice both reference the same round.
     const items = rows.map(
       ({
         appChainId,

--- a/src/app/api/flow-council/inbox/route.ts
+++ b/src/app/api/flow-council/inbox/route.ts
@@ -82,7 +82,11 @@ export async function GET(request: Request) {
       .leftJoin("applications", "applications.id", "inboxItems.applicationId")
       .leftJoin("rounds", "rounds.id", "applications.roundId")
       .leftJoin("messages", "messages.id", "inboxItems.messageId")
-      .leftJoin("rounds as messageRounds", "messageRounds.id", "messages.roundId")
+      .leftJoin(
+        "rounds as messageRounds",
+        "messageRounds.id",
+        "messages.roundId",
+      )
       .leftJoin("projectManagers", (join) =>
         join
           .onRef("projectManagers.projectId", "=", "applications.projectId")

--- a/src/app/inbox/InboxPage.tsx
+++ b/src/app/inbox/InboxPage.tsx
@@ -80,10 +80,22 @@ function formatTimestamp(value: string): string {
 
 function getItemHref(item: InboxItem): string | null {
   if (item.reviewChainId == null || item.reviewCouncilId == null) return null;
+  const commsBase = `/flow-councils/communications/${item.reviewChainId}/${item.reviewCouncilId}`;
+
+  // Round announcements point to the round's announcements channel.
+  if (item.category === "round_announcements") {
+    return `${commsBase}?channel=announcements`;
+  }
+  // Project channel messages point to that project's channel.
+  if (item.category === "project_channels") {
+    return item.reviewProjectId != null
+      ? `${commsBase}?channel=${item.reviewProjectId}`
+      : null;
+  }
   // Project managers can't access the admin-only recipient review page —
   // send them to their project's comms channel instead.
   if (item.isProjectManager && item.reviewProjectId != null) {
-    return `/flow-councils/communications/${item.reviewChainId}/${item.reviewCouncilId}?channel=${item.reviewProjectId}`;
+    return `${commsBase}?channel=${item.reviewProjectId}`;
   }
   if (item.applicationId != null) {
     return `/flow-councils/review/${item.reviewChainId}/${item.reviewCouncilId}?applicationId=${item.applicationId}`;
@@ -92,10 +104,22 @@ function getItemHref(item: InboxItem): string | null {
 }
 
 export default function InboxPage() {
-  const { status } = useSession();
-  const { address } = useAccount();
+  const { status, data: session } = useSession();
+  const { address, isConnecting, isReconnecting } = useAccount();
   const { openConnectModal } = useConnectModal();
   const { handleSignIn } = useSiwe();
+
+  // Only treat the inbox as ready once the SIWE session and the connected
+  // wallet agree. While the wallet is reconnecting (page refresh) or has been
+  // switched to a different account, hold on the loading state instead of
+  // briefly flashing inbox content that belongs to a stale session — AuthSync
+  // resolves a mismatch by signing out (and reloading on a wallet switch).
+  const isWalletSettling = isConnecting || isReconnecting;
+  const sessionMatchesWallet =
+    status === "authenticated" &&
+    !!session?.address &&
+    !!address &&
+    session.address.toLowerCase() === address.toLowerCase();
 
   const [items, setItems] = useState<InboxItem[]>([]);
   const [unreadCount, setUnreadCount] = useState(0);
@@ -215,12 +239,14 @@ export default function InboxPage() {
     }
   };
 
-  if (status === "loading") {
-    return (
-      <Container className="py-5 d-flex justify-content-center">
-        <Spinner />
-      </Container>
-    );
+  const loadingView = (
+    <Container className="py-5 d-flex justify-content-center">
+      <Spinner />
+    </Container>
+  );
+
+  if (status === "loading" || isWalletSettling) {
+    return loadingView;
   }
 
   if (status === "unauthenticated") {
@@ -245,6 +271,13 @@ export default function InboxPage() {
         </Card>
       </Container>
     );
+  }
+
+  // Authenticated session whose address doesn't (yet) match the connected
+  // wallet — e.g. a wallet switch that AuthSync is signing out. Keep loading
+  // rather than flashing content from the previous session.
+  if (!sessionMatchesWallet) {
+    return loadingView;
   }
 
   return (

--- a/src/app/inbox/InboxPage.tsx
+++ b/src/app/inbox/InboxPage.tsx
@@ -56,7 +56,10 @@ const CATEGORY_LABELS: Record<InboxCategory, string> = {
 
 const CATEGORY_FILTERS: { key: CategoryFilter; label: string }[] = [
   { key: "all", label: "All" },
-  { key: "application_eligibility", label: CATEGORY_LABELS.application_eligibility },
+  {
+    key: "application_eligibility",
+    label: CATEGORY_LABELS.application_eligibility,
+  },
   { key: "project_channels", label: CATEGORY_LABELS.project_channels },
   { key: "round_announcements", label: CATEGORY_LABELS.round_announcements },
   { key: "internal_review", label: CATEGORY_LABELS.internal_review },
@@ -82,11 +85,9 @@ function getItemHref(item: InboxItem): string | null {
   if (item.reviewChainId == null || item.reviewCouncilId == null) return null;
   const commsBase = `/flow-councils/communications/${item.reviewChainId}/${item.reviewCouncilId}`;
 
-  // Round announcements point to the round's announcements channel.
   if (item.category === "round_announcements") {
     return `${commsBase}?channel=announcements`;
   }
-  // Project channel messages point to that project's channel.
   if (item.category === "project_channels") {
     return item.reviewProjectId != null
       ? `${commsBase}?channel=${item.reviewProjectId}`
@@ -123,7 +124,8 @@ export default function InboxPage() {
 
   const [items, setItems] = useState<InboxItem[]>([]);
   const [unreadCount, setUnreadCount] = useState(0);
-  const [selectedCategory, setSelectedCategory] = useState<CategoryFilter>("all");
+  const [selectedCategory, setSelectedCategory] =
+    useState<CategoryFilter>("all");
   const [isLoading, setIsLoading] = useState(false);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [nextCursor, setNextCursor] = useState<string | null>(null);
@@ -346,8 +348,7 @@ export default function InboxPage() {
           {items.map((item) => {
             const isUnread = item.readAt === null;
             const href = getItemHref(item);
-            const title =
-              item.sourceLabel ?? getCategoryLabel(item.category);
+            const title = item.sourceLabel ?? getCategoryLabel(item.category);
             const rowContent = (
               <Card
                 className={`rounded-4 border-0 p-3 ${
@@ -364,14 +365,20 @@ export default function InboxPage() {
                 }}
                 style={{ cursor: "pointer" }}
               >
-                <Stack direction="horizontal" gap={3} className="align-items-start">
+                <Stack
+                  direction="horizontal"
+                  gap={3}
+                  className="align-items-start"
+                >
                   <span
                     aria-hidden="true"
                     className="d-inline-block rounded-circle mt-2"
                     style={{
                       width: 8,
                       height: 8,
-                      backgroundColor: isUnread ? "var(--bs-primary)" : "transparent",
+                      backgroundColor: isUnread
+                        ? "var(--bs-primary)"
+                        : "transparent",
                       flexShrink: 0,
                     }}
                   />

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useEffect, useMemo, useRef } from "react";
+import { Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 import { SessionProvider, signOut, useSession } from "next-auth/react";
 import { http } from "viem";
@@ -18,6 +18,7 @@ import {
 import { createConfig, WagmiProvider, useAccount } from "wagmi";
 import { arbitrum, base, celo, optimism, optimismSepolia } from "wagmi/chains";
 import { QueryClientProvider, QueryClient } from "@tanstack/react-query";
+import Alert from "react-bootstrap/Alert";
 import posthog from "posthog-js";
 import { PostHogProvider } from "posthog-js/react";
 import { DonorParamsContextProvider } from "@/context/DonorParams";
@@ -119,10 +120,16 @@ function RainbowKitWithInitialChain({
   );
 }
 
+// Bound the wallet-switch sign-out retries so a sustained NextAuth outage
+// can't trap the user in an endless sign-out → reload loop.
+const SIGNOUT_ATTEMPTS_KEY = "wallet-switch-signout-attempts";
+const MAX_SIGNOUT_ATTEMPTS = 2;
+
 function AuthSync() {
   const { address, isDisconnected } = useAccount();
   const { data: session } = useSession();
   const reloadingRef = useRef(false);
+  const [signOutFailed, setSignOutFailed] = useState(false);
 
   useEffect(() => {
     if (!session?.address) return;
@@ -140,16 +147,55 @@ function AuthSync() {
     if (address && address.toLowerCase() !== session.address.toLowerCase()) {
       if (reloadingRef.current) return;
       reloadingRef.current = true;
-      // Reload even if signOut rejects (e.g. a network blip on the NextAuth
-      // endpoint) — otherwise the ref stays set and the user is stuck with a
-      // session that no longer matches their connected wallet.
       signOut({ redirect: false })
-        .catch(() => {})
-        .finally(() => {
+        .then(() => {
+          // Signed out cleanly — the stale cookie is gone, so the reload
+          // won't re-detect the mismatch. Clear the retry counter.
+          sessionStorage.removeItem(SIGNOUT_ATTEMPTS_KEY);
           window.location.reload();
+        })
+        .catch(() => {
+          // signOut rejected (e.g. the NextAuth endpoint is down). The stale
+          // cookie survives, so a reload re-detects the same mismatch and we
+          // retry — which loops forever on a sustained outage. Bound it:
+          // reload to ride out a transient blip, but after MAX_SIGNOUT_ATTEMPTS
+          // consecutive failures stop and surface an error instead.
+          const attempts =
+            Number(sessionStorage.getItem(SIGNOUT_ATTEMPTS_KEY) ?? "0") + 1;
+          if (attempts < MAX_SIGNOUT_ATTEMPTS) {
+            sessionStorage.setItem(SIGNOUT_ATTEMPTS_KEY, String(attempts));
+            window.location.reload();
+          } else {
+            sessionStorage.removeItem(SIGNOUT_ATTEMPTS_KEY);
+            reloadingRef.current = false;
+            setSignOutFailed(true);
+          }
         });
     }
   }, [address, isDisconnected, session]);
+
+  if (signOutFailed) {
+    return (
+      <Alert
+        variant="warning"
+        className="position-fixed top-0 start-50 translate-middle-x mt-3 shadow"
+        style={{ zIndex: 2000, maxWidth: "90vw" }}
+      >
+        Your connected wallet changed, but we couldn&apos;t refresh your
+        session.{" "}
+        <Alert.Link
+          href="#"
+          onClick={(e) => {
+            e.preventDefault();
+            window.location.reload();
+          }}
+        >
+          Reload the page
+        </Alert.Link>{" "}
+        to sign in again.
+      </Alert>
+    );
+  }
 
   return null;
 }

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -140,9 +140,14 @@ function AuthSync() {
     if (address && address.toLowerCase() !== session.address.toLowerCase()) {
       if (reloadingRef.current) return;
       reloadingRef.current = true;
-      signOut({ redirect: false }).then(() => {
-        window.location.reload();
-      });
+      // Reload even if signOut rejects (e.g. a network blip on the NextAuth
+      // endpoint) — otherwise the ref stays set and the user is stuck with a
+      // session that no longer matches their connected wallet.
+      signOut({ redirect: false })
+        .catch(() => {})
+        .finally(() => {
+          window.location.reload();
+        });
     }
   }, [address, isDisconnected, session]);
 

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useEffect, useMemo } from "react";
+import { Suspense, useEffect, useMemo, useRef } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 import { SessionProvider, signOut, useSession } from "next-auth/react";
 import { http } from "viem";
@@ -120,14 +120,31 @@ function RainbowKitWithInitialChain({
 }
 
 function AuthSync() {
-  const { isDisconnected } = useAccount();
+  const { address, isDisconnected } = useAccount();
   const { data: session } = useSession();
+  const reloadingRef = useRef(false);
 
   useEffect(() => {
-    if (isDisconnected && session) {
+    if (!session?.address) return;
+
+    // Wallet fully disconnected — drop the stale session. No reload needed;
+    // the UI falls back to the connect / sign-in prompt.
+    if (isDisconnected) {
       signOut({ redirect: false });
+      return;
     }
-  }, [isDisconnected, session]);
+
+    // Wallet switched to a different account while signed in. The session
+    // still belongs to the previous address, so sign out and reload the page
+    // to rebuild all wallet-scoped state and require a fresh SIWE.
+    if (address && address.toLowerCase() !== session.address.toLowerCase()) {
+      if (reloadingRef.current) return;
+      reloadingRef.current = true;
+      signOut({ redirect: false }).then(() => {
+        window.location.reload();
+      });
+    }
+  }, [address, isDisconnected, session]);
 
   return null;
 }

--- a/src/components/ConsentGate.tsx
+++ b/src/components/ConsentGate.tsx
@@ -214,42 +214,48 @@ export default function ConsentGate() {
           checked={consentChecked}
           onChange={(e) => setConsentChecked(e.target.checked)}
         />
-        {consentChecked && (
-          <div className="mt-3">
-            <Form.Switch
-              id="consent-modal-notify-application-eligibility"
-              label="Application & eligibility updates"
-              checked={notifyApplicationEligibility}
-              onChange={(e) =>
-                setNotifyApplicationEligibility(e.target.checked)
-              }
-            />
-            <Form.Switch
-              id="consent-modal-notify-project-channels"
-              label="Project channel messages"
-              checked={notifyProjectChannels}
-              onChange={(e) => setNotifyProjectChannels(e.target.checked)}
-            />
-            <Form.Switch
-              id="consent-modal-notify-round-announcements"
-              label="Round announcements"
-              checked={notifyRoundAnnouncements}
-              onChange={(e) => setNotifyRoundAnnouncements(e.target.checked)}
-            />
-            <Form.Switch
-              id="consent-modal-notify-internal-review"
-              label="Internal review comments"
-              checked={notifyInternalReview}
-              onChange={(e) => setNotifyInternalReview(e.target.checked)}
-            />
-            <Form.Switch
-              id="consent-modal-notify-platform"
-              label="Flow State Platform updates"
-              checked={notifyPlatform}
-              onChange={(e) => setNotifyPlatform(e.target.checked)}
-            />
-          </div>
-        )}
+        {/* Always show the categories up front so users can see what they'll
+            be able to choose. They stay disabled until consent is given. */}
+        <div className="mt-3">
+          <p className="text-muted small mb-2">
+            Choose what you&apos;d like to hear about:
+          </p>
+          <Form.Switch
+            id="consent-modal-notify-application-eligibility"
+            label="Application & eligibility updates"
+            checked={notifyApplicationEligibility}
+            disabled={!consentChecked}
+            onChange={(e) => setNotifyApplicationEligibility(e.target.checked)}
+          />
+          <Form.Switch
+            id="consent-modal-notify-project-channels"
+            label="Project channel messages"
+            checked={notifyProjectChannels}
+            disabled={!consentChecked}
+            onChange={(e) => setNotifyProjectChannels(e.target.checked)}
+          />
+          <Form.Switch
+            id="consent-modal-notify-round-announcements"
+            label="Round announcements"
+            checked={notifyRoundAnnouncements}
+            disabled={!consentChecked}
+            onChange={(e) => setNotifyRoundAnnouncements(e.target.checked)}
+          />
+          <Form.Switch
+            id="consent-modal-notify-internal-review"
+            label="Internal review comments"
+            checked={notifyInternalReview}
+            disabled={!consentChecked}
+            onChange={(e) => setNotifyInternalReview(e.target.checked)}
+          />
+          <Form.Switch
+            id="consent-modal-notify-platform"
+            label="Flow State Platform updates"
+            checked={notifyPlatform}
+            disabled={!consentChecked}
+            onChange={(e) => setNotifyPlatform(e.target.checked)}
+          />
+        </div>
         {error && (
           <div className="text-danger mt-3" role="alert">
             {error}

--- a/src/components/ConsentGate.tsx
+++ b/src/components/ConsentGate.tsx
@@ -43,7 +43,8 @@ export default function ConsentGate() {
   const [notifyApplicationEligibility, setNotifyApplicationEligibility] =
     useState(true);
   const [notifyProjectChannels, setNotifyProjectChannels] = useState(true);
-  const [notifyRoundAnnouncements, setNotifyRoundAnnouncements] = useState(true);
+  const [notifyRoundAnnouncements, setNotifyRoundAnnouncements] =
+    useState(true);
   const [notifyInternalReview, setNotifyInternalReview] = useState(true);
   const [notifyPlatform, setNotifyPlatform] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -62,7 +63,9 @@ export default function ConsentGate() {
     // + return" requirement. The authoritative gate remains server-side
     // (`consent_confirmed_at IS NOT NULL` in the dispatch pipeline) — do
     // not remove the server check thinking this is sufficient.
-    const dismissedAt = sessionStorage.getItem(`${DISMISS_KEY_PREFIX}${address}`);
+    const dismissedAt = sessionStorage.getItem(
+      `${DISMISS_KEY_PREFIX}${address}`,
+    );
     if (dismissedAt) {
       return;
     }
@@ -163,7 +166,9 @@ export default function ConsentGate() {
       } | null;
 
       if (!res.ok || !json?.success) {
-        setError(json?.error || "Could not save preferences. Please try again.");
+        setError(
+          json?.error || "Could not save preferences. Please try again.",
+        );
         return;
       }
 
@@ -214,8 +219,6 @@ export default function ConsentGate() {
           checked={consentChecked}
           onChange={(e) => setConsentChecked(e.target.checked)}
         />
-        {/* Always show the categories up front so users can see what they'll
-            be able to choose. They stay disabled until consent is given. */}
         <div className="mt-3">
           <p className="text-muted small mb-2">
             Choose what you&apos;d like to hear about:


### PR DESCRIPTION
Follow-ups to the email notifications work, addressing review feedback.

## Changes

**1. Consent modal shows all options up front** (`ConsentGate.tsx`)
The notification category toggles were hidden until the consent checkbox was ticked. They now always render (under a short "Choose what you'd like to hear about" label) and stay **disabled** until consent is given, so users can see what's available before opting in.

**2. No more inbox flash on refresh / wallet switch** (`InboxPage.tsx`, `providers.tsx`)
- `AuthSync` now detects a **wallet address change** (not just disconnect) while signed in: it signs out and reloads the page so all wallet-scoped state is rebuilt and a fresh SIWE is required.
- The inbox holds its loading state until the SIWE session and the connected wallet agree (and while the wallet is reconnecting), instead of briefly flashing stale inbox content before falling back to the sign-in prompt.

**3. View links for Project Channel & Announcement items** (`inbox/route.ts`, `InboxPage.tsx`)
These items carry a `message_id` but no `application_id`, so the previous `applications → rounds` join produced no chain/council and no link. The API now also resolves context via `messages → rounds`, and the client routes View links by category:
- `round_announcements` → `…/communications/{chain}/{council}?channel=announcements`
- `project_channels` → `…?channel={projectId}`

Application & internal-review links (review page, with the project-manager → comms fallback) are unchanged.

## Note
The fourth piece of feedback — fetching the unread count on sign-in on any page — already works: `AccountDropdown` (in the global header) fetches the unread count whenever the session is authenticated, not only after visiting `/inbox`. No change was needed.

## Verification
`pnpm typecheck` and `pnpm lint` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
