### PR TITLE
fix: black round description body, gray distributing subtitle

### DIFF
--- a/src/app/flow-councils/application/[chainId]/[councilId]/project-selection.tsx
+++ b/src/app/flow-councils/application/[chainId]/[councilId]/project-selection.tsx
@@ -387,7 +387,11 @@ export default function ProjectSelection(props: ProjectSelectionProps) {
   return (
     <Stack direction="vertical" className="px-2 pt-10 pb-30 px-lg-30 px-xxl-52">
       <h1 className="mt-5 mb-0 fs-3">{councilMetadata.name}</h1>
-      <Stack direction="horizontal" gap={1} className="align-items-center mb-4">
+      <Stack
+        direction="horizontal"
+        gap={1}
+        className="align-items-center mb-4 text-info"
+      >
         Distributing{" "}
         {!!councilToken.icon && (
           <Image src={councilToken.icon} alt="" width={18} height={18} />
@@ -418,9 +422,7 @@ export default function ProjectSelection(props: ProjectSelectionProps) {
           />
         </Button>
       </Stack>
-      <Markdown className="fs-6 text-info">
-        {councilMetadata.description}
-      </Markdown>
+      <Markdown className="fs-6">{councilMetadata.description}</Markdown>
       <h2 className="mt-5 mb-2 fw-bold fs-3">
         {applicationsClosed
           ? "Applications Closed"


### PR DESCRIPTION
## What

On the Flow Council application page (`project-selection.tsx`), swap the text colors in the round header per client (Rael) request:

- **Round description body** — was gray (`text-info` / `#888888`), now renders in the default near-black body color, matching the page title and headings.
- **"Distributing G\$ on …" subtitle** — was default near-black, now gray (`text-info`).

## Why

Client feedback on the GoodBuilders Season 4 round: the description body text was hard to read in gray; they want it black, with the smaller "Distributing" line de-emphasized to gray instead.

## Notes

- The other surface that renders the council description (`DistributionPoolDetails.tsx`) already uses `<Markdown className="fs-lg">` with no `text-info`, so it was already black — no change needed there.
- `pnpm lint` + `pnpm typecheck` + prettier all pass.