### PR TITLE
feat: replace Contact Email with required attestation questions in Minimal template

### DIFF
--- a/src/app/flow-councils/types/formSchema.ts
+++ b/src/app/flow-councils/types/formSchema.ts
@@ -132,9 +132,31 @@ export const MINIMAL_TEMPLATE: FormSchema = {
   ],
   attestation: [
     {
-      id: "b2c3d4e5-f6a7-8901-bcde-f12345678901",
-      type: "email",
-      label: "Contact Email",
+      id: "c3d4e5f6-a7b8-9012-cdef-123456789012",
+      type: "boolean",
+      label:
+        "I consent to the collection and use of my data for the purposes of participating in this round and receiving funding via the Flow State platform.",
+      required: true,
+    },
+    {
+      id: "d4e5f6a7-b8c9-0123-defa-234567890123",
+      type: "boolean",
+      label:
+        "I confirm that the information provided in this application is true and accurate to the best of my knowledge.",
+      required: true,
+    },
+    {
+      id: "e5f6a7b8-c9d0-1234-efab-345678901234",
+      type: "boolean",
+      label:
+        "I am at least 18 years old (or the age of majority in my jurisdiction) and have the legal authority to accept these funds.",
+      required: true,
+    },
+    {
+      id: "f6a7b8c9-d0e1-2345-fabc-456789012345",
+      type: "boolean",
+      label:
+        "I attest that I am not a citizen or resident of, nor located or operating my business in, any country or territory subject to comprehensive sanctions or embargoes (including those administered by the U.S. Office of Foreign Assets Control (OFAC), the United Nations, the European Union, or the United Kingdom), and that I am not subject to such sanctions nor listed on any government restricted- or denied-persons list.",
       required: true,
     },
   ],


### PR DESCRIPTION
## Summary

Updates the **Attestation** tab of the **Minimal** form template (`MINIMAL_TEMPLATE` in `src/app/flow-councils/types/formSchema.ts`).

- Removes the **Contact Email** field.
- Adds four required Y/N (`boolean`) attestation questions:
  1. Consent to collection and use of data for participating in the round and receiving funding via the Flow State platform.
  2. Confirmation that the information provided is true and accurate.
  3. Attestation of being at least 18 (or age of majority) with legal authority to accept the funds.
  4. Sanctions/embargo attestation (OFAC, UN, EU, UK; not on any restricted/denied-persons list).

All four are `required: true` and render as Yes/No radio buttons via `DynamicFormSection`. The server-side validator in `validation.ts` enforces the required flag for booleans (a "No"/`false` answer satisfies the required check, then the type is validated).

## Scope & impact

- Only the reusable `MINIMAL_TEMPLATE` definition changes, so this affects forms newly created/reset from the Minimal template. Existing applications keep their stored attestation data.
- The separate hardcoded GoodBuilders `AttestationTab.tsx` is unaffected.

## Verification

- `pnpm typecheck` — clean
- ESLint + Prettier on the changed file — clean