### PR TITLE
Remove SUP icons from round cards

### DIFF
--- a/src/app/explore/explore.tsx
+++ b/src/app/explore/explore.tsx
@@ -92,7 +92,6 @@ export default function Explore(props: ExploreProps) {
             activeStreamCount={flowCasterArbFlowInfo.donors}
             tokenSymbol="USDN"
             link="https://farcaster.xyz/miniapps/0EyeQpCD0lSP/flowcaster"
-            showSupRewards
           />
           <RoundCard
             name="Core Contributors"
@@ -106,7 +105,6 @@ export default function Explore(props: ExploreProps) {
             activeStreamCount={coreInflow?.activeIncomingStreamCount}
             tokenSymbol="ETHx"
             link="/flow-guilds/core"
-            showSupRewards
           />
           <RoundCard
             name="Cracked Devs"
@@ -131,7 +129,6 @@ export default function Explore(props: ExploreProps) {
             activeStreamCount={guildGuildInflow?.activeIncomingStreamCount}
             tokenSymbol="ETHx"
             link="/flow-guilds/guild-guild"
-            showSupRewards
           />
         </div>
         <span className="fs-4 fw-semi-bold">Completed</span>


### PR DESCRIPTION
Removes the SUP icon from all round cards on the Explore page (Arbitrum Mini Apps, Core Contributors, Guild Guild) for now.

The change is minimal and reversible: only the `showSupRewards` prop usage was dropped from the three card instances. The `RoundCard` component's `showSupRewards` prop + rendering logic and the `public/sup.svg` asset are left intact, so the icons can be re-enabled by simply re-adding the prop.