### PR TITLE
chore: close down GoodBuilders S3

### DIFF
--- a/src/app/api/flow-council/eligibility/route.ts
+++ b/src/app/api/flow-council/eligibility/route.ts
@@ -5,6 +5,7 @@ import { networks, getViemChain } from "@/lib/networks";
 import {
   GOODBUILDERS_COUNCIL_ADDRESSES,
   GOODDOLLAR_IDENTITY_ADDRESS,
+  GOODDOLLAR_SELF_CLAIM_OPEN,
 } from "@/app/flow-councils/lib/constants";
 
 export const dynamic = "force-dynamic";
@@ -20,6 +21,15 @@ const IDENTITY_ABI = [
 ] as const;
 
 export async function POST(request: Request) {
+  // GoodBuilders S3 has ended: the GoodDollar voter self-claim flow is closed,
+  // so the bot no longer adds voters. Re-enable via GOODDOLLAR_SELF_CLAIM_OPEN.
+  if (!GOODDOLLAR_SELF_CLAIM_OPEN) {
+    return Response.json({
+      success: false,
+      error: "Voter eligibility self-claim is closed",
+    });
+  }
+
   try {
     const { address, chainId, councilId } = await request.json();
 

--- a/src/app/explore/explore.tsx
+++ b/src/app/explore/explore.tsx
@@ -83,22 +83,6 @@ export default function Explore(props: ExploreProps) {
           }}
         >
           <RoundCard
-            name="GoodBuilders S3"
-            image="/good-dollar.png"
-            roundType="Flow Council"
-            totalStreamedUntilUpdatedAt={BigInt(
-              goodBuildersS3Inflow?.totalAmountStreamedInUntilUpdatedAt ?? 0,
-            ).toString()}
-            flowRate={BigInt(
-              goodBuildersS3Inflow?.totalInflowRate ?? 0,
-            ).toString()}
-            updatedAt={goodBuildersS3Inflow?.updatedAtTimestamp}
-            activeStreamCount={goodBuildersS3Inflow?.activeIncomingStreamCount}
-            tokenSymbol="G$"
-            link="https://flowstate.network/goodbuilders-3"
-            showSupRewards
-          />
-          <RoundCard
             name="Arbitrum Mini Apps"
             image="/arb.png"
             roundType="Flow Caster"
@@ -167,6 +151,21 @@ export default function Explore(props: ExploreProps) {
                   : "",
           }}
         >
+          <RoundCard
+            name="GoodBuilders S3"
+            image="/good-dollar.png"
+            roundType="Flow Council"
+            totalStreamedUntilUpdatedAt={BigInt(
+              goodBuildersS3Inflow?.totalAmountStreamedInUntilUpdatedAt ?? 0,
+            ).toString()}
+            flowRate={BigInt(
+              goodBuildersS3Inflow?.totalInflowRate ?? 0,
+            ).toString()}
+            updatedAt={goodBuildersS3Inflow?.updatedAtTimestamp}
+            activeStreamCount={goodBuildersS3Inflow?.activeIncomingStreamCount}
+            tokenSymbol="G$"
+            link="https://flowstate.network/goodbuilders-3"
+          />
           <RoundCard
             name="Octant Builder Accelerator"
             image="/octant-circle.svg"

--- a/src/app/flow-councils/components/EligibilityButton.tsx
+++ b/src/app/flow-councils/components/EligibilityButton.tsx
@@ -4,7 +4,10 @@ import { useConnectModal } from "@rainbow-me/rainbowkit";
 import Button from "react-bootstrap/Button";
 import Spinner from "react-bootstrap/Spinner";
 import useFlowCouncil from "../hooks/flowCouncil";
-import { GOODBUILDERS_COUNCIL_ADDRESSES } from "../lib/constants";
+import {
+  GOODBUILDERS_COUNCIL_ADDRESSES,
+  GOODDOLLAR_SELF_CLAIM_OPEN,
+} from "../lib/constants";
 
 type EligibilityStatus =
   | "idle"
@@ -73,7 +76,7 @@ export default function EligibilityButton({
     }
   }, [status, councilMember]);
 
-  if (!isGoodBuildersCouncil) {
+  if (!isGoodBuildersCouncil || !GOODDOLLAR_SELF_CLAIM_OPEN) {
     return null;
   }
 

--- a/src/app/flow-councils/lib/constants.ts
+++ b/src/app/flow-councils/lib/constants.ts
@@ -10,6 +10,13 @@ export const GOODBUILDERS_COUNCIL_ADDRESSES: `0x${string}`[] = [
   "0xfabef1abae4998146e8a8422813eb787caa26ec2",
 ];
 
+// GoodBuilders S3 has ended: the GoodDollar voter self-claim flow is closed.
+// This gates both the "Check Voter Eligibility" button (EligibilityButton.tsx)
+// and the bot-driven addVoter endpoint (api/flow-council/eligibility). Set back
+// to true to reopen self-claim. The onchain kill switch is revoking the bot's
+// VOTER_MANAGER_ROLE on the council.
+export const GOODDOLLAR_SELF_CLAIM_OPEN = false;
+
 export const GOODDOLLAR_IDENTITY_ADDRESS: `0x${string}` =
   "0xC361A6E67822a0EDc17D899227dd9FC50BD62F42";
 


### PR DESCRIPTION
Part of the GoodBuilders S3 closedown.

## Changes
- **/explore**: move the GoodBuilders S3 card from Active to Completed and remove the SUP rewards badge.
- **GoodDollar voter self-claim**: gated behind a single `GOODDOLLAR_SELF_CLAIM_OPEN` flag (default `false`):
  - `EligibilityButton` no longer renders on the GoodBuilders councils.
  - `POST /api/flow-council/eligibility` returns "self-claim is closed" without calling the bot.
  - Flip the flag back to `true` to reopen.

## Not in this PR (onchain / ops, handled separately)
- Closing the inbound G$ streams to the splitter + GDA wind-down.
- Withdrawing G$ from the splitter (`emergencyWithdraw`, admin EOA).
- Revoking the bot's `VOTER_MANAGER_ROLE`.
- Disabling the external SUP-points crons.

`pnpm typecheck` and `pnpm lint` pass.
