### PR TITLE
feat: Listed/Unlisted visibility for Flow Councils & Splitters

### DIFF
--- a/src/app/api/flow-council/launch/listed.integration.test.ts
+++ b/src/app/api/flow-council/launch/listed.integration.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import { createPublicClient } from "viem";
+
+vi.mock("viem", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("viem")>();
+  return { ...actual, createPublicClient: vi.fn() };
+});
+
+vi.mock("next-auth/next", () => ({
+  getServerSession: vi.fn(),
+}));
+
+vi.mock("@/app/api/auth/[...nextauth]/route", () => ({ authOptions: {} }));
+
+vi.mock("../db", async () => {
+  const { getTestDb } = await import("@tests/helpers/db");
+  return { db: getTestDb() };
+});
+
+import { POST } from "./route";
+import {
+  getTestDb,
+  resetDb,
+  TEST_ADMIN_ADDRESS,
+  TEST_OUTSIDER_ADDRESS,
+} from "@tests/helpers/db";
+import { mockSession } from "@tests/helpers/session";
+import { mockPublicClient } from "@tests/helpers/publicClient";
+
+const db = getTestDb();
+
+const COUNCIL_ADDRESS = "0xc1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1";
+const OPTIMISM_CHAIN_ID = 10;
+
+afterAll(async () => {
+  await resetDb(db);
+  await db.destroy();
+});
+
+beforeEach(async () => {
+  await resetDb(db);
+});
+
+async function readJson(res: Response) {
+  return JSON.parse(await res.text());
+}
+
+function postRequest(body: unknown) {
+  return new Request("http://localhost/api/flow-council/launch", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function stubAdminRole(
+  councilAddress: string,
+  callerAddress: string,
+  hasRole: boolean,
+) {
+  vi.mocked(createPublicClient).mockReturnValue(
+    mockPublicClient([
+      {
+        address: councilAddress,
+        functionName: "hasRole",
+        args: [
+          "0x0000000000000000000000000000000000000000000000000000000000000000",
+          callerAddress,
+        ],
+        returnValue: hasRole,
+      },
+    ]) as unknown as ReturnType<typeof createPublicClient>,
+  );
+}
+
+// Spec: "Council flag persists on both POST (create) and edit"
+// Spec: "POST /api/flow-council/launch with listed:true stores listed in the
+//        details JSON"
+describe("POST /api/flow-council/launch — listed flag", () => {
+  it("stores listed:true in rounds.details when posted at creation", async () => {
+    mockSession(TEST_ADMIN_ADDRESS);
+    stubAdminRole(COUNCIL_ADDRESS, TEST_ADMIN_ADDRESS, true);
+
+    const res = await POST(
+      postRequest({
+        chainId: OPTIMISM_CHAIN_ID,
+        flowCouncilAddress: COUNCIL_ADDRESS,
+        name: "Listed Round",
+        listed: true,
+      }),
+    );
+    const body = await readJson(res);
+    expect(body.success).toBe(true);
+
+    const stored = await db
+      .selectFrom("rounds")
+      .select("details")
+      .where("id", "=", body.round.id)
+      .executeTakeFirstOrThrow();
+
+    const details =
+      typeof stored.details === "string"
+        ? JSON.parse(stored.details)
+        : stored.details;
+    expect(details.listed).toBe(true);
+  });
+
+  it("stores listed:false in rounds.details when posted at creation with listed:false", async () => {
+    mockSession(TEST_ADMIN_ADDRESS);
+    stubAdminRole(COUNCIL_ADDRESS, TEST_ADMIN_ADDRESS, true);
+
+    const res = await POST(
+      postRequest({
+        chainId: OPTIMISM_CHAIN_ID,
+        flowCouncilAddress: COUNCIL_ADDRESS,
+        name: "Unlisted Round",
+        listed: false,
+      }),
+    );
+    const body = await readJson(res);
+    expect(body.success).toBe(true);
+
+    const stored = await db
+      .selectFrom("rounds")
+      .select("details")
+      .where("id", "=", body.round.id)
+      .executeTakeFirstOrThrow();
+
+    const details =
+      typeof stored.details === "string"
+        ? JSON.parse(stored.details)
+        : stored.details;
+    expect(details.listed).toBe(false);
+  });
+
+  // Spec: "Default Unlisted for all existing and new rounds — missing/non-true = unlisted"
+  it("new round without listed field in POST body defaults to no listed key (unlisted)", async () => {
+    mockSession(TEST_ADMIN_ADDRESS);
+    stubAdminRole(COUNCIL_ADDRESS, TEST_ADMIN_ADDRESS, true);
+
+    const res = await POST(
+      postRequest({
+        chainId: OPTIMISM_CHAIN_ID,
+        flowCouncilAddress: COUNCIL_ADDRESS,
+        name: "Default Round",
+      }),
+    );
+    const body = await readJson(res);
+    expect(body.success).toBe(true);
+
+    const stored = await db
+      .selectFrom("rounds")
+      .select("details")
+      .where("id", "=", body.round.id)
+      .executeTakeFirstOrThrow();
+
+    const details =
+      typeof stored.details === "string"
+        ? JSON.parse(stored.details)
+        : stored.details;
+    // listed absent or not true → unlisted
+    expect(details.listed).not.toBe(true);
+  });
+
+  // Spec: "Only round/pool admins may change the flag"
+  it("rejects non-admin from creating a listed round", async () => {
+    mockSession(TEST_OUTSIDER_ADDRESS);
+    stubAdminRole(COUNCIL_ADDRESS, TEST_OUTSIDER_ADDRESS, false);
+
+    const res = await POST(
+      postRequest({
+        chainId: OPTIMISM_CHAIN_ID,
+        flowCouncilAddress: COUNCIL_ADDRESS,
+        name: "Listed Round",
+        listed: true,
+      }),
+    );
+    const body = await readJson(res);
+    expect(body.success).toBe(false);
+    expect(body.error).toBe("Not an admin of this council");
+  });
+});

--- a/src/app/api/flow-council/launch/route.ts
+++ b/src/app/api/flow-council/launch/route.ts
@@ -29,6 +29,7 @@ export async function POST(request: Request) {
     if (!parsed.success) {
       return new Response(
         JSON.stringify({ success: false, error: "Invalid request" }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
       );
     }
 

--- a/src/app/api/flow-council/launch/route.ts
+++ b/src/app/api/flow-council/launch/route.ts
@@ -15,6 +15,7 @@ export async function POST(request: Request) {
       name,
       description,
       logoUrl,
+      listed,
       superappSplitterAddress,
     } = await request.json();
 
@@ -87,7 +88,14 @@ export async function POST(request: Request) {
           chainId,
           flowCouncilAddress: flowCouncilAddress.toLowerCase(),
           superappSplitterAddress: validatedSplitterAddress,
-          details: JSON.stringify({ name, description, logoUrl }),
+          details: JSON.stringify({
+            name,
+            description,
+            logoUrl,
+            // Only persist a real boolean — the launch route has no Zod schema,
+            // so guard against a non-boolean `listed` reaching the JSON column.
+            ...(typeof listed === "boolean" ? { listed } : {}),
+          }),
         })
         .returning([
           "id",

--- a/src/app/api/flow-council/launch/route.ts
+++ b/src/app/api/flow-council/launch/route.ts
@@ -1,14 +1,37 @@
 import { getServerSession } from "next-auth/next";
+import { z } from "zod";
 import { createPublicClient, http, parseAbi, Address, isAddress } from "viem";
 import { db } from "../db";
 import { authOptions } from "../../auth/[...nextauth]/route";
 import { networks, getViemChain } from "@/lib/networks";
 import { DEFAULT_ADMIN_ROLE } from "@/app/flow-councils/lib/constants";
 
+// Type-validate the body so `listed` is handled the same way as the rounds
+// PATCH route (z.boolean().optional()). Address/network/name are still checked
+// below with their existing business-rule error messages, so this schema only
+// enforces shapes and stays permissive on the optional metadata fields.
+const launchSchema = z.object({
+  chainId: z.number(),
+  flowCouncilAddress: z.string(),
+  name: z.string().optional(),
+  description: z.string().optional(),
+  logoUrl: z.string().optional(),
+  listed: z.boolean().optional(),
+  superappSplitterAddress: z.string().optional(),
+});
+
 export const dynamic = "force-dynamic";
 
 export async function POST(request: Request) {
   try {
+    const parsed = launchSchema.safeParse(await request.json());
+
+    if (!parsed.success) {
+      return new Response(
+        JSON.stringify({ success: false, error: "Invalid request" }),
+      );
+    }
+
     const {
       chainId,
       flowCouncilAddress,
@@ -17,7 +40,7 @@ export async function POST(request: Request) {
       logoUrl,
       listed,
       superappSplitterAddress,
-    } = await request.json();
+    } = parsed.data;
 
     const session = await getServerSession(authOptions);
 
@@ -92,9 +115,9 @@ export async function POST(request: Request) {
             name,
             description,
             logoUrl,
-            // Only persist a real boolean — the launch route has no Zod schema,
-            // so guard against a non-boolean `listed` reaching the JSON column.
-            ...(typeof listed === "boolean" ? { listed } : {}),
+            // Omitting `listed` from the body leaves the new round unlisted
+            // (missing/non-true = unlisted), mirroring the rounds PATCH route.
+            ...(listed !== undefined ? { listed } : {}),
           }),
         })
         .returning([

--- a/src/app/api/flow-council/rounds/route.integration.test.ts
+++ b/src/app/api/flow-council/rounds/route.integration.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+
+vi.mock("viem", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("viem")>();
+  return { ...actual, createPublicClient: vi.fn() };
+});
+
+vi.mock("next-auth/next", () => ({
+  getServerSession: vi.fn(),
+}));
+
+vi.mock("@/app/api/auth/[...nextauth]/route", () => ({ authOptions: {} }));
+
+vi.mock("../db", async () => {
+  const { getTestDb } = await import("@tests/helpers/db");
+  return { db: getTestDb() };
+});
+
+import { PATCH } from "./route";
+import {
+  getTestDb,
+  resetDb,
+  seedTestData,
+  TEST_ADMIN_ADDRESS,
+  TEST_OUTSIDER_ADDRESS,
+  TEST_COUNCIL_ADDRESS,
+  TEST_CHAIN_ID,
+} from "@tests/helpers/db";
+import { mockSession, mockUnauthenticated } from "@tests/helpers/session";
+
+const db = getTestDb();
+
+afterAll(async () => {
+  await resetDb(db);
+  await db.destroy();
+});
+
+beforeEach(async () => {
+  await resetDb(db);
+  await seedTestData(db);
+});
+
+async function readJson(res: Response) {
+  return JSON.parse(await res.text());
+}
+
+function patchRequest(body: unknown) {
+  return new Request("http://localhost/api/flow-council/rounds", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// Spec: "Only round/pool admins may change the flag. For councils this is
+//        enforced server-side via the existing SIWE admin check."
+describe("PATCH /api/flow-council/rounds — listed flag", () => {
+  const basePayload = {
+    chainId: TEST_CHAIN_ID,
+    flowCouncilAddress: TEST_COUNCIL_ADDRESS,
+    name: "Test Round",
+    description: "A test round",
+  };
+
+  it("rejects unauthenticated requests", async () => {
+    mockUnauthenticated();
+    const res = await PATCH(
+      patchRequest({ ...basePayload, listed: true }),
+    );
+    const body = await readJson(res);
+    expect(body.success).toBe(false);
+    expect(body.error).toBe("Unauthenticated");
+  });
+
+  it("rejects a non-admin from changing listed", async () => {
+    mockSession(TEST_OUTSIDER_ADDRESS);
+    const res = await PATCH(
+      patchRequest({ ...basePayload, listed: true }),
+    );
+    const body = await readJson(res);
+    expect(body.success).toBe(false);
+  });
+
+  // Spec: "PATCH with listed:true stores listed in the details JSON"
+  it("stores listed:true in rounds.details when admin sends listed:true", async () => {
+    mockSession(TEST_ADMIN_ADDRESS);
+    const res = await PATCH(
+      patchRequest({ ...basePayload, listed: true }),
+    );
+    const body = await readJson(res);
+    expect(body.success).toBe(true);
+
+    const stored = await db
+      .selectFrom("rounds")
+      .select("details")
+      .where("chainId", "=", TEST_CHAIN_ID)
+      .where(
+        "flowCouncilAddress",
+        "=",
+        TEST_COUNCIL_ADDRESS.toLowerCase(),
+      )
+      .executeTakeFirstOrThrow();
+
+    const details =
+      typeof stored.details === "string"
+        ? JSON.parse(stored.details)
+        : stored.details;
+    expect(details.listed).toBe(true);
+  });
+
+  // Spec: "PATCH with listed:false updates it"
+  it("stores listed:false in rounds.details when admin sends listed:false", async () => {
+    mockSession(TEST_ADMIN_ADDRESS);
+    const res = await PATCH(
+      patchRequest({ ...basePayload, listed: false }),
+    );
+    const body = await readJson(res);
+    expect(body.success).toBe(true);
+
+    const stored = await db
+      .selectFrom("rounds")
+      .select("details")
+      .where("chainId", "=", TEST_CHAIN_ID)
+      .where(
+        "flowCouncilAddress",
+        "=",
+        TEST_COUNCIL_ADDRESS.toLowerCase(),
+      )
+      .executeTakeFirstOrThrow();
+
+    const details =
+      typeof stored.details === "string"
+        ? JSON.parse(stored.details)
+        : stored.details;
+    expect(details.listed).toBe(false);
+  });
+
+  // Spec: "a PATCH WITHOUT `listed` preserves the existing value (the merge
+  //        must not drop it)"
+  it("preserves an existing listed:true when a PATCH omits the listed field", async () => {
+    // First, set listed:true
+    mockSession(TEST_ADMIN_ADDRESS);
+    await PATCH(patchRequest({ ...basePayload, listed: true }));
+
+    // Now PATCH without listed — should preserve it
+    mockSession(TEST_ADMIN_ADDRESS);
+    const res = await PATCH(
+      patchRequest({ ...basePayload, name: "Updated Name" }),
+    );
+    const body = await readJson(res);
+    expect(body.success).toBe(true);
+
+    const stored = await db
+      .selectFrom("rounds")
+      .select("details")
+      .where("chainId", "=", TEST_CHAIN_ID)
+      .where(
+        "flowCouncilAddress",
+        "=",
+        TEST_COUNCIL_ADDRESS.toLowerCase(),
+      )
+      .executeTakeFirstOrThrow();
+
+    const details =
+      typeof stored.details === "string"
+        ? JSON.parse(stored.details)
+        : stored.details;
+    // The existing listed:true must not have been clobbered
+    expect(details.listed).toBe(true);
+  });
+
+  // Spec: "A Flow Council row whose `details` has no `listed` field reads as Unlisted"
+  it("rounds with no listed field in details default to unlisted (listed absent means unlisted)", async () => {
+    // The seed inserts a round with details: {} — no listed field
+    const stored = await db
+      .selectFrom("rounds")
+      .select("details")
+      .where("chainId", "=", TEST_CHAIN_ID)
+      .where(
+        "flowCouncilAddress",
+        "=",
+        TEST_COUNCIL_ADDRESS.toLowerCase(),
+      )
+      .executeTakeFirstOrThrow();
+
+    const details =
+      typeof stored.details === "string"
+        ? JSON.parse(stored.details)
+        : stored.details;
+    // listed absent → unlisted (i.e. not true)
+    expect(details.listed).not.toBe(true);
+  });
+
+  it("does not alter other fields in details when updating listed", async () => {
+    // Set name and description first
+    mockSession(TEST_ADMIN_ADDRESS);
+    await PATCH(patchRequest({ ...basePayload, name: "My Round", description: "My desc" }));
+
+    // Now set listed:true
+    mockSession(TEST_ADMIN_ADDRESS);
+    await PATCH(patchRequest({ ...basePayload, name: "My Round", description: "My desc", listed: true }));
+
+    const stored = await db
+      .selectFrom("rounds")
+      .select("details")
+      .where("chainId", "=", TEST_CHAIN_ID)
+      .where(
+        "flowCouncilAddress",
+        "=",
+        TEST_COUNCIL_ADDRESS.toLowerCase(),
+      )
+      .executeTakeFirstOrThrow();
+
+    const details =
+      typeof stored.details === "string"
+        ? JSON.parse(stored.details)
+        : stored.details;
+    expect(details.listed).toBe(true);
+    expect(details.name).toBe("My Round");
+    expect(details.description).toBe("My desc");
+  });
+});

--- a/src/app/api/flow-council/rounds/route.ts
+++ b/src/app/api/flow-council/rounds/route.ts
@@ -28,6 +28,7 @@ const roundPatchSchema = z.object({
     )
     .optional()
     .or(z.literal("")),
+  listed: z.boolean().optional(),
 });
 
 export const dynamic = "force-dynamic";
@@ -120,7 +121,7 @@ export async function PATCH(request: Request) {
         { status: 400, headers: { "Content-Type": "application/json" } },
       );
     }
-    const { name, description, logoUrl } = parsed.data;
+    const { name, description, logoUrl, listed } = parsed.data;
 
     const round = await db
       .selectFrom("rounds")
@@ -150,7 +151,14 @@ export async function PATCH(request: Request) {
         ? JSON.parse(round.details)
         : (round.details ?? {});
 
-    const mergedDetails = { ...existingDetails, name, description, logoUrl };
+    const mergedDetails = {
+      ...existingDetails,
+      name,
+      description,
+      logoUrl,
+      // Omitting `listed` from the PATCH leaves the existing value untouched.
+      ...(listed !== undefined ? { listed } : {}),
+    };
 
     const updatedRound = await db
       .updateTable("rounds")

--- a/src/app/flow-councils/round-metadata/round-metadata.tsx
+++ b/src/app/flow-councils/round-metadata/round-metadata.tsx
@@ -7,6 +7,7 @@ import { useAccount, useSwitchChain } from "wagmi";
 import { useConnectModal } from "@rainbow-me/rainbowkit";
 import Stack from "react-bootstrap/Stack";
 import Form from "react-bootstrap/Form";
+import FormCheck from "react-bootstrap/FormCheck";
 import Toast from "react-bootstrap/Toast";
 import Button from "react-bootstrap/Button";
 import Spinner from "react-bootstrap/Spinner";
@@ -58,6 +59,7 @@ type RoundDetails = {
   name: string;
   description: string;
   logoUrl: string;
+  listed: boolean;
 };
 
 export default function RoundMetadata(props: RoundMetadataProps) {
@@ -67,6 +69,7 @@ export default function RoundMetadata(props: RoundMetadataProps) {
     name: "",
     description: "",
     logoUrl: "",
+    listed: false,
   });
   const [logoBlob, setLogoBlob] = useState<Blob | null>(null);
   const [logoError, setLogoError] = useState("");
@@ -108,6 +111,7 @@ export default function RoundMetadata(props: RoundMetadataProps) {
             name: details?.name ?? "",
             description: details?.description ?? "",
             logoUrl: details?.logoUrl ?? "",
+            listed: details?.listed === true,
           });
           setRoundExists(true);
         }
@@ -167,6 +171,7 @@ export default function RoundMetadata(props: RoundMetadataProps) {
           name: roundDetails.name,
           description: roundDetails.description,
           logoUrl,
+          listed: roundDetails.listed,
         }),
       });
 
@@ -325,6 +330,43 @@ export default function RoundMetadata(props: RoundMetadataProps) {
                     </>
                   )
                 )}
