### PR TITLE
fix: default Flow Council launch network to the selected network

### DIFF
--- a/src/app/api/flow-council/rounds/route.integration.test.ts
+++ b/src/app/api/flow-council/rounds/route.integration.test.ts
@@ -64,9 +64,7 @@ describe("PATCH /api/flow-council/rounds — listed flag", () => {
 
   it("rejects unauthenticated requests", async () => {
     mockUnauthenticated();
-    const res = await PATCH(
-      patchRequest({ ...basePayload, listed: true }),
-    );
+    const res = await PATCH(patchRequest({ ...basePayload, listed: true }));
     const body = await readJson(res);
     expect(body.success).toBe(false);
     expect(body.error).toBe("Unauthenticated");
@@ -74,9 +72,7 @@ describe("PATCH /api/flow-council/rounds — listed flag", () => {
 
   it("rejects a non-admin from changing listed", async () => {
     mockSession(TEST_OUTSIDER_ADDRESS);
-    const res = await PATCH(
-      patchRequest({ ...basePayload, listed: true }),
-    );
+    const res = await PATCH(patchRequest({ ...basePayload, listed: true }));
     const body = await readJson(res);
     expect(body.success).toBe(false);
   });
@@ -84,9 +80,7 @@ describe("PATCH /api/flow-council/rounds — listed flag", () => {
   // Spec: "PATCH with listed:true stores listed in the details JSON"
   it("stores listed:true in rounds.details when admin sends listed:true", async () => {
     mockSession(TEST_ADMIN_ADDRESS);
-    const res = await PATCH(
-      patchRequest({ ...basePayload, listed: true }),
-    );
+    const res = await PATCH(patchRequest({ ...basePayload, listed: true }));
     const body = await readJson(res);
     expect(body.success).toBe(true);
 
@@ -94,11 +88,7 @@ describe("PATCH /api/flow-council/rounds — listed flag", () => {
       .selectFrom("rounds")
       .select("details")
       .where("chainId", "=", TEST_CHAIN_ID)
-      .where(
-        "flowCouncilAddress",
-        "=",
-        TEST_COUNCIL_ADDRESS.toLowerCase(),
-      )
+      .where("flowCouncilAddress", "=", TEST_COUNCIL_ADDRESS.toLowerCase())
       .executeTakeFirstOrThrow();
 
     const details =
@@ -111,9 +101,7 @@ describe("PATCH /api/flow-council/rounds — listed flag", () => {
   // Spec: "PATCH with listed:false updates it"
   it("stores listed:false in rounds.details when admin sends listed:false", async () => {
     mockSession(TEST_ADMIN_ADDRESS);
-    const res = await PATCH(
-      patchRequest({ ...basePayload, listed: false }),
-    );
+    const res = await PATCH(patchRequest({ ...basePayload, listed: false }));
     const body = await readJson(res);
     expect(body.success).toBe(true);
 
@@ -121,11 +109,7 @@ describe("PATCH /api/flow-council/rounds — listed flag", () => {
       .selectFrom("rounds")
       .select("details")
       .where("chainId", "=", TEST_CHAIN_ID)
-      .where(
-        "flowCouncilAddress",
-        "=",
-        TEST_COUNCIL_ADDRESS.toLowerCase(),
-      )
+      .where("flowCouncilAddress", "=", TEST_COUNCIL_ADDRESS.toLowerCase())
       .executeTakeFirstOrThrow();
 
     const details =
@@ -154,11 +138,7 @@ describe("PATCH /api/flow-council/rounds — listed flag", () => {
       .selectFrom("rounds")
       .select("details")
       .where("chainId", "=", TEST_CHAIN_ID)
-      .where(
-        "flowCouncilAddress",
-        "=",
-        TEST_COUNCIL_ADDRESS.toLowerCase(),
-      )
+      .where("flowCouncilAddress", "=", TEST_COUNCIL_ADDRESS.toLowerCase())
       .executeTakeFirstOrThrow();
 
     const details =
@@ -176,11 +156,7 @@ describe("PATCH /api/flow-council/rounds — listed flag", () => {
       .selectFrom("rounds")
       .select("details")
       .where("chainId", "=", TEST_CHAIN_ID)
-      .where(
-        "flowCouncilAddress",
-        "=",
-        TEST_COUNCIL_ADDRESS.toLowerCase(),
-      )
+      .where("flowCouncilAddress", "=", TEST_COUNCIL_ADDRESS.toLowerCase())
       .executeTakeFirstOrThrow();
 
     const details =
@@ -194,21 +170,30 @@ describe("PATCH /api/flow-council/rounds — listed flag", () => {
   it("does not alter other fields in details when updating listed", async () => {
     // Set name and description first
     mockSession(TEST_ADMIN_ADDRESS);
-    await PATCH(patchRequest({ ...basePayload, name: "My Round", description: "My desc" }));
+    await PATCH(
+      patchRequest({
+        ...basePayload,
+        name: "My Round",
+        description: "My desc",
+      }),
+    );
 
     // Now set listed:true
     mockSession(TEST_ADMIN_ADDRESS);
-    await PATCH(patchRequest({ ...basePayload, name: "My Round", description: "My desc", listed: true }));
+    await PATCH(
+      patchRequest({
+        ...basePayload,
+        name: "My Round",
+        description: "My desc",
+        listed: true,
+      }),
+    );
 
     const stored = await db
       .selectFrom("rounds")
       .select("details")
       .where("chainId", "=", TEST_CHAIN_ID)
-      .where(
-        "flowCouncilAddress",
-        "=",
-        TEST_COUNCIL_ADDRESS.toLowerCase(),
-      )
+      .where("flowCouncilAddress", "=", TEST_COUNCIL_ADDRESS.toLowerCase())
       .executeTakeFirstOrThrow();
 
     const details =

--- a/src/app/flow-councils/components/Sidebar.tsx
+++ b/src/app/flow-councils/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
-import { usePathname, useRouter } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useAccount, useSwitchChain } from "wagmi";
 import { useConnectModal } from "@rainbow-me/rainbowkit";
 import Link from "next/link";
@@ -135,6 +135,7 @@ function Sidebar() {
 
   const pathname = usePathname();
   const router = useRouter();
+  const searchParams = useSearchParams();
 
   const { chainId, councilId } = useMemo(() => {
     const segments = pathname?.split("/").filter(Boolean) ?? [];
@@ -146,6 +147,9 @@ function Sidebar() {
     }
     return { chainId: null, councilId: null };
   }, [pathname]);
+  // The launch "Create New" page carries the chosen network in the `?chainId=`
+  // query string rather than a path segment, so fall back to it there.
+  const queryChainId = Number(searchParams?.get("chainId")) || null;
   const { address, chain: connectedChain } = useAccount();
   const { switchChain } = useSwitchChain();
   const { openConnectModal } = useConnectModal();
@@ -153,14 +157,15 @@ function Sidebar() {
 
   // Keep the network dropdown in sync with the council currently open in the URL.
   useEffect(() => {
-    if (!chainId) {
+    const targetChainId = chainId ?? queryChainId;
+    if (!targetChainId) {
       return;
     }
-    const network = networks.find((n) => n.id === chainId);
+    const network = networks.find((n) => n.id === targetChainId);
     if (network && isFlowCouncilNetwork(network)) {
       setSelectedNetwork(network);
     }
-  }, [chainId]);
+  }, [chainId, queryChainId]);
 
   const { data: flowCouncilsQueryRes } = useQuery(FLOW_COUNCIL_MANAGER_QUERY, {
     client: getApolloClient("flowCouncil", selectedNetwork.id),

--- a/src/app/flow-councils/components/Sidebar.tsx
+++ b/src/app/flow-councils/components/Sidebar.tsx
@@ -332,7 +332,7 @@ function Sidebar() {
         <Dropdown.Item
           className="text-truncate fw-semi-bold"
           onClick={() => {
-            router.push("/flow-councils/launch");
+            router.push(`/flow-councils/launch?chainId=${selectedNetwork.id}`);
           }}
         >
           Create New

--- a/src/app/flow-councils/flow-councils.tsx
+++ b/src/app/flow-councils/flow-councils.tsx
@@ -443,7 +443,9 @@ export default function FlowCouncils(props: FlowCouncilsProps) {
               style={{ height: 400 }}
               onClick={() => {
                 if (address) {
-                  router.push("/flow-councils/launch");
+                  router.push(
+                    `/flow-councils/launch?chainId=${selectedNetwork.id}`,
+                  );
                 } else if (openConnectModal) {
                   openConnectModal();
                 }

--- a/src/app/flow-councils/launch/launch.tsx
+++ b/src/app/flow-councils/launch/launch.tsx
@@ -38,7 +38,7 @@ const SUPERAPP_SPLITTER_FEE_PORTION = BigInt(50);
 type LaunchProps = {
   defaultNetwork: Network;
   councilId?: string;
-  explicitChainId?: boolean;
+  isChainIdExplicit?: boolean;
 };
 
 const FLOW_COUNCIL_QUERY = gql`
@@ -51,7 +51,7 @@ const FLOW_COUNCIL_QUERY = gql`
 `;
 
 export default function Launch(props: LaunchProps) {
-  const { defaultNetwork, councilId, explicitChainId } = props;
+  const { defaultNetwork, councilId, isChainIdExplicit } = props;
 
   const [selectedNetwork, setSelectedNetwork] =
     useState<Network>(defaultNetwork);
@@ -91,7 +91,7 @@ export default function Launch(props: LaunchProps) {
     selectedNetwork.tokens[0];
 
   useEffect(() => {
-    if (councilId || explicitChainId || !connectedChain) {
+    if (councilId || isChainIdExplicit || !connectedChain) {
       return;
     }
 
@@ -102,7 +102,7 @@ export default function Launch(props: LaunchProps) {
     if (userNetwork) {
       setSelectedNetwork(userNetwork);
     }
-  }, [councilId, explicitChainId, connectedChain, launchNetworks]);
+  }, [councilId, isChainIdExplicit, connectedChain, launchNetworks]);
 
   const handleSubmit = async () => {
     if (!address || !publicClient) {

--- a/src/app/flow-councils/launch/launch.tsx
+++ b/src/app/flow-councils/launch/launch.tsx
@@ -38,6 +38,7 @@ const SUPERAPP_SPLITTER_FEE_PORTION = BigInt(50);
 type LaunchProps = {
   defaultNetwork: Network;
   councilId?: string;
+  explicitChainId?: boolean;
 };
 
 const FLOW_COUNCIL_QUERY = gql`
@@ -50,7 +51,7 @@ const FLOW_COUNCIL_QUERY = gql`
 `;
 
 export default function Launch(props: LaunchProps) {
-  const { defaultNetwork, councilId } = props;
+  const { defaultNetwork, councilId, explicitChainId } = props;
 
   const [selectedNetwork, setSelectedNetwork] =
     useState<Network>(defaultNetwork);
@@ -90,7 +91,7 @@ export default function Launch(props: LaunchProps) {
     selectedNetwork.tokens[0];
 
   useEffect(() => {
-    if (councilId || !connectedChain) {
+    if (councilId || explicitChainId || !connectedChain) {
       return;
     }
 
@@ -101,7 +102,7 @@ export default function Launch(props: LaunchProps) {
     if (userNetwork) {
       setSelectedNetwork(userNetwork);
     }
-  }, [councilId, connectedChain, launchNetworks]);
+  }, [councilId, explicitChainId, connectedChain, launchNetworks]);
 
   const handleSubmit = async () => {
     if (!address || !publicClient) {

--- a/src/app/flow-councils/launch/page.tsx
+++ b/src/app/flow-councils/launch/page.tsx
@@ -15,5 +15,7 @@ export default async function Page({
   const network =
     matchedNetwork ?? networks.find((network) => network.label === "celo")!;
 
-  return <Launch defaultNetwork={network} explicitChainId={!!matchedNetwork} />;
+  return (
+    <Launch defaultNetwork={network} isChainIdExplicit={!!matchedNetwork} />
+  );
 }

--- a/src/app/flow-councils/launch/page.tsx
+++ b/src/app/flow-councils/launch/page.tsx
@@ -9,9 +9,11 @@ export default async function Page({
 }) {
   const { chainId } = await searchParams;
 
+  const matchedNetwork = networks.find(
+    (network) => network.id === Number(chainId),
+  );
   const network =
-    networks.find((network) => network.id === Number(chainId)) ??
-    networks.find((network) => network.label === "celo")!;
+    matchedNetwork ?? networks.find((network) => network.label === "celo")!;
 
-  return <Launch defaultNetwork={network} />;
+  return <Launch defaultNetwork={network} explicitChainId={!!matchedNetwork} />;
 }

--- a/src/lib/listedMetadata.test.ts
+++ b/src/lib/listedMetadata.test.ts
@@ -117,7 +117,7 @@ describe("serializeListed", () => {
     expect(result).not.toMatch(/\s/);
   });
 
-  it('listed:true output contains the substring \'"listed":true\'', () => {
+  it("listed:true output contains the substring '\"listed\":true'", () => {
     // Confirms the future subgraph metadata_contains filter will match
     expect(serializeListed(true)).toContain('"listed":true');
   });


### PR DESCRIPTION
## Problem
Launching a new Flow Council always defaulted to Celo, ignoring the network
selected on the previous page. E.g. picking OP Sepolia on the Flow Councils
page and clicking "Create Flow Council" landed on a launch screen showing Celo.

Two causes:
1. The "Create Flow Council" card (and the Sidebar "Create New" item) navigated
   to `/flow-councils/launch` without the selected network, so the launch route
   fell back to its hardcoded Celo default.
2. On the launch screen a `useEffect` forced the selected network to follow the
   connected wallet's chain, overriding the URL — so even a correct `?chainId=`
   link could be ignored and could silently launch on the wallet's chain.

## Changes
- `flow-councils.tsx`: "Create Flow Council" navigates with `?chainId=${selectedNetwork.id}`.
- `Sidebar.tsx`: "Create New" navigates with `?chainId=${selectedNetwork.id}` —
  following the sidebar's network dropdown (added in #300) instead of the raw URL
  `chainId`, consistent with the sibling nav items.
- `launch/page.tsx`: passes an `isChainIdExplicit` flag when `?chainId=` matches a
  real network.
- `launch.tsx`: the wallet-follow effect skips when `isChainIdExplicit` is set,
  making the URL authoritative; the existing "Switch Network" button prompts the
  wallet switch when chains differ. With no `?chainId=`, behavior is unchanged.

## Notes
- Rebased onto `main` after #300 (sidebar network dropdown) merged, since the
  "Create New" behavior now depends on it.
- Includes a small `chore` commit applying `prettier` to two flow-council test
  files (pre-existing formatting left over from #295, picked up by `prettier -w src`).

## Testing
- `pnpm typecheck` ✓
- `pnpm lint` ✓
- prettier ✓
