### PR TITLE
feat: Projected Funding estimate in Sponsor Stream

### DIFF
--- a/src/app/api/flow-council/email.ts
+++ b/src/app/api/flow-council/email.ts
@@ -1,8 +1,5 @@
 import removeMarkdown from "remove-markdown";
-import {
-  sendPersonalizedEmail,
-  type PersonalizedRecipient,
-} from "./ses";
+import { sendPersonalizedEmail, type PersonalizedRecipient } from "./ses";
 import { db } from "./db";
 import { generateNotificationToken } from "@/lib/notificationToken";
 import type { NotificationCategory } from "@/lib/consent";
@@ -172,11 +169,7 @@ export async function resolveRoundAdminRecipients(
     .where("userProfiles.emailSuspendedAt", "is", null)
     .where(`userProfiles.${col}`, "=", true);
   if (excludeAddress) {
-    q = q.where(
-      "roundAdmins.adminAddress",
-      "!=",
-      excludeAddress.toLowerCase(),
-    );
+    q = q.where("roundAdmins.adminAddress", "!=", excludeAddress.toLowerCase());
   }
   const rows = await q.execute();
   return toResolvedRecipients(rows);
@@ -558,4 +551,3 @@ export async function getRoundDetails(roundId: number): Promise<{
     councilId: round.flowCouncilAddress,
   };
 }
-

--- a/src/app/api/flow-council/platform-message/route.ts
+++ b/src/app/api/flow-council/platform-message/route.ts
@@ -33,9 +33,7 @@ export async function POST(request: Request) {
   }
 
   const authHeader = request.headers.get("authorization") ?? "";
-  const provided = authHeader.startsWith("Bearer ")
-    ? authHeader.slice(7)
-    : "";
+  const provided = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : "";
   // Hash both sides first so the comparison is constant-length and
   // constant-time regardless of `provided` length — avoids leaking the
   // secret's length via a short-circuit on length mismatch.