+              </Stack>
+            </Form.Group>
+            <Form.Group className="d-flex flex-column mt-3">
+              <Form.Label className="fs-lg fw-semi-bold">
+                Discovery Visibility
+              </Form.Label>
+              <Card.Text className="m-0 mb-2 text-info small">
+                Listed rounds may be surfaced on the Explore page. Unlisted
+                rounds stay accessible via direct link.
+              </Card.Text>
+              <Stack direction="horizontal" gap={5}>
+                <FormCheck type="radio">
+                  <FormCheck.Input
+                    type="radio"
+                    checked={!roundDetails.listed}
+                    disabled={!session || session.address !== address}
+                    onChange={() =>
+                      setRoundDetails({ ...roundDetails, listed: false })
+                    }
+                  />
+                  <FormCheck.Label className="fw-semi-bold">
+                    Unlisted
+                  </FormCheck.Label>
+                </FormCheck>
+                <FormCheck type="radio">
+                  <FormCheck.Input
+                    type="radio"
+                    checked={!!roundDetails.listed}
+                    disabled={!session || session.address !== address}
+                    onChange={() =>
+                      setRoundDetails({ ...roundDetails, listed: true })
+                    }
+                  />
+                  <FormCheck.Label className="fw-semi-bold">
+                    Listed
+                  </FormCheck.Label>
+                </FormCheck>
               </Stack>
             </Form.Group>
           </Card.Body>

