### PR TITLE
fix: switch network and show success state on pool Connect

### DIFF
--- a/.github/workflows/test-main.yml
+++ b/.github/workflows/test-main.yml
@@ -4,6 +4,14 @@ on:
   push:
     branches: [main]
 
+# PR and main test jobs share one Neon test database (see tests/setup/global.ts).
+# Serialize them into a single global concurrency group so one run's resetDb
+# `truncate ... cascade` can't wipe another in-flight run's seed data mid-test
+# (which surfaces as FK-constraint violations). Don't cancel an in-progress run.
+concurrency:
+  group: shared-test-db
+  cancel-in-progress: false
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -4,6 +4,14 @@ on:
   pull_request:
     branches: [main]
 
+# PR and main test jobs share one Neon test database (see tests/setup/global.ts).
+# Serialize them into a single global concurrency group so one run's resetDb
+# `truncate ... cascade` can't wipe another in-flight run's seed data mid-test
+# (which surfaces as FK-constraint violations). Don't cancel an in-progress run.
+concurrency:
+  group: shared-test-db
+  cancel-in-progress: false
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/src/app/flow-councils/[chainId]/[councilId]/flow-council.tsx
+++ b/src/app/flow-councils/[chainId]/[councilId]/flow-council.tsx
@@ -497,6 +497,7 @@ export default function FlowCouncil({
             network={network}
             poolAddress={distributionPool?.id ?? "0x"}
             isConnected={!shouldConnect}
+            onSuccess={() => setShowConnectionModal(false)}
           />
         </Modal.Footer>
       </Modal>

--- a/src/app/flow-guilds/[id]/flow-guild.tsx
+++ b/src/app/flow-guilds/[id]/flow-guild.tsx
@@ -540,6 +540,7 @@ export default function FlowGuild(props: FlowGuildProps) {
             network={network}
             poolAddress={pool?.poolAddress}
             isConnected={!shouldConnect}
+            onSuccess={() => setShowConnectionModal(false)}
           />
         </Modal.Footer>
       </Modal>

--- a/src/app/flow-splitters/[chainId]/[poolId]/flow-splitter.tsx
+++ b/src/app/flow-splitters/[chainId]/[poolId]/flow-splitter.tsx
@@ -423,6 +423,7 @@ export default function FlowSplitter(props: FlowSplitterProps) {
             network={network}
             poolAddress={pool?.poolAddress}
             isConnected={!shouldConnect}
+            onSuccess={() => setShowConnectionModal(false)}
           />
         </Modal.Footer>
       </Modal>

--- a/src/app/pools/[chainId]/[poolAddress]/pool-detail.tsx
+++ b/src/app/pools/[chainId]/[poolAddress]/pool-detail.tsx
@@ -391,6 +391,7 @@ export default function PoolDetail(props: PoolDetailProps) {
             network={network}
             poolAddress={poolAddress}
             isConnected={!shouldConnect}
+            onSuccess={() => setShowConnectionModal(false)}
           />
         </Modal.Footer>
       </Modal>

--- a/src/components/PoolConnectionButton.tsx
+++ b/src/components/PoolConnectionButton.tsx
@@ -1,6 +1,11 @@
 import { useState } from "react";
 import { Address } from "viem";
-import { useAccount, useWriteContract, usePublicClient } from "wagmi";
+import {
+  useAccount,
+  useWriteContract,
+  usePublicClient,
+  useSwitchChain,
+} from "wagmi";
 import { Network } from "@/types/network";
 import { gdaForwarderAbi } from "@sfpro/sdk/abi";
 import { waitForReceipt } from "@/lib/utils";
@@ -11,14 +16,17 @@ export default function PoolConnectionButton(props: {
   network?: Network;
   poolAddress: string;
   isConnected: boolean;
+  onSuccess?: () => void;
 }) {
-  const { network, poolAddress, isConnected } = props;
+  const { network, poolAddress, isConnected, onSuccess } = props;
 
   const [isTransactionConfirming, setIsTransactionConfirming] = useState(false);
+  const [isSuccess, setIsSuccess] = useState(false);
 
-  const publicClient = usePublicClient();
+  const publicClient = usePublicClient({ chainId: network?.id });
   const { writeContractAsync } = useWriteContract();
-  const { address } = useAccount();
+  const { switchChainAsync } = useSwitchChain();
+  const { address, chain: connectedChain } = useAccount();
 
   const handlePoolConnection = async () => {
     if (!network || !address || !publicClient) {
@@ -28,16 +36,26 @@ export default function PoolConnectionButton(props: {
     try {
       setIsTransactionConfirming(true);
 
+      if (connectedChain?.id !== network.id) {
+        await switchChainAsync({ chainId: network.id });
+      }
+
       const hash = await writeContractAsync({
         address: network.gdaForwarder,
         abi: gdaForwarderAbi,
         functionName: "connectPool",
         args: [poolAddress as Address, "0x"],
+        chainId: network.id,
       });
 
       await waitForReceipt(publicClient, hash);
 
       setIsTransactionConfirming(false);
+      setIsSuccess(true);
+
+      if (onSuccess) {
+        setTimeout(onSuccess, 1500);
+      }
     } catch (err) {
       console.error(err);
 
@@ -49,12 +67,12 @@ export default function PoolConnectionButton(props: {
     <Button
       variant="secondary"
       onClick={handlePoolConnection}
-      disabled={isConnected}
+      disabled={isConnected || isSuccess || isTransactionConfirming}
       className="w-100 text-white rounded-4 py-4 fw-semi-bold"
     >
       {isTransactionConfirming ? (
         <Spinner size="sm" />
-      ) : isConnected ? (
+      ) : isSuccess || isConnected ? (
         "Connected"
       ) : (
         "Connect"

--- a/src/components/PoolConnectionButton.tsx
+++ b/src/components/PoolConnectionButton.tsx
@@ -13,6 +13,16 @@ import Stack from "react-bootstrap/Stack";
 import Button from "react-bootstrap/Button";
 import Spinner from "react-bootstrap/Spinner";
 
+function isUserRejection(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const code = (err as { code?: unknown }).code;
+  return (
+    code === 4001 ||
+    code === "ACTION_REJECTED" ||
+    (err as { name?: unknown }).name === "UserRejectedRequestError"
+  );
+}
+
 export default function PoolConnectionButton(props: {
   network?: Network;
   poolAddress: string;
@@ -25,20 +35,22 @@ export default function PoolConnectionButton(props: {
   const [isSuccess, setIsSuccess] = useState(false);
   const [error, setError] = useState(false);
   const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const mountedRef = useRef(true);
 
   const publicClient = usePublicClient({ chainId: network?.id });
   const { writeContractAsync } = useWriteContract();
   const { switchChainAsync } = useSwitchChain();
   const { address, chain: connectedChain } = useAccount();
 
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
       if (closeTimer.current) {
         clearTimeout(closeTimer.current);
       }
-    },
-    [],
-  );
+    };
+  }, []);
 
   const handlePoolConnection = async () => {
     if (!network || !address || !publicClient) {
@@ -63,6 +75,10 @@ export default function PoolConnectionButton(props: {
 
       await waitForReceipt(publicClient, hash);
 
+      // The modal may have been dismissed mid-tx; don't write state or fire
+      // onSuccess on a flow the parent no longer cares about.
+      if (!mountedRef.current) return;
+
       setIsTransactionConfirming(false);
       setIsSuccess(true);
 
@@ -72,8 +88,14 @@ export default function PoolConnectionButton(props: {
     } catch (err) {
       console.error(err);
 
+      if (!mountedRef.current) return;
+
       setIsTransactionConfirming(false);
-      setError(true);
+      // A deliberate wallet rejection (switch or tx) isn't a failure — reset
+      // the button quietly instead of showing the error message.
+      if (!isUserRejection(err)) {
+        setError(true);
+      }
     }
   };
 

--- a/src/components/PoolConnectionButton.tsx
+++ b/src/components/PoolConnectionButton.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Address } from "viem";
 import {
   useAccount,
@@ -9,6 +9,7 @@ import {
 import { Network } from "@/types/network";
 import { gdaForwarderAbi } from "@sfpro/sdk/abi";
 import { waitForReceipt } from "@/lib/utils";
+import Stack from "react-bootstrap/Stack";
 import Button from "react-bootstrap/Button";
 import Spinner from "react-bootstrap/Spinner";
 
@@ -22,11 +23,22 @@ export default function PoolConnectionButton(props: {
 
   const [isTransactionConfirming, setIsTransactionConfirming] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);
+  const [error, setError] = useState(false);
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const publicClient = usePublicClient({ chainId: network?.id });
   const { writeContractAsync } = useWriteContract();
   const { switchChainAsync } = useSwitchChain();
   const { address, chain: connectedChain } = useAccount();
+
+  useEffect(
+    () => () => {
+      if (closeTimer.current) {
+        clearTimeout(closeTimer.current);
+      }
+    },
+    [],
+  );
 
   const handlePoolConnection = async () => {
     if (!network || !address || !publicClient) {
@@ -34,6 +46,7 @@ export default function PoolConnectionButton(props: {
     }
 
     try {
+      setError(false);
       setIsTransactionConfirming(true);
 
       if (connectedChain?.id !== network.id) {
@@ -54,29 +67,37 @@ export default function PoolConnectionButton(props: {
       setIsSuccess(true);
 
       if (onSuccess) {
-        setTimeout(onSuccess, 1500);
+        closeTimer.current = setTimeout(onSuccess, 1500);
       }
     } catch (err) {
       console.error(err);
 
       setIsTransactionConfirming(false);
+      setError(true);
     }
   };
 
   return (
-    <Button
-      variant="secondary"
-      onClick={handlePoolConnection}
-      disabled={isConnected || isSuccess || isTransactionConfirming}
-      className="w-100 text-white rounded-4 py-4 fw-semi-bold"
-    >
-      {isTransactionConfirming ? (
-        <Spinner size="sm" />
-      ) : isSuccess || isConnected ? (
-        "Connected"
-      ) : (
-        "Connect"
+    <Stack direction="vertical" className="w-100">
+      <Button
+        variant="secondary"
+        onClick={handlePoolConnection}
+        disabled={isConnected || isSuccess || isTransactionConfirming}
+        className="w-100 text-white rounded-4 py-4 fw-semi-bold"
+      >
+        {isTransactionConfirming ? (
+          <Spinner size="sm" />
+        ) : isSuccess || isConnected ? (
+          "Connected"
+        ) : (
+          "Connect"
+        )}
+      </Button>
+      {error && (
+        <p className="text-danger small text-center mt-2 mb-0">
+          Something went wrong. Please try again.
+        </p>
       )}
-    </Button>
+    </Stack>
   );
 }


### PR DESCRIPTION
## Summary

Improves the shared `PoolConnectionButton` (the "Connect" prompt shown to unconnected GDA recipients in Flow Splitters, Flow Councils, Flow Guilds, and pools).

- **Switch to the pool's network on click.** Before sending the `connectPool` tx, the button now switches the wallet to the pool's chain if needed (`switchChainAsync`), and pins `usePublicClient`/`writeContractAsync` to that chain so the tx and receipt are always read against the correct network instead of whatever chain the wallet happened to be on. A rejected switch resets the button gracefully.
- **Success state instead of a flash.** After the receipt confirms, the button shows "Connected" rather than briefly dropping back to "Connect" (the subgraph's `isConnected` lags ~10s behind on-chain state). It's also disabled during confirming/success to block double-clicks.
- **Modal closes directly.** New optional `onSuccess` prop; the four modal-based prompts (`flow-splitter`, `pool-detail`, `flow-guild`, `flow-council`) pass it to close the modal ~1.5s after success so the "Connected" state is visible first.

The two inline list usages (`flow-splitters`, `flow-councils`) need no callback but still get the network switch and no-flash behavior.

## Test plan

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- Manual: as an unconnected recipient on the wrong network, click Connect → wallet prompts to switch → tx confirms → button shows "Connected" → modal closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)