### PR TITLE
test: retry prisma migrate deploy on transient DB errors

### DIFF
--- a/tests/setup/global.ts
+++ b/tests/setup/global.ts
@@ -22,11 +22,65 @@ export default async function globalSetup() {
 
   // prisma.config.ts reads COUNCIL_DATABASE_URL — override it (not DATABASE_URL)
   // so `migrate deploy` targets the test branch, not production.
-  execSync("pnpm prisma migrate deploy", {
-    stdio: "inherit",
-    timeout: 60_000,
-    env: { ...process.env, COUNCIL_DATABASE_URL: migrateUrl },
-  });
+  await migrateDeploy({ ...process.env, COUNCIL_DATABASE_URL: migrateUrl });
+}
+
+// PR and main runs share one test database, so concurrent `migrate deploy`
+// invocations contend on Prisma's migration advisory lock; the loser times out
+// after 10s ("P1002 … Timed out trying to acquire a postgres advisory lock").
+// Neon can also drop the first connection to a cold compute (P1001). Both are
+// transient, so retry with linear backoff before failing. Genuine migration
+// errors don't match these patterns and surface on the first attempt.
+const TRANSIENT_PATTERNS = [
+  "P1002", // server reached but timed out (advisory-lock contention)
+  "P1001", // can't reach the database server
+  "advisory lock",
+  "Timed out",
+  "ECONNRESET",
+];
+
+async function migrateDeploy(env: NodeJS.ProcessEnv): Promise<void> {
+  const maxAttempts = 5;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const stdout = execSync("pnpm prisma migrate deploy", {
+        stdio: ["ignore", "pipe", "pipe"],
+        encoding: "utf8",
+        timeout: 60_000,
+        env,
+      });
+      process.stdout.write(stdout);
+      return;
+    } catch (error) {
+      const { stdout, stderr, signal } = error as {
+        stdout?: string;
+        stderr?: string;
+        signal?: string;
+      };
+      const output = `${stdout ?? ""}${stderr ?? ""}`;
+      process.stderr.write(output);
+
+      // signal !== null means execSync killed it at the timeout — a stuck/cold
+      // compute, also worth retrying.
+      const transient =
+        signal != null || TRANSIENT_PATTERNS.some((p) => output.includes(p));
+      if (!transient || attempt === maxAttempts) {
+        throw new Error(
+          `prisma migrate deploy failed after ${attempt} attempt(s)`,
+        );
+      }
+
+      const delayMs = attempt * 5_000;
+      console.warn(
+        `migrate deploy hit a transient database error (attempt ${attempt}/${maxAttempts}); retrying in ${delayMs / 1000}s`,
+      );
+      await sleep(delayMs);
+    }
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function withConnectTimeout(urlString: string, seconds: number): string {

--- a/tests/setup/global.ts
+++ b/tests/setup/global.ts
@@ -55,18 +55,20 @@ async function migrateDeploy(env: NodeJS.ProcessEnv): Promise<void> {
       const { stdout, stderr, signal } = error as {
         stdout?: string;
         stderr?: string;
-        signal?: string;
+        signal?: NodeJS.Signals;
       };
       const output = `${stdout ?? ""}${stderr ?? ""}`;
       process.stderr.write(output);
 
-      // signal !== null means execSync killed it at the timeout — a stuck/cold
+      // A defined signal means execSync killed it at the timeout — a stuck/cold
       // compute, also worth retrying.
       const transient =
-        signal != null || TRANSIENT_PATTERNS.some((p) => output.includes(p));
+        signal !== undefined ||
+        TRANSIENT_PATTERNS.some((p) => output.includes(p));
       if (!transient || attempt === maxAttempts) {
         throw new Error(
           `prisma migrate deploy failed after ${attempt} attempt(s)`,
+          { cause: error },
         );
       }
 


### PR DESCRIPTION
## Problem

The integration-test job in `test-pr` / `test-main` intermittently fails in `tests/setup/global.ts` during `pnpm prisma migrate deploy`:

```
Error: P1002 — The database server was reached but timed out.
Context: Timed out trying to acquire a postgres advisory lock
(SELECT pg_advisory_lock(72707369)). Timeout: 10000ms.
```

All branches share a single `TEST_DATABASE_URL` (one Neon DB), so when two CI runs overlap, both attempt `migrate deploy` at once and contend on Prisma's migration advisory lock. The run that doesn't get the lock times out after 10s and fails the whole job — even though nothing is wrong with the code. This is what failed PR #292 (its run overlapped the `test-main` run kicked off by merging #291).

## Fix

Wrap `migrate deploy` in a retry loop (`tests/setup/global.ts`):

- Retries up to 5× with linear backoff (5s, 10s, 15s, 20s) **only** on transient errors: advisory-lock timeout (`P1002`), unreachable server (`P1001`), connection drops (`ECONNRESET`), or a timeout-kill (cold compute).
- Fails fast on genuine migration errors — they don't match the transient patterns and surface on the first attempt.
- Output is still streamed to the CI logs.

No production code touched; this only affects test setup.

## Testing

- `pnpm typecheck` ✅
- `pnpm lint` ✅