--- a/src/app/flow-councils/round-metadata/round-metadata.tsx
+++ b/src/app/flow-councils/round-metadata/round-metadata.tsx
@@ -344,6 +344,7 @@ export default function RoundMetadata(props: RoundMetadataProps) {
                 <FormCheck type="radio">
                   <FormCheck.Input
                     type="radio"
+                    name="discovery-visibility"
                     checked={!roundDetails.listed}
                     disabled={!session || session.address !== address}
                     onChange={() =>
@@ -357,6 +358,7 @@ export default function RoundMetadata(props: RoundMetadataProps) {
                 <FormCheck type="radio">
                   <FormCheck.Input
                     type="radio"
+                    name="discovery-visibility"
                     checked={!!roundDetails.listed}
                     disabled={!session || session.address !== address}
                     onChange={() =>

--- a/src/app/flow-splitters/[chainId]/[poolId]/admin/admin.tsx
+++ b/src/app/flow-splitters/[chainId]/[poolId]/admin/admin.tsx
@@ -1240,6 +1240,7 @@ export default function Admin(props: AdminProps) {
                     <FormCheck type="radio">
                       <FormCheck.Input
                         type="radio"
+                        name="discovery-visibility"
                         checked={!poolConfig.listed}
                         disabled={!isAdmin}
                         onChange={() =>
@@ -1253,6 +1254,7 @@ export default function Admin(props: AdminProps) {
                     <FormCheck type="radio">
                       <FormCheck.Input
                         type="radio"
+                        name="discovery-visibility"
                         checked={!!poolConfig.listed}
                         disabled={!isAdmin}
                         onChange={() =>

--- a/src/app/flow-splitters/[chainId]/[poolId]/admin/admin.tsx
+++ b/src/app/flow-splitters/[chainId]/[poolId]/admin/admin.tsx
@@ -33,7 +33,7 @@ import { flowSplitterAbi } from "@/lib/abi/flowSplitter";
 import { useMediaQuery } from "@/hooks/mediaQuery";
 import { networks } from "@/lib/networks";
 import { isNumber, truncateStr } from "@/lib/utils";
-import { parseListed } from "@/lib/listedMetadata";
+import { parseListed, serializeListed } from "@/lib/listedMetadata";
 
 type AdminProps = {
   chainId: number;
@@ -484,32 +484,14 @@ export default function Admin(props: AdminProps) {
       setListedError("");
       setListedLoading(true);
 
-      // Preserve any other structured fields already in the metadata JSON and
-      // overwrite only `listed`. Legacy free-form (non-JSON) metadata has
-      // nothing to preserve and is replaced. The `"listed":<bool>` substring is
-      // always present, so the future subgraph metadata_contains filter matches.
-      let metadataObj: Record<string, unknown> = {};
-      try {
-        const parsed = JSON.parse(pool?.metadata ?? "");
-        if (
-          typeof parsed === "object" &&
-          parsed !== null &&
-          !Array.isArray(parsed)
-        ) {
-          metadataObj = parsed;
-        }
-      } catch {
-        // legacy free-form metadata — nothing to preserve
-      }
-
       const hash = await writeContract(wagmiConfig, {
         address: network.flowSplitter,
         abi: flowSplitterAbi,
         functionName: "updatePoolMetadata",
-        args: [
-          BigInt(poolId),
-          JSON.stringify({ ...metadataObj, listed: poolConfig.listed }),
-        ],
+        // serializeListed writes the canonical single-key blob — same as the
+        // create path (launch.tsx) and the helper's contract. Any legacy
+        // free-form metadata is replaced; only `listed` is stored.
+        args: [BigInt(poolId), serializeListed(poolConfig.listed)],
       });
 
       await waitForReceipt(publicClient, hash);

--- a/src/app/flow-splitters/[chainId]/[poolId]/admin/admin.tsx
+++ b/src/app/flow-splitters/[chainId]/[poolId]/admin/admin.tsx
@@ -33,6 +33,7 @@ import { flowSplitterAbi } from "@/lib/abi/flowSplitter";
 import { useMediaQuery } from "@/hooks/mediaQuery";
 import { networks } from "@/lib/networks";
 import { isNumber, truncateStr } from "@/lib/utils";
+import { parseListed } from "@/lib/listedMetadata";
 
 type AdminProps = {
   chainId: number;
@@ -42,6 +43,7 @@ type AdminProps = {
 type PoolConfig = {
   transferableUnits: boolean;
   immutable: boolean;
+  listed: boolean;
 };
 
 type AdminEntry = { address: string; validationError: string };
@@ -54,6 +56,7 @@ const FLOW_SPLITTER_POOL_QUERY = gql`
       name
       symbol
       token
+      metadata
       poolAdmins {
         address
       }
@@ -91,6 +94,7 @@ export default function Admin(props: AdminProps) {
   const [poolConfig, setPoolConfig] = useState<PoolConfig>({
     transferableUnits: false,
     immutable: false,
+    listed: false,
   });
   const [adminsEntry, setAdminsEntry] = useState<AdminEntry[]>([
     { address: "", validationError: "" },
@@ -102,6 +106,12 @@ export default function Admin(props: AdminProps) {
   const [transactionSuccess, setTransactionSuccess] = useState("");
   const [transactionError, setTransactionError] = useState("");
   const [isTransactionLoading, setIsTransactionLoading] = useState(false);
+  const [listedLoading, setListedLoading] = useState(false);
+  const [listedError, setListedError] = useState("");
+  // The listed value currently committed on-chain, used to detect unsaved
+  // changes for the Save Visibility button (kept in sync after a save so the
+  // button disables immediately, without waiting for the next subgraph poll).
+  const [committedListed, setCommittedListed] = useState(false);
 
   const { isMobile } = useMediaQuery();
   const { data: walletClient } = useWalletClient();
@@ -251,6 +261,13 @@ export default function Admin(props: AdminProps) {
           }),
         );
       }
+
+      // Initialize the listed toggle from the pool's on-chain metadata.
+      // parseListed defends against legacy free-form metadata (e.g. a bare
+      // label string) — anything not `{"listed":true}` reads as unlisted.
+      const listed = parseListed(pool?.metadata);
+      setPoolConfig((prev) => ({ ...prev, listed }));
+      setCommittedListed(listed);
     })();
   }, [flowSplitterPoolQueryLoading, pool, poolAdmins]);
 
@@ -438,7 +455,10 @@ export default function Admin(props: AdminProps) {
                     return { account: adminAddress, status: BigInt(1) };
                   }),
                 ),
-          "",
+          // Pass the current on-chain metadata through so a members/admins
+          // edit never clobbers the listed flag (the dedicated visibility
+          // action below owns metadata changes).
+          pool?.metadata ?? "",
         ],
       });
 
@@ -452,6 +472,56 @@ export default function Admin(props: AdminProps) {
 
       setTransactionError("Transaction Error");
       setIsTransactionLoading(false);
+    }
+  };
+
+  const handleUpdateMetadata = async () => {
+    if (!network || !address || !publicClient) {
+      return;
+    }
+
+    try {
+      setListedError("");
+      setListedLoading(true);
+
+      // Preserve any other structured fields already in the metadata JSON and
+      // overwrite only `listed`. Legacy free-form (non-JSON) metadata has
+      // nothing to preserve and is replaced. The `"listed":<bool>` substring is
+      // always present, so the future subgraph metadata_contains filter matches.
+      let metadataObj: Record<string, unknown> = {};
+      try {
+        const parsed = JSON.parse(pool?.metadata ?? "");
+        if (
+          typeof parsed === "object" &&
+          parsed !== null &&
+          !Array.isArray(parsed)
+        ) {
+          metadataObj = parsed;
+        }
+      } catch {
+        // legacy free-form metadata — nothing to preserve
+      }
+
+      const hash = await writeContract(wagmiConfig, {
+        address: network.flowSplitter,
+        abi: flowSplitterAbi,
+        functionName: "updatePoolMetadata",
+        args: [
+          BigInt(poolId),
+          JSON.stringify({ ...metadataObj, listed: poolConfig.listed }),
+        ],
+      });
+
+      await waitForReceipt(publicClient, hash);
+
+      setListedLoading(false);
+      setCommittedListed(poolConfig.listed);
+      setTransactionSuccess("Visibility Updated Successfully");
+    } catch (err) {
+      console.error(err);
+
+      setListedError("Transaction Error");
+      setListedLoading(false);
     }
   };
 
@@ -1139,6 +1209,91 @@ export default function Admin(props: AdminProps) {
                 >
                   Template
                 </Card.Link>
+              </Card.Body>
+            </Card>
+            <Card className="bg-lace-100 rounded-4 border-0 mt-8 p-4">
+              <Card.Header className="d-flex gap-1 mb-3 bg-transparent border-0 rounded-4 p-0 fs-6 text-secondary fw-semi-bold">
+                Discovery Visibility
+                <InfoTooltip
+                  position={{ top: true }}
+                  target={
+                    <Image
+                      src="/info.svg"
+                      alt="Info"
+                      width={18}
+                      height={18}
+                      className="align-top"
+                    />
+                  }
+                  content={
+                    <p className="m-0 p-2">
+                      Listed Flow Splitters may be surfaced on the Explore page.
+                      Unlisted ones stay accessible via direct link. Changing
+                      this requires an on-chain transaction.
+                    </p>
+                  }
+                />
+              </Card.Header>
+              <Card.Body className="p-0 mt-4">
+                <Form.Group>
+                  <Stack direction="horizontal" gap={5}>
+                    <FormCheck type="radio">
+                      <FormCheck.Input
+                        type="radio"
+                        checked={!poolConfig.listed}
+                        disabled={!isAdmin}
+                        onChange={() =>
+                          setPoolConfig({ ...poolConfig, listed: false })
+                        }
+                      />
+                      <FormCheck.Label className="fw-semi-bold">
+                        Unlisted
+                      </FormCheck.Label>
+                    </FormCheck>
+                    <FormCheck type="radio">
+                      <FormCheck.Input
+                        type="radio"
+                        checked={!!poolConfig.listed}
+                        disabled={!isAdmin}
+                        onChange={() =>
+                          setPoolConfig({ ...poolConfig, listed: true })
+                        }
+                      />
+                      <FormCheck.Label className="fw-semi-bold">
+                        Listed
+                      </FormCheck.Label>
+                    </FormCheck>
+                  </Stack>
+                  <Button
+                    disabled={
+                      !isAdmin ||
+                      listedLoading ||
+                      poolConfig.listed === committedListed
+                    }
+                    className="mt-4 px-8 py-3 rounded-4 fw-semi-bold"
+                    onClick={() =>
+                      !address && openConnectModal
+                        ? openConnectModal()
+                        : connectedChain?.id !== chainId
+                          ? switchChain({ chainId })
+                          : handleUpdateMetadata()
+                    }
+                  >
+                    {listedLoading ? (
+                      <Spinner size="sm" className="ms-2" />
+                    ) : (
+                      "Save Visibility"
+                    )}
+                  </Button>
+                  {listedError ? (
+                    <Alert
+                      variant="danger"
+                      className="w-100 mt-4 p-4 fw-semi-bold"
+                    >
+                      {listedError}
+                    </Alert>
+                  ) : null}
+                </Form.Group>
               </Card.Body>
             </Card>
             <Stack direction="vertical" className="mt-8">

--- a/src/app/flow-splitters/launch/launch.tsx
+++ b/src/app/flow-splitters/launch/launch.tsx
@@ -1024,6 +1024,7 @@ export default function Launch(props: LaunchProps) {
                 <FormCheck type="radio">
                   <FormCheck.Input
                     type="radio"
+                    name="discovery-visibility"
                     checked={!poolConfig.listed}
                     onChange={() =>
                       setPoolConfig({
@@ -1039,6 +1040,7 @@ export default function Launch(props: LaunchProps) {
                 <FormCheck type="radio">
                   <FormCheck.Input
                     type="radio"
+                    name="discovery-visibility"
                     checked={!!poolConfig.listed}
                     onChange={() =>
                       setPoolConfig({

--- a/src/app/flow-splitters/launch/launch.tsx
+++ b/src/app/flow-splitters/launch/launch.tsx
@@ -27,12 +27,14 @@ import { flowSplitterAbi } from "@/lib/abi/flowSplitter";
 import { useMediaQuery } from "@/hooks/mediaQuery";
 import { networks } from "@/lib/networks";
 import { isNumber } from "@/lib/utils";
+import { serializeListed } from "@/lib/listedMetadata";
 
 type LaunchProps = { defaultNetwork: Network };
 
 type PoolConfig = {
   transferableUnits: boolean;
   immutable: boolean;
+  listed: boolean;
 };
 
 type Erc20Metadata = { name: string; symbol: string };
@@ -64,6 +66,7 @@ export default function Launch(props: LaunchProps) {
   const [poolConfig, setPoolConfig] = useState<PoolConfig>({
     transferableUnits: false,
     immutable: false,
+    listed: false,
   });
   const [customTokenEntry, setCustomTokenEntry] = useState<CustomTokenEntry>({
     address: "",
@@ -177,7 +180,7 @@ export default function Launch(props: LaunchProps) {
           poolConfig.immutable
             ? []
             : validAdmins.map((admin) => admin.address as Address),
-          "",
+          serializeListed(poolConfig.listed),
         ],
       });
 
@@ -990,6 +993,66 @@ export default function Launch(props: LaunchProps) {
             >
               Template
             </Card.Link>
+          </Card.Body>
+        </Card>
+        <Card className="bg-lace-100 rounded-4 border-0 mt-8 p-4">
+          <Card.Header className="d-flex gap-1 mb-3 bg-transparent border-0 rounded-4 p-0 fs-5 text-secondary fw-semi-bold">
+            Discovery Visibility
+            <InfoTooltip
+              position={{ top: true }}
+              target={
+                <Image
+                  src="/info.svg"
+                  alt="Info"
+                  width={18}
+                  height={18}
+                  className="align-top"
+                />
+              }
+              content={
+                <p className="m-0 p-2">
+                  Listed Flow Splitters may be surfaced on the Explore page.
+                  Unlisted ones stay accessible via direct link. You can change
+                  this later from the admin page.
+                </p>
+              }
+            />
+          </Card.Header>
+          <Card.Body className="p-0 mt-4">
+            <Form.Group>
+              <Stack direction="horizontal" gap={5}>
+                <FormCheck type="radio">
+                  <FormCheck.Input
+                    type="radio"
+                    checked={!poolConfig.listed}
+                    onChange={() =>
+                      setPoolConfig({
+                        ...poolConfig,
+                        listed: false,
+                      })
+                    }
+                  />
+                  <FormCheck.Label className="fw-semi-bold">
+                    Unlisted
+                  </FormCheck.Label>
+                </FormCheck>
+                <FormCheck type="radio">
+                  <FormCheck.Input
+                    type="radio"
+                    checked={!!poolConfig.listed}
+                    onChange={() =>
+                      setPoolConfig({
+                        ...poolConfig,
+                        listed: true,
+                      })
+                    }
+                  />
+                  <FormCheck.Label className="fw-semi-bold">
+                    Listed
+                  </FormCheck.Label>
+                </FormCheck>
+              </Stack>
+            </Form.Group>
           </Card.Body>
         </Card>
         <Stack direction="vertical" className="mt-6">

--- a/src/lib/listedMetadata.test.ts
+++ b/src/lib/listedMetadata.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import { parseListed, serializeListed } from "./listedMetadata";
+
+// Spec: "missing/non-true = unlisted" contract
+// Spec: "The flag is always written as a JSON object with listed:true (listed) or
+//        listed:false (unlisted). A round reads as Unlisted whenever the `listed`
+//        field is absent or not `true`"
+// Spec: "serialization must stay canonical (stable key, no incidental whitespace)"
+
+describe("parseListed", () => {
+  describe("returns true only for JSON with listed === true (boolean)", () => {
+    it('returns true for {"listed":true}', () => {
+      expect(parseListed('{"listed":true}')).toBe(true);
+    });
+
+    it("returns true for JSON with listed:true alongside other keys", () => {
+      expect(parseListed('{"listed":true,"other":"value"}')).toBe(true);
+    });
+
+    it("returns true for JSON with whitespace around listed:true", () => {
+      expect(parseListed('{ "listed": true }')).toBe(true);
+    });
+  });
+
+  describe("returns false for listed:false", () => {
+    it('returns false for {"listed":false}', () => {
+      expect(parseListed('{"listed":false}')).toBe(false);
+    });
+  });
+
+  describe("returns false for absent/missing listed key", () => {
+    it("returns false for empty JSON object", () => {
+      expect(parseListed("{}")).toBe(false);
+    });
+
+    it("returns false for JSON missing the listed key", () => {
+      expect(parseListed('{"name":"test","description":"foo"}')).toBe(false);
+    });
+  });
+
+  describe("returns false for non-boolean listed values (strict equality)", () => {
+    it('returns false for listed:"true" (string, not boolean)', () => {
+      expect(parseListed('{"listed":"true"}')).toBe(false);
+    });
+
+    it("returns false for listed:1 (number, not boolean)", () => {
+      expect(parseListed('{"listed":1}')).toBe(false);
+    });
+
+    it("returns false for listed:null", () => {
+      expect(parseListed('{"listed":null}')).toBe(false);
+    });
+
+    it('returns false for listed:"false"', () => {
+      expect(parseListed('{"listed":"false"}')).toBe(false);
+    });
+  });
+
+  describe("returns false for malformed / non-JSON input", () => {
+    it("returns false for empty string", () => {
+      expect(parseListed("")).toBe(false);
+    });
+
+    it("returns false for null", () => {
+      expect(parseListed(null)).toBe(false);
+    });
+
+    it("returns false for undefined", () => {
+      expect(parseListed(undefined)).toBe(false);
+    });
+
+    it("returns false for legacy free-form text (e.g. 'Test Dev Rewards')", () => {
+      expect(parseListed("Test Dev Rewards")).toBe(false);
+    });
+
+    it("returns false for another legacy free-form text value", () => {
+      expect(parseListed("ai16z Continuous Funding")).toBe(false);
+    });
+
+    it("returns false for partial JSON", () => {
+      expect(parseListed('{"listed":tru')).toBe(false);
+    });
+
+    it("returns false for a bare JSON string (not an object)", () => {
+      expect(parseListed('"listed"')).toBe(false);
+    });
+
+    it("returns false for a JSON array", () => {
+      expect(parseListed("[true]")).toBe(false);
+    });
+
+    it("returns false for a JSON number", () => {
+      expect(parseListed("1")).toBe(false);
+    });
+  });
+});
+
+describe("serializeListed", () => {
+  // Spec: "canonical (stable key, no incidental whitespace)" so the future
+  // subgraph `metadata_contains: '"listed":true'` substring filter matches.
+
+  it('serializes true as the exact string {"listed":true}', () => {
+    expect(serializeListed(true)).toBe('{"listed":true}');
+  });
+
+  it('serializes false as the exact string {"listed":false}', () => {
+    expect(serializeListed(false)).toBe('{"listed":false}');
+  });
+
+  it("produces no whitespace in the output for true", () => {
+    const result = serializeListed(true);
+    expect(result).not.toMatch(/\s/);
+  });
+
+  it("produces no whitespace in the output for false", () => {
+    const result = serializeListed(false);
+    expect(result).not.toMatch(/\s/);
+  });
+
+  it('listed:true output contains the substring \'"listed":true\'', () => {
+    // Confirms the future subgraph metadata_contains filter will match
+    expect(serializeListed(true)).toContain('"listed":true');
+  });
+
+  it("serializeListed(true) is parseable back to true via parseListed (round-trip)", () => {
+    expect(parseListed(serializeListed(true))).toBe(true);
+  });
+
+  it("serializeListed(false) is parseable back to false via parseListed (round-trip)", () => {
+    expect(parseListed(serializeListed(false))).toBe(false);
+  });
+});

--- a/src/lib/listedMetadata.ts
+++ b/src/lib/listedMetadata.ts
@@ -1,0 +1,36 @@
+/**
+ * Helpers for the round "listed" discovery flag.
+ *
+ * The flag is stored inside a round's existing metadata blob as a JSON object,
+ * e.g. `{"listed":true}` — in Postgres `rounds.details` for Flow Councils and in
+ * the on-chain `metadata` string for Flow Splitters. A round is "listed" ONLY
+ * when that object's `listed` value is the boolean `true`; everything else
+ * (empty/undefined, legacy free-form text, malformed JSON, a missing key, or a
+ * non-boolean value) reads as unlisted. This is the spec's
+ * "missing/non-true = unlisted" contract.
+ */
+export function parseListed(metadata: string | null | undefined): boolean {
+  if (!metadata) return false;
+  try {
+    const parsed = JSON.parse(metadata);
+    return (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      !Array.isArray(parsed) &&
+      parsed.listed === true
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Serializes the "listed" flag into the canonical metadata string, exactly
+ * `{"listed":true}` or `{"listed":false}` with no whitespace, so a future
+ * subgraph `metadata_contains: '"listed":true'` substring filter matches
+ * reliably. Keep this object to the single `listed` key — adding more keys
+ * would make substring matching order-sensitive.
+ */
+export function serializeListed(listed: boolean): string {
+  return JSON.stringify({ listed });
+}


### PR DESCRIPTION
## What
Adds a Listed/Unlisted discovery flag admins can set per round.
- **Flow Council** — toggle on the round metadata page; stored in Postgres `rounds.details`.
- **Flow Splitter** — toggle on launch (free, via `createPool`) and a dedicated "Save Visibility" action on the admin page (`updatePoolMetadata`); stored in the on-chain `metadata` string as `{"listed":true|false}`.

Shared helper `src/lib/listedMetadata.ts` enforces "missing/non-true = unlisted" and canonical serialization so a future Explore `metadata_contains` filter matches.

## Behavior
- Existing **and** new rounds default to **Unlisted** — no migration (absent `listed` = false).
- Council flag persists on create (POST) **and** edit (PATCH); a PATCH omitting `listed` won't clobber it.
- Splitter members/admins edits pass existing metadata through, so they never silently unlist; legacy free-form metadata parses safely to Unlisted.
- Non-admins and immutable pools have the toggle disabled (server/contract enforced).

## Out of scope
- Wiring the Explore page to read the flag (follow-up). Already queryable: subgraph `Pool.metadata` is indexed + filterable on all 5 chains; councils via DB.
- Verified/Featured stays the separate team-curated tier (unchanged).

## Testing
26 unit + 11 integration tests; `pnpm typecheck` + `pnpm lint` clean; full unit suite (138) green. On-chain splitter paths need manual smoke.