--- a/src/app/api/flow-council/profile/route.ts
+++ b/src/app/api/flow-council/profile/route.ts
@@ -135,7 +135,8 @@ export async function PUT(request: Request) {
 
     // Transition 1: email change (treat null === null as no-change).
     const emailChanged =
-      currentRow !== undefined && normalizedEmail !== (currentRow.email ?? null);
+      currentRow !== undefined &&
+      normalizedEmail !== (currentRow.email ?? null);
 
     // Transition 2: consent revocation (had consent → explicit null).
     // `undefined` means "field omitted" — must NOT count as revocation, or any
@@ -188,7 +189,8 @@ export async function PUT(request: Request) {
       values.consentVersion = data.consentVersion;
     }
     if (data.notifyApplicationEligibility !== undefined) {
-      updateSet.notifyApplicationEligibility = data.notifyApplicationEligibility;
+      updateSet.notifyApplicationEligibility =
+        data.notifyApplicationEligibility;
       values.notifyApplicationEligibility = data.notifyApplicationEligibility;
     }
     if (data.notifyProjectChannels !== undefined) {
@@ -221,7 +223,8 @@ export async function PUT(request: Request) {
       // is ambiguous (target row vs. EXCLUDED tuple) and Postgres aborts with
       // 42702. `user_profiles.email_version` is the pre-update value, which
       // is what we want to increment.
-      updateSet.emailVersion = sql<number>`user_profiles.email_version + 1` as unknown as number;
+      updateSet.emailVersion =
+        sql<number>`user_profiles.email_version + 1` as unknown as number;
     }
 
     const profile = await db

--- a/src/app/api/ses/sns-webhook/__tests__/route.test.ts
+++ b/src/app/api/ses/sns-webhook/__tests__/route.test.ts
@@ -112,11 +112,7 @@ describe("POST /api/ses/sns-webhook", () => {
       "=",
       "bouncer@example.com",
     );
-    expect(dbMock.where).toHaveBeenCalledWith(
-      "emailSuspendedAt",
-      "is",
-      null,
-    );
+    expect(dbMock.where).toHaveBeenCalledWith("emailSuspendedAt", "is", null);
     expect(dbMock.execute).toHaveBeenCalledTimes(1);
   });
 

--- a/src/app/api/ses/sns-webhook/route.ts
+++ b/src/app/api/ses/sns-webhook/route.ts
@@ -111,7 +111,10 @@ export async function POST(request: Request) {
   // 3. Branch on payload.Type.
   const type = payload.Type;
 
-  if (type === "SubscriptionConfirmation" || type === "UnsubscribeConfirmation") {
+  if (
+    type === "SubscriptionConfirmation" ||
+    type === "UnsubscribeConfirmation"
+  ) {
     if (typeof payload.SubscribeURL === "string") {
       // Restrict the outbound fetch host to AWS SNS regional endpoints.
       // Without this, a verified-but-attacker-shaped payload could direct us

--- a/src/app/flow-councils/funding/funding.tsx
+++ b/src/app/flow-councils/funding/funding.tsx
@@ -24,6 +24,7 @@ import Card from "react-bootstrap/Card";
 import Alert from "react-bootstrap/Alert";
 import { hostAddress } from "@sfpro/sdk/abi/core";
 import Sidebar from "@/app/flow-councils/components/Sidebar";
+import InfoTooltip from "@/components/InfoTooltip";
 import { getApolloClient } from "@/lib/apollo";
 import { networks, isSplitterFactoryDeployed } from "@/lib/networks";
 import { superAppSplitterAbi } from "@/lib/abi/superAppSplitter";
@@ -201,8 +202,8 @@ export default function Funding(props: FundingProps) {
   }, [senderOutflowsRes, address, acceptedToken, splitterAddress]);
 
   const currentFlowRate = useMemo<bigint | null>(() => {
-    if (!address || !acceptedToken || !splitterAddress) return null;
-    if (!senderOutflowsRes) return null;
+    if (!address || !acceptedToken || !splitterAddress || !senderOutflowsRes)
+      return null;
     return sponsoredOutflow ? BigInt(sponsoredOutflow.currentFlowRate) : 0n;
   }, [
     senderOutflowsRes,
@@ -355,12 +356,15 @@ export default function Funding(props: FundingProps) {
     if (remainingSeconds === null) return null;
     const updatedAt = sponsoredOutflow?.updatedAtTimestamp ?? 0;
     const rate = currentFlowRate ?? 0n;
-    const elapsed = updatedAt ? BigInt(nowSeconds) - BigInt(updatedAt) : 0n;
-    const streamedSoFar =
-      elapsed > 0n
+    const streamedSoFarAt = (t: bigint) => {
+      const elapsed = updatedAt ? t - BigInt(updatedAt) : 0n;
+      return elapsed > 0n
         ? sponsoredStreamedUntilUpdatedAt + rate * elapsed
         : sponsoredStreamedUntilUpdatedAt;
-    return streamedSoFar + streamFlowRate * remainingSeconds;
+    };
+    return (
+      streamedSoFarAt(BigInt(nowSeconds)) + streamFlowRate * remainingSeconds
+    );
   }, [
     remainingSeconds,
     nowSeconds,
@@ -1278,10 +1282,18 @@ export default function Funding(props: FundingProps) {
                   <span className="fw-semi-bold">
                     {!projectedFundingReady
                       ? "—"
-                      : `${formatTokenAmount(
-                          streamFlowRate * BigInt(SECONDS_IN_MONTH),
-                          4,
-                        )} ${tokenSymbol}/mo`}
+                      : isStreamUpdate && additionalFlowRate > 0n
+                        ? `${formatTokenAmount(
+                            (currentFlowRate ?? 0n) * BigInt(SECONDS_IN_MONTH),
+                            4,
+                          )} + ${formatTokenAmount(
+                            additionalFlowRate * BigInt(SECONDS_IN_MONTH),
+                            4,
+                          )} ${tokenSymbol}/mo`
+                        : `${formatTokenAmount(
+                            streamFlowRate * BigInt(SECONDS_IN_MONTH),
+                            4,
+                          )} ${tokenSymbol}/mo`}
                   </span>
                 </Stack>
                 <Stack
@@ -1301,8 +1313,27 @@ export default function Funding(props: FundingProps) {
                   direction="horizontal"
                   className="justify-content-between"
                 >
-                  <span className="text-info fw-semi-bold">
+                  <span className="text-info fw-semi-bold d-flex align-items-center gap-1">
                     Projected sponsored
+                    <InfoTooltip
+                      position={{ top: true }}
+                      content={
+                        <>
+                          Your total streamed to the round when it ends, if you
+                          submit this rate now. The amount already streamed
+                          keeps accruing at your current rate; the remaining
+                          duration uses the new rate above.
+                        </>
+                      }
+                      target={
+                        <NextImage
+                          src="/info.svg"
+                          alt="More info"
+                          width={14}
+                          height={14}
+                        />
+                      }
+                    />
                   </span>
                   <span className="fw-semi-bold">
                     {!projectedFundingReady || projectedSponsored === null

--- a/src/app/flow-councils/funding/funding.tsx
+++ b/src/app/flow-councils/funding/funding.tsx
@@ -310,9 +310,28 @@ export default function Funding(props: FundingProps) {
   }, [additionalFlowRate, liquidationPeriod]);
 
   // ─── Projected Funding (read-only estimate) ───
+  // Coarse clock so "Remaining duration" and the projection stay current
+  // without riding the requestAnimationFrame path (i.e. without dancing).
+  const [nowSeconds, setNowSeconds] = useState(() =>
+    Math.floor(Date.now() / 1000),
+  );
+  useEffect(() => {
+    const id = setInterval(
+      () => setNowSeconds(Math.floor(Date.now() / 1000)),
+      30_000,
+    );
+    return () => clearInterval(id);
+  }, []);
+
+  // The Projected Funding figures depend on subgraph data; until the
+  // sender-outflows query resolves (or a wallet connects) `currentFlowRate`
+  // is null. Gate the display on this to avoid a flash of zero values.
+  const projectedFundingReady = currentFlowRate !== null;
+
   // Total already streamed by this wallet to the splitter, animated.
-  const sponsoredStreamedUntilUpdatedAt = BigInt(
-    sponsoredOutflow?.streamedUntilUpdatedAt ?? 0,
+  const sponsoredStreamedUntilUpdatedAt = useMemo(
+    () => BigInt(sponsoredOutflow?.streamedUntilUpdatedAt ?? 0),
+    [sponsoredOutflow],
   );
   const currentSponsored = useFlowingAmount(
     sponsoredStreamedUntilUpdatedAt,
@@ -321,23 +340,22 @@ export default function Funding(props: FundingProps) {
   );
 
   // Time left until the round closes. `null` when there is no end date set.
-  // Anchored on `roundEndsAt` so it does not recompute on animation frames.
   const remainingSeconds = useMemo<bigint | null>(() => {
     if (!roundEndsAt || roundEndsAt === 0n) return null;
-    const now = BigInt(Math.floor(Date.now() / 1000));
-    const remaining = roundEndsAt - now;
+    const remaining = roundEndsAt - BigInt(nowSeconds);
     return remaining > 0n ? remaining : 0n;
-  }, [roundEndsAt]);
+  }, [roundEndsAt, nowSeconds]);
 
-  // Snapshot of total streamed once at the pending rate over the remaining
-  // duration. Memoized (not animated) so this value stays put — the spec
-  // requires a static projection, not a dancing balance.
+  // Snapshot of the wallet's total streamed at round close. Memoized (not
+  // animated) so it stays put — the spec wants a static projection, not a
+  // dancing balance. Intentional rate switch: the already-streamed portion
+  // accrues at the current on-chain rate, while the remaining duration uses
+  // the pending input rate — i.e. "what my total becomes if I submit this".
   const projectedSponsored = useMemo<bigint | null>(() => {
     if (remainingSeconds === null) return null;
     const updatedAt = sponsoredOutflow?.updatedAtTimestamp ?? 0;
     const rate = currentFlowRate ?? 0n;
-    const now = BigInt(Math.floor(Date.now() / 1000));
-    const elapsed = updatedAt ? now - BigInt(updatedAt) : 0n;
+    const elapsed = updatedAt ? BigInt(nowSeconds) - BigInt(updatedAt) : 0n;
     const streamedSoFar =
       elapsed > 0n
         ? sponsoredStreamedUntilUpdatedAt + rate * elapsed
@@ -345,6 +363,7 @@ export default function Funding(props: FundingProps) {
     return streamedSoFar + streamFlowRate * remainingSeconds;
   }, [
     remainingSeconds,
+    nowSeconds,
     streamFlowRate,
     currentFlowRate,
     sponsoredOutflow,
@@ -1238,14 +1257,17 @@ export default function Funding(props: FundingProps) {
                     Remaining duration
                   </span>
                   <span className="fw-semi-bold">
-                    {remainingSeconds === null
-                      ? "No end date"
-                      : remainingSeconds === 0n
-                        ? "Round ended"
-                        : `${(Number(remainingSeconds) / 86400).toLocaleString(
-                            undefined,
-                            { maximumFractionDigits: 1 },
-                          )} days`}
+                    {roundStatus === "loading"
+                      ? "—"
+                      : remainingSeconds === null
+                        ? "No end date"
+                        : remainingSeconds === 0n
+                          ? "Round ended"
+                          : `${(
+                              Number(remainingSeconds) / 86400
+                            ).toLocaleString(undefined, {
+                              maximumFractionDigits: 1,
+                            })} days`}
                   </span>
                 </Stack>
                 <Stack
@@ -1254,10 +1276,12 @@ export default function Funding(props: FundingProps) {
                 >
                   <span className="text-info fw-semi-bold">Sponsored rate</span>
                   <span className="fw-semi-bold">
-                    {`${formatTokenAmount(
-                      streamFlowRate * BigInt(SECONDS_IN_MONTH),
-                      4,
-                    )} ${tokenSymbol}/mo`}
+                    {!projectedFundingReady
+                      ? "—"
+                      : `${formatTokenAmount(
+                          streamFlowRate * BigInt(SECONDS_IN_MONTH),
+                          4,
+                        )} ${tokenSymbol}/mo`}
                   </span>
                 </Stack>
                 <Stack
@@ -1268,7 +1292,9 @@ export default function Funding(props: FundingProps) {
                     Current sponsored
                   </span>
                   <span className="fw-semi-bold">
-                    {`${formatTokenAmount(currentSponsored)} ${tokenSymbol}`}
+                    {!projectedFundingReady
+                      ? "—"
+                      : `${formatTokenAmount(currentSponsored)} ${tokenSymbol}`}
                   </span>
                 </Stack>
                 <Stack
@@ -1279,7 +1305,7 @@ export default function Funding(props: FundingProps) {
                     Projected sponsored
                   </span>
                   <span className="fw-semi-bold">
-                    {projectedSponsored === null
+                    {!projectedFundingReady || projectedSponsored === null
                       ? "—"
                       : `${formatTokenAmount(projectedSponsored, 4)} ${tokenSymbol}`}
                   </span>

--- a/src/app/flow-councils/funding/funding.tsx
+++ b/src/app/flow-councils/funding/funding.tsx
@@ -38,6 +38,7 @@ import { TransactionCall } from "@/types/transactionCall";
 import { SECONDS_IN_MONTH } from "@/lib/constants";
 import { truncateStr, waitForReceipt } from "@/lib/utils";
 import { useMediaQuery } from "@/hooks/mediaQuery";
+import useFlowingAmount from "@/hooks/flowingAmount";
 import useSuperTokenBalanceOfNow from "@/hooks/superTokenBalanceOfNow";
 import useSuperTokenType from "@/hooks/superTokenType";
 import useTransactionsQueue from "@/hooks/transactionsQueue";
@@ -68,6 +69,8 @@ const SF_SENDER_OUTFLOWS_QUERY = gql`
         receiver {
           id
         }
+        streamedUntilUpdatedAt
+        updatedAtTimestamp
         currentFlowRate
       }
     }
@@ -85,6 +88,12 @@ function formatMonthlyForInput(monthlyWei: bigint): string {
   const half = PRECISION_DIVISOR / 2n;
   const rounded = ((monthlyWei + half) / PRECISION_DIVISOR) * PRECISION_DIVISOR;
   return formatUnits(rounded, 18);
+}
+
+function formatTokenAmount(wei: bigint, maxDigits = 6): string {
+  return Number(formatUnits(wei, 18)).toLocaleString(undefined, {
+    maximumFractionDigits: maxDigits,
+  });
 }
 
 function SuccessCheckmark() {
@@ -176,15 +185,32 @@ export default function Funding(props: FundingProps) {
     pollInterval: 10000,
   });
 
+  const sponsoredOutflow = useMemo<{
+    streamedUntilUpdatedAt: string;
+    updatedAtTimestamp: number;
+    currentFlowRate: string;
+  } | null>(() => {
+    if (!address || !acceptedToken || !splitterAddress) return null;
+    if (!senderOutflowsRes) return null;
+    return (
+      senderOutflowsRes.account?.outflows?.find(
+        (o: { receiver: { id: string } }) =>
+          o.receiver.id === splitterAddress.toLowerCase(),
+      ) ?? null
+    );
+  }, [senderOutflowsRes, address, acceptedToken, splitterAddress]);
+
   const currentFlowRate = useMemo<bigint | null>(() => {
     if (!address || !acceptedToken || !splitterAddress) return null;
     if (!senderOutflowsRes) return null;
-    const outflow = senderOutflowsRes.account?.outflows?.find(
-      (o: { receiver: { id: string }; currentFlowRate: string }) =>
-        o.receiver.id === splitterAddress.toLowerCase(),
-    );
-    return outflow ? BigInt(outflow.currentFlowRate) : 0n;
-  }, [senderOutflowsRes, address, acceptedToken, splitterAddress]);
+    return sponsoredOutflow ? BigInt(sponsoredOutflow.currentFlowRate) : 0n;
+  }, [
+    senderOutflowsRes,
+    sponsoredOutflow,
+    address,
+    acceptedToken,
+    splitterAddress,
+  ]);
 
   const { balanceUntilUpdatedAt: adminBalanceRaw } = useSuperTokenBalanceOfNow({
     token: acceptedToken ?? undefined,
@@ -282,6 +308,48 @@ export default function Funding(props: FundingProps) {
     if (additionalFlowRate === 0n || !liquidationPeriod) return 0n;
     return additionalFlowRate * liquidationPeriod;
   }, [additionalFlowRate, liquidationPeriod]);
+
+  // ─── Projected Funding (read-only estimate) ───
+  // Total already streamed by this wallet to the splitter, animated.
+  const sponsoredStreamedUntilUpdatedAt = BigInt(
+    sponsoredOutflow?.streamedUntilUpdatedAt ?? 0,
+  );
+  const currentSponsored = useFlowingAmount(
+    sponsoredStreamedUntilUpdatedAt,
+    sponsoredOutflow?.updatedAtTimestamp ?? 0,
+    currentFlowRate ?? 0n,
+  );
+
+  // Time left until the round closes. `null` when there is no end date set.
+  // Anchored on `roundEndsAt` so it does not recompute on animation frames.
+  const remainingSeconds = useMemo<bigint | null>(() => {
+    if (!roundEndsAt || roundEndsAt === 0n) return null;
+    const now = BigInt(Math.floor(Date.now() / 1000));
+    const remaining = roundEndsAt - now;
+    return remaining > 0n ? remaining : 0n;
+  }, [roundEndsAt]);
+
+  // Snapshot of total streamed once at the pending rate over the remaining
+  // duration. Memoized (not animated) so this value stays put — the spec
+  // requires a static projection, not a dancing balance.
+  const projectedSponsored = useMemo<bigint | null>(() => {
+    if (remainingSeconds === null) return null;
+    const updatedAt = sponsoredOutflow?.updatedAtTimestamp ?? 0;
+    const rate = currentFlowRate ?? 0n;
+    const now = BigInt(Math.floor(Date.now() / 1000));
+    const elapsed = updatedAt ? now - BigInt(updatedAt) : 0n;
+    const streamedSoFar =
+      elapsed > 0n
+        ? sponsoredStreamedUntilUpdatedAt + rate * elapsed
+        : sponsoredStreamedUntilUpdatedAt;
+    return streamedSoFar + streamFlowRate * remainingSeconds;
+  }, [
+    remainingSeconds,
+    streamFlowRate,
+    currentFlowRate,
+    sponsoredOutflow,
+    sponsoredStreamedUntilUpdatedAt,
+  ]);
 
   const isStreamUpdate = (currentFlowRate ?? 0n) > 0n;
   const streamFlowRateUnchanged =
@@ -1154,6 +1222,69 @@ export default function Funding(props: FundingProps) {
                   />
                 </Form.Group>
               )}
+              <Stack
+                direction="vertical"
+                gap={2}
+                className="bg-white rounded-4 p-3"
+              >
+                <Card.Text className="mb-0 fw-semi-bold">
+                  Projected Funding
+                </Card.Text>
+                <Stack
+                  direction="horizontal"
+                  className="justify-content-between"
+                >
+                  <span className="text-info fw-semi-bold">
+                    Remaining duration
+                  </span>
+                  <span className="fw-semi-bold">
+                    {remainingSeconds === null
+                      ? "No end date"
+                      : remainingSeconds === 0n
+                        ? "Round ended"
+                        : `${(Number(remainingSeconds) / 86400).toLocaleString(
+                            undefined,
+                            { maximumFractionDigits: 1 },
+                          )} days`}
+                  </span>
+                </Stack>
+                <Stack
+                  direction="horizontal"
+                  className="justify-content-between"
+                >
+                  <span className="text-info fw-semi-bold">Sponsored rate</span>
+                  <span className="fw-semi-bold">
+                    {`${formatTokenAmount(
+                      streamFlowRate * BigInt(SECONDS_IN_MONTH),
+                      4,
+                    )} ${tokenSymbol}/mo`}
+                  </span>
+                </Stack>
+                <Stack
+                  direction="horizontal"
+                  className="justify-content-between"
+                >
+                  <span className="text-info fw-semi-bold">
+                    Current sponsored
+                  </span>
+                  <span className="fw-semi-bold">
+                    {`${formatTokenAmount(currentSponsored)} ${tokenSymbol}`}
+                  </span>
+                </Stack>
+                <Stack
+                  direction="horizontal"
+                  className="justify-content-between"
+                >
+                  <span className="text-info fw-semi-bold">
+                    Projected sponsored
+                  </span>
+                  <span className="fw-semi-bold">
+                    {projectedSponsored === null
+                      ? "—"
+                      : `${formatTokenAmount(projectedSponsored, 4)} ${tokenSymbol}`}
+                  </span>
+                </Stack>
+              </Stack>
               {streamWrapExceedsUnderlying ? (
                 <Alert variant="danger" className="mb-0 fw-semi-bold">
                   Wrap amount exceeds your underlying balance.

--- a/src/components/checkout/Review.tsx
+++ b/src/components/checkout/Review.tsx
@@ -105,10 +105,8 @@ export default function Review(props: ReviewProps) {
     hasAcceptedCloseLiquidationWarning,
     setHasAcceptedCloseLiquidationWarning,
   ] = useState(false);
-  const [
-    hasAcceptedSplitterCapWarning,
-    setHasAcceptedSplitterCapWarning,
-  ] = useState(false);
+  const [hasAcceptedSplitterCapWarning, setHasAcceptedSplitterCapWarning] =
+    useState(false);
 
   const wrapAmountForDisplay =
     areTransactionsLoading && transactionDetailsSnapshot

--- a/src/generated/kysely.ts
+++ b/src/generated/kysely.ts
@@ -1,164 +1,166 @@
 import type { ColumnType } from "kysely";
-export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
-  ? ColumnType<S, I | undefined, U>
-  : ColumnType<T, T | undefined, T>;
+export type Generated<T> =
+  T extends ColumnType<infer S, infer I, infer U>
+    ? ColumnType<S, I | undefined, U>
+    : ColumnType<T, T | undefined, T>;
 export type Timestamp = ColumnType<Date, Date | string, Date | string>;
 
 export const ApplicationStatus = {
-    INCOMPLETE: "INCOMPLETE",
-    SUBMITTED: "SUBMITTED",
-    ACCEPTED: "ACCEPTED",
-    CHANGES_REQUESTED: "CHANGES_REQUESTED",
-    REJECTED: "REJECTED",
-    REMOVED: "REMOVED",
-    GRADUATED: "GRADUATED"
+  INCOMPLETE: "INCOMPLETE",
+  SUBMITTED: "SUBMITTED",
+  ACCEPTED: "ACCEPTED",
+  CHANGES_REQUESTED: "CHANGES_REQUESTED",
+  REJECTED: "REJECTED",
+  REMOVED: "REMOVED",
+  GRADUATED: "GRADUATED",
 } as const;
-export type ApplicationStatus = (typeof ApplicationStatus)[keyof typeof ApplicationStatus];
+export type ApplicationStatus =
+  (typeof ApplicationStatus)[keyof typeof ApplicationStatus];
 export const ChannelType = {
-    INTERNAL_APPLICATION: "INTERNAL_APPLICATION",
-    GROUP_ANNOUNCEMENTS: "GROUP_ANNOUNCEMENTS",
-    GROUP_APPLICANTS: "GROUP_APPLICANTS",
-    GROUP_GRANTEES: "GROUP_GRANTEES",
-    GROUP_ROUND_ADMINS: "GROUP_ROUND_ADMINS",
-    GROUP_PROJECT: "GROUP_PROJECT",
-    PUBLIC_ROUND: "PUBLIC_ROUND",
-    PUBLIC_PROJECT: "PUBLIC_PROJECT"
+  INTERNAL_APPLICATION: "INTERNAL_APPLICATION",
+  GROUP_ANNOUNCEMENTS: "GROUP_ANNOUNCEMENTS",
+  GROUP_APPLICANTS: "GROUP_APPLICANTS",
+  GROUP_GRANTEES: "GROUP_GRANTEES",
+  GROUP_ROUND_ADMINS: "GROUP_ROUND_ADMINS",
+  GROUP_PROJECT: "GROUP_PROJECT",
+  PUBLIC_ROUND: "PUBLIC_ROUND",
+  PUBLIC_PROJECT: "PUBLIC_PROJECT",
 } as const;
 export type ChannelType = (typeof ChannelType)[keyof typeof ChannelType];
 export type Application = {
-    id: Generated<number>;
-    projectId: number;
-    roundId: number;
-    fundingAddress: string;
-    status: Generated<ApplicationStatus>;
-    details: unknown | null;
-    editsUnlocked: Generated<boolean>;
-    createdAt: Generated<Timestamp>;
-    updatedAt: Generated<Timestamp>;
+  id: Generated<number>;
+  projectId: number;
+  roundId: number;
+  fundingAddress: string;
+  status: Generated<ApplicationStatus>;
+  details: unknown | null;
+  editsUnlocked: Generated<boolean>;
+  createdAt: Generated<Timestamp>;
+  updatedAt: Generated<Timestamp>;
 };
 export type InboxItem = {
-    id: Generated<number>;
-    recipientAddress: string;
-    messageId: number | null;
-    applicationId: number | null;
-    category: string;
-    sourceLabel: string | null;
-    snippet: string | null;
-    readAt: Timestamp | null;
-    createdAt: Generated<Timestamp>;
+  id: Generated<number>;
+  recipientAddress: string;
+  messageId: number | null;
+  applicationId: number | null;
+  category: string;
+  sourceLabel: string | null;
+  snippet: string | null;
+  readAt: Timestamp | null;
+  createdAt: Generated<Timestamp>;
 };
 export type Message = {
-    id: Generated<number>;
-    channelType: ChannelType;
-    roundId: number | null;
-    projectId: number | null;
-    applicationId: number | null;
-    authorAddress: string;
-    content: string;
-    messageType: Generated<string>;
-    pinnedAt: Timestamp | null;
-    pinnedBy: string | null;
-    createdAt: Generated<Timestamp>;
-    updatedAt: Generated<Timestamp>;
+  id: Generated<number>;
+  channelType: ChannelType;
+  roundId: number | null;
+  projectId: number | null;
+  applicationId: number | null;
+  authorAddress: string;
+  content: string;
+  messageType: Generated<string>;
+  pinnedAt: Timestamp | null;
+  pinnedBy: string | null;
+  createdAt: Generated<Timestamp>;
+  updatedAt: Generated<Timestamp>;
 };
 export type MessageReaction = {
-    id: Generated<number>;
-    messageId: number;
-    authorAddress: string;
-    emoji: string;
-    createdAt: Generated<Timestamp>;
+  id: Generated<number>;
+  messageId: number;
+  authorAddress: string;
+  emoji: string;
+  createdAt: Generated<Timestamp>;
 };
 export type MilestoneProgress = {
-    id: Generated<number>;
-    applicationId: number;
-    milestoneType: string;
-    milestoneIndex: number;
-    progress: unknown | null;
-    createdAt: Generated<Timestamp>;
-    updatedAt: Generated<Timestamp>;
+  id: Generated<number>;
+  applicationId: number;
+  milestoneType: string;
+  milestoneIndex: number;
+  progress: unknown | null;
+  createdAt: Generated<Timestamp>;
+  updatedAt: Generated<Timestamp>;
 };
 export type Project = {
-    id: Generated<number>;
-    details: unknown | null;
-    createdAt: Generated<Timestamp>;
-    updatedAt: Generated<Timestamp>;
+  id: Generated<number>;
+  details: unknown | null;
+  createdAt: Generated<Timestamp>;
+  updatedAt: Generated<Timestamp>;
 };
 export type ProjectEmail = {
-    id: Generated<number>;
-    projectId: number;
-    email: string;
-    managerAddress: string | null;
-    createdAt: Generated<Timestamp>;
+  id: Generated<number>;
+  projectId: number;
+  email: string;
+  managerAddress: string | null;
+  createdAt: Generated<Timestamp>;
 };
 export type ProjectManager = {
-    id: Generated<number>;
-    projectId: number;
-    managerAddress: string;
-    createdAt: Generated<Timestamp>;
+  id: Generated<number>;
+  projectId: number;
+  managerAddress: string;
+  createdAt: Generated<Timestamp>;
 };
 export type Recipient = {
-    id: Generated<number>;
-    applicationId: number;
-    createdAt: Generated<Timestamp>;
+  id: Generated<number>;
+  applicationId: number;
+  createdAt: Generated<Timestamp>;
 };
 export type Round = {
-    id: Generated<number>;
-    chainId: number;
-    flowCouncilAddress: string;
-    superappSplitterAddress: string | null;
-    applicationsClosed: Generated<boolean>;
-    details: unknown | null;
-    createdAt: Generated<Timestamp>;
-    updatedAt: Generated<Timestamp>;
+  id: Generated<number>;
+  chainId: number;
+  flowCouncilAddress: string;
+  superappSplitterAddress: string | null;
+  applicationsClosed: Generated<boolean>;
+  details: unknown | null;
+  createdAt: Generated<Timestamp>;
+  updatedAt: Generated<Timestamp>;
 };
 export type RoundAdmin = {
-    id: Generated<number>;
-    roundId: number;
-    adminAddress: string;
-    createdAt: Generated<Timestamp>;
+  id: Generated<number>;
+  roundId: number;
+  adminAddress: string;
+  createdAt: Generated<Timestamp>;
 };
 export type RoundAdminEmail = {
-    id: Generated<number>;
-    roundAdminId: number;
-    email: string;
-    createdAt: Generated<Timestamp>;
+  id: Generated<number>;
+  roundAdminId: number;
+  email: string;
+  createdAt: Generated<Timestamp>;
 };
 export type UserProfile = {
-    id: Generated<number>;
-    address: string;
-    displayName: string;
-    bio: string | null;
-    twitter: string | null;
-    github: string | null;
-    linkedin: string | null;
-    farcaster: string | null;
-    email: string | null;
-    telegram: string | null;
-    notifyApplicationEligibility: Generated<boolean>;
-    notifyProjectChannels: Generated<boolean>;
-    notifyRoundAnnouncements: Generated<boolean>;
-    notifyInternalReview: Generated<boolean>;
-    notifyPlatform: Generated<boolean>;
-    consentConfirmedAt: Timestamp | null;
-    consentVersion: string | null;
-    emailVersion: Generated<number>;
-    emailSuspendedAt: Timestamp | null;
-    emailSuspensionReason: string | null;
-    createdAt: Generated<Timestamp>;
-    updatedAt: Generated<Timestamp>;
+  id: Generated<number>;
+  address: string;
+  displayName: string;
+  bio: string | null;
+  twitter: string | null;
+  github: string | null;
+  linkedin: string | null;
+  farcaster: string | null;
+  email: string | null;
+  telegram: string | null;
+  notifyApplicationEligibility: Generated<boolean>;
+  notifyProjectChannels: Generated<boolean>;
+  notifyRoundAnnouncements: Generated<boolean>;
+  notifyInternalReview: Generated<boolean>;
+  notifyPlatform: Generated<boolean>;
+  consentConfirmedAt: Timestamp | null;
+  consentVersion: string | null;
+  emailVersion: Generated<number>;
+  emailSuspendedAt: Timestamp | null;
+  emailSuspensionReason: string | null;
+  createdAt: Generated<Timestamp>;
+  updatedAt: Generated<Timestamp>;
 };
 export type DB = {
-    applications: Application;
-    inboxItems: InboxItem;
-    messageReactions: MessageReaction;
-    messages: Message;
-    milestoneProgress: MilestoneProgress;
-    projectEmails: ProjectEmail;
-    projectManagers: ProjectManager;
-    projects: Project;
-    recipients: Recipient;
-    roundAdminEmails: RoundAdminEmail;
-    roundAdmins: RoundAdmin;
-    rounds: Round;
-    userProfiles: UserProfile;
+  applications: Application;
+  inboxItems: InboxItem;
+  messageReactions: MessageReaction;
+  messages: Message;
+  milestoneProgress: MilestoneProgress;
+  projectEmails: ProjectEmail;
+  projectManagers: ProjectManager;
+  projects: Project;
+  recipients: Recipient;
+  roundAdminEmails: RoundAdminEmail;
+  roundAdmins: RoundAdmin;
+  rounds: Round;
+  userProfiles: UserProfile;
 };


### PR DESCRIPTION
## What

Adds a read-only **Projected Funding** block to the Sponsor Stream card on the flow-council funding page, positioned between the Wrap Token input and the Open Stream button.

Four fields:
- **Remaining duration** — `roundEndsAt − now` in days (shows "No end date" / "Round ended" when applicable).
- **Sponsored rate** — the monthly flow-rate input, in `{TOKEN}/mo`.
- **Current sponsored** — total streamed by the connected wallet to the splitter so far, as an animated *dancing balance* (`useFlowingAmount`).
- **Projected sponsored** — projected total streamed at round close = `streamed-so-far + pending rate × remaining duration`. A static `useMemo` snapshot (intentionally **not** a dancing balance).

## Implementation notes

- Extends `SF_SENDER_OUTFLOWS_QUERY` with `streamedUntilUpdatedAt` + `updatedAtTimestamp` (mirrors the existing query in `DistributionPoolFunding.tsx`).
- Factored the matching outflow into a `sponsoredOutflow` memo; `currentFlowRate` now derives from it.
- `remainingSeconds` / `projectedSponsored` are anchored on their real inputs so they don't recompute on animation frames — keeping the projected total stationary while the current balance animates.

## Interpretation flag

The spec described Sponsored Rate as "Current Rate + Pending Input". The existing monthly-rate field is prefilled with the current rate and represents the *new total* (the form derives the additional buffer from the delta), so the displayed value already equals current + your change. If the input should instead be treated as additive on top of the current rate, the form semantics would need to change too.

## Commits

- `feat:` the Projected Funding feature (`funding.tsx` only)
- `style:` a tree-wide prettier pass that reformatted 7 pre-existing unrelated files

## Verification

`pnpm typecheck` ✅ · `pnpm lint` ✅ · `prettier --check src` ✅