### PR TITLE
feat: add Flow State Markee banner to Explore page

### DIFF
--- a/src/app/api/markee/route.ts
+++ b/src/app/api/markee/route.ts
@@ -1,8 +1,13 @@
+import { unstable_cache } from "next/cache";
 import { getFlowStateMarkee } from "@/app/explore/lib/getFlowStateMarkee";
 
 export const dynamic = "force-dynamic";
 
+const getCachedMarkee = unstable_cache(getFlowStateMarkee, ["flow-state-markee"], {
+  revalidate: 30,
+});
+
 export async function GET() {
-  const markee = await getFlowStateMarkee();
+  const markee = await getCachedMarkee();
   return Response.json({ markee });
 }

--- a/src/app/api/markee/route.ts
+++ b/src/app/api/markee/route.ts
@@ -1,0 +1,8 @@
+import { getFlowStateMarkee } from "@/app/explore/lib/getFlowStateMarkee";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const markee = await getFlowStateMarkee();
+  return Response.json({ markee });
+}

--- a/src/app/explore/components/MarkeeBanner.tsx
+++ b/src/app/explore/components/MarkeeBanner.tsx
@@ -25,7 +25,7 @@ export default function MarkeeBanner({
       const data = (await res.json().catch(() => null)) as {
         markee: MarkeeInfo | null;
       } | null;
-      if (active && data?.markee) {
+      if (active && data) {
         setMarkee(data.markee);
       }
     };

--- a/src/app/explore/components/MarkeeBanner.tsx
+++ b/src/app/explore/components/MarkeeBanner.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import {
+  FLOW_STATE_MARKEE_ADDRESS,
+  FLOW_STATE_MARKEE_URL,
+  type MarkeeInfo,
+} from "../lib/markee";
+
+const REFRESH_MS = 60_000;
+
+export default function MarkeeBanner({
+  markee: initialMarkee,
+}: {
+  markee: MarkeeInfo | null;
+}) {
+  const [markee, setMarkee] = useState(initialMarkee);
+
+  useEffect(() => {
+    let active = true;
+    const refresh = async () => {
+      const res = await fetch("/api/markee").catch(() => null);
+      if (!res?.ok) return;
+      const data = (await res.json().catch(() => null)) as {
+        markee: MarkeeInfo | null;
+      } | null;
+      if (active && data?.markee) {
+        setMarkee(data.markee);
+      }
+    };
+    const interval = setInterval(refresh, REFRESH_MS);
+    return () => {
+      active = false;
+      clearInterval(interval);
+    };
+  }, []);
+
+  if (!markee) {
+    return null;
+  }
+
+  return (
+    <Link
+      href={FLOW_STATE_MARKEE_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-decoration-none text-dark d-block"
+      data-markee-address={FLOW_STATE_MARKEE_ADDRESS.toLowerCase()}
+    >
+      <div className="d-flex flex-column gap-1 border border-2 border-dark rounded-4 shadow-sm px-3 py-2 mb-4 cursor-pointer">
+        <span className="fw-bold" style={{ fontSize: 13 }}>
+          <span className="me-1" style={{ fontSize: 15 }}>
+            📣
+          </span>
+          Flow State Markee
+        </span>
+        <span
+          style={{
+            fontFamily: "'Courier New', Courier, monospace",
+            fontSize: 14,
+            lineHeight: 1.5,
+            display: "-webkit-box",
+            WebkitLineClamp: 4,
+            WebkitBoxOrient: "vertical",
+            overflow: "hidden",
+            overflowWrap: "anywhere",
+            maxHeight: "6em",
+          }}
+        >
+          {markee.message}
+        </span>
+        <div className="d-flex justify-content-between align-items-center gap-2 mt-1">
+          <span className="text-secondary" style={{ fontSize: 12 }}>
+            {markee.priceEth} ETH to change
+          </span>
+          <span className="bg-primary text-white fw-semi-bold rounded-pill px-3 py-1 text-nowrap flex-shrink-0">
+            Change →
+          </span>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/src/app/explore/explore.tsx
+++ b/src/app/explore/explore.tsx
@@ -2,6 +2,8 @@
 
 import Stack from "react-bootstrap/Stack";
 import RoundCard from "./components/RoundCard";
+import MarkeeBanner from "./components/MarkeeBanner";
+import { MarkeeInfo } from "./lib/markee";
 import { Inflow } from "@/types/inflow";
 import { GDAPool } from "@/types/gdaPool";
 import { useMediaQuery } from "@/hooks/mediaQuery";
@@ -22,6 +24,7 @@ type ExploreProps = {
   goodBuildersS3Inflow: Inflow;
   flowCasterArbFlowInfo: PoolPairFlowInfo;
   flowCasterFlowInfo: PoolPairFlowInfo;
+  markee: MarkeeInfo | null;
 };
 
 // Octant round snapshot (round concluded)
@@ -41,6 +44,7 @@ export default function Explore(props: ExploreProps) {
     goodBuildersS3Inflow,
     flowCasterArbFlowInfo,
     flowCasterFlowInfo,
+    markee,
   } = props;
 
   const { isMobile, isTablet, isSmallScreen, isMediumScreen, isBigScreen } =
@@ -65,6 +69,7 @@ export default function Explore(props: ExploreProps) {
         </h2>
       </Stack>
       <div className="px-2 pb-20 px-lg-30 px-xxl-52">
+        <MarkeeBanner markee={markee} />
         <span className="fs-4 fw-semi-bold">Active</span>
         <div
           className="mt-2 mb-6"

--- a/src/app/explore/lib/getFlowStateMarkee.ts
+++ b/src/app/explore/lib/getFlowStateMarkee.ts
@@ -65,13 +65,11 @@ export async function getFlowStateMarkee(): Promise<MarkeeInfo | null> {
       ],
     });
 
-    const minimumPrice = (priceRes.result as bigint) ?? 0n;
-    const top = topRes.result as
-      | readonly [readonly `0x${string}`[], readonly bigint[]]
-      | undefined;
-    if (!top) return null;
+    if (topRes.status !== "success") return null;
 
-    const [topAddresses, topFunds] = top;
+    const minimumPrice =
+      priceRes.status === "success" ? priceRes.result : 0n;
+    const [topAddresses, topFunds] = topRes.result;
     const topIdx = topFunds.findIndex((f) => f > 0n);
     if (topIdx < 0 || !topAddresses[topIdx]) return null;
 
@@ -87,12 +85,12 @@ export async function getFlowStateMarkee(): Promise<MarkeeInfo | null> {
       ],
     });
 
-    const message = (msgRes.result as string) ?? "";
+    const message = msgRes.status === "success" ? msgRes.result : "";
     if (!message) return null;
 
     return {
       message,
-      owner: (ownerRes.result as string) ?? "",
+      owner: ownerRes.status === "success" ? ownerRes.result : "",
       priceEth: parseFloat(formatEther(buyPrice)).toFixed(3),
     };
   } catch {

--- a/src/app/explore/lib/getFlowStateMarkee.ts
+++ b/src/app/explore/lib/getFlowStateMarkee.ts
@@ -1,0 +1,101 @@
+import { createPublicClient, http, formatEther, parseEther } from "viem";
+import { base } from "viem/chains";
+import { networks } from "@/lib/networks";
+import { FLOW_STATE_MARKEE_ADDRESS, type MarkeeInfo } from "./markee";
+
+const LEADERBOARD_ABI = [
+  {
+    inputs: [],
+    name: "minimumPrice",
+    outputs: [{ name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ name: "limit", type: "uint256" }],
+    name: "getTopMarkees",
+    outputs: [
+      { name: "topAddresses", type: "address[]" },
+      { name: "topFunds", type: "uint256[]" },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
+
+const MARKEE_ABI = [
+  {
+    inputs: [],
+    name: "message",
+    outputs: [{ name: "", type: "string" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "owner",
+    outputs: [{ name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
+
+const MIN_INCREMENT = parseEther("0.001");
+
+export async function getFlowStateMarkee(): Promise<MarkeeInfo | null> {
+  try {
+    const rpcUrl =
+      networks.find((n) => n.id === base.id)?.rpcUrl ??
+      "https://mainnet.base.org";
+    const client = createPublicClient({
+      chain: base,
+      transport: http(rpcUrl, { fetchOptions: { cache: "no-store" } }),
+    });
+    const leaderboard = FLOW_STATE_MARKEE_ADDRESS as `0x${string}`;
+
+    const [priceRes, topRes] = await client.multicall({
+      contracts: [
+        { address: leaderboard, abi: LEADERBOARD_ABI, functionName: "minimumPrice" },
+        {
+          address: leaderboard,
+          abi: LEADERBOARD_ABI,
+          functionName: "getTopMarkees",
+          args: [3n],
+        },
+      ],
+    });
+
+    const minimumPrice = (priceRes.result as bigint) ?? 0n;
+    const top = topRes.result as
+      | readonly [readonly `0x${string}`[], readonly bigint[]]
+      | undefined;
+    if (!top) return null;
+
+    const [topAddresses, topFunds] = top;
+    const topIdx = topFunds.findIndex((f) => f > 0n);
+    if (topIdx < 0 || !topAddresses[topIdx]) return null;
+
+    const buyPrice =
+      topFunds[topIdx] + MIN_INCREMENT > minimumPrice
+        ? topFunds[topIdx] + MIN_INCREMENT
+        : minimumPrice;
+
+    const [msgRes, ownerRes] = await client.multicall({
+      contracts: [
+        { address: topAddresses[topIdx], abi: MARKEE_ABI, functionName: "message" },
+        { address: topAddresses[topIdx], abi: MARKEE_ABI, functionName: "owner" },
+      ],
+    });
+
+    const message = (msgRes.result as string) ?? "";
+    if (!message) return null;
+
+    return {
+      message,
+      owner: (ownerRes.result as string) ?? "",
+      priceEth: parseFloat(formatEther(buyPrice)).toFixed(3),
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/app/explore/lib/markee.ts
+++ b/src/app/explore/lib/markee.ts
@@ -1,0 +1,10 @@
+export const FLOW_STATE_MARKEE_ADDRESS =
+  "0x8b6b33289c0C4aC55E7ae69382B10e071B0D3dEE" as const;
+export const FLOW_STATE_MARKEE_URL =
+  "https://www.markee.xyz/ecosystem/platforms/superfluid/0x8b6b33289c0C4aC55E7ae69382B10e071B0D3dEE";
+
+export type MarkeeInfo = {
+  message: string;
+  owner: string;
+  priceEth: string;
+};

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -6,6 +6,7 @@ import { gql, request } from "graphql-request";
 import { Inflow } from "@/types/inflow";
 import { GDAPool } from "@/types/gdaPool";
 import { networks } from "@/lib/networks";
+import { getFlowStateMarkee } from "./lib/getFlowStateMarkee";
 
 const FLOW_GUILD_QUERY = gql`
   query FlowGuildQuery($safeAddress: String, $token: String) {
@@ -114,6 +115,7 @@ export default async function Page() {
     flowCasterArbTeamQueryRes,
     flowCasterBaseCrackedDevsQueryRes,
     flowCasterBaseTeamQueryRes,
+    markee,
   ] = await Promise.all([
     request<{ account: Account }>(baseSubgraph, FLOW_GUILD_QUERY, {
       safeAddress: FLOW_GUILD_ADDRESSES["core"].safeAddress,
@@ -150,6 +152,7 @@ export default async function Page() {
     request<{ pool: GDAPool }>(baseSubgraph, GDA_POOL_QUERY, {
       gdaPool: FLOW_CASTER_BASE_POOLS[1],
     }),
+    getFlowStateMarkee(),
   ]);
 
   const now = (Date.now() / 1000) | 0;
@@ -176,6 +179,7 @@ export default async function Page() {
       }
       flowCasterArbFlowInfo={flowCasterArbFlowInfo}
       flowCasterFlowInfo={flowCasterFlowInfo}
+      markee={markee}
     />
   );
 }


### PR DESCRIPTION
Adds the Flow State Markee to the Explore page as a banner above the round grids.

## What
- Slim banner at the top of `/explore` (below the hero, above Active/Completed) showing the current top Markee message, owner, and price-to-change, linking out to the Flow State Markee on markee.xyz.
- Reads the message **on-chain** from the Flow State leaderboard on Base (`0x8b6b…3dEE`) via viem, mirroring Markee's own embed logic (`getTopMarkees` → top-funded markee's `message` / `owner`).
- Server-rendered fresh on load + client polling every 60s so an open page stays current.

## Files
- `src/app/explore/lib/markee.ts` — client-safe constants + `MarkeeInfo` type
- `src/app/explore/lib/getFlowStateMarkee.ts` — on-chain read (Base, viem multicall)
- `src/app/api/markee/route.ts` — JSON endpoint for the 60s client poll
- `src/app/explore/components/MarkeeBanner.tsx` — banner (polling client component)
- `src/app/explore/{page,explore}.tsx` — fetch + render the banner

## Notes
- Changing the message happens on markee.xyz (wallet connect + pay-to-change on Base); the banner links out — same pattern as Markee's official integrations.
- Includes `data-markee-address` on the banner for Markee's integration verification.
- Degrades gracefully: if the on-chain read fails, the banner is hidden and the page is unaffected.

## Verification
- `pnpm typecheck` + `pnpm lint` clean.
- Verified against live data: `GET /api/markee` returns the current Season 6 message, owner, and `0.022 ETH`.
