### PR TITLE
feat: add Name column to Permissions table; warn on bot Voter Review removal

### DIFF
--- a/src/app/flow-councils/lib/constants.ts
+++ b/src/app/flow-councils/lib/constants.ts
@@ -23,6 +23,10 @@ export const GOODDOLLAR_IDENTITY_ADDRESS: `0x${string}` =
 export const FLOW_STATE_BOT_ADDRESS: `0x${string}` =
   "0x7F0a04F131B8395e4e0bCf4c77E47845c952f49D";
 
+export const KNOWN_ADDRESS_NAMES: Record<string, string> = {
+  [FLOW_STATE_BOT_ADDRESS.toLowerCase()]: "F(S) Automation Bot",
+};
+
 export const GOODBUILDERS_S2_POOL_ADDRESS: `0x${string}` =
   "0xafcab1ab378354b8ce0dbd0ae2e2c0dea01dcf0b";
 

--- a/src/app/flow-councils/permissions/permissions.tsx
+++ b/src/app/flow-councils/permissions/permissions.tsx
@@ -391,7 +391,11 @@ export default function Permissions(props: PermissionsProps) {
               gap={isMobile ? 2 : 4}
               className="justify-content-end align-items-center"
             >
-              <span className="w-50" />
+              <span className="flex-grow-1" />
+              <span
+                className="flex-shrink-0"
+                style={{ width: isMobile ? 90 : 180 }}
+              />
               <Stack direction="horizontal" gap={2}>
                 <Card.Text
                   className="m-0 text-center flex-shrink-0"
@@ -487,7 +491,7 @@ export default function Permissions(props: PermissionsProps) {
                     KNOWN_ADDRESS_NAMES[managerEntry.address.toLowerCase()] ??
                     ""
                   }
-                  className="flex-shrink-0 border-0 bg-white py-4 rounded-4 fw-semi-bold"
+                  className="flex-shrink-0 border-0 bg-white rounded-4 fw-semi-bold"
                   style={{
                     width: isMobile ? 90 : 180,
                     paddingTop: 12,

--- a/src/app/flow-councils/permissions/permissions.tsx
+++ b/src/app/flow-councils/permissions/permissions.tsx
@@ -19,6 +19,7 @@ import Spinner from "react-bootstrap/Spinner";
 import Card from "react-bootstrap/Card";
 import Alert from "react-bootstrap/Alert";
 import Sidebar from "@/app/flow-councils/components/Sidebar";
+import { splitIntoChunks } from "@/app/flow-councils/hooks/useChunkedTxQueue";
 import { waitForReceipt } from "@/lib/utils";
 import { useMediaQuery } from "@/hooks/mediaQuery";
 import { getApolloClient } from "@/lib/apollo";
@@ -47,6 +48,8 @@ enum StatusChange {
   ADDED,
   REMOVED,
 }
+
+const PROFILE_BATCH = 150;
 
 const FLOW_COUNCIL_QUERY = gql`
   query FlowCouncilQuery($councilId: String!) {
@@ -276,29 +279,31 @@ export default function Permissions(props: PermissionsProps) {
     let cancelled = false;
 
     (async () => {
-      try {
-        const res = await fetch("/api/flow-council/voter-groups/profiles", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ addresses: managerAddresses }),
-        });
-        const data = await res.json();
+      const names: Record<string, string> = {};
 
-        if (cancelled || !data.success || !data.names) {
-          return;
+      for (const batch of splitIntoChunks(managerAddresses, PROFILE_BATCH)) {
+        try {
+          const res = await fetch("/api/flow-council/voter-groups/profiles", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ addresses: batch }),
+          });
+          const data = await res.json();
+
+          if (data.success && data.names) {
+            for (const [managerAddress, name] of Object.entries(
+              data.names as Record<string, string>,
+            )) {
+              names[managerAddress.toLowerCase()] = name;
+            }
+          }
+        } catch (err) {
+          console.error(err);
         }
+      }
 
-        const names: Record<string, string> = {};
-
-        for (const [managerAddress, name] of Object.entries(
-          data.names as Record<string, string>,
-        )) {
-          names[managerAddress.toLowerCase()] = name;
-        }
-
+      if (!cancelled) {
         setProfileNames(names);
-      } catch (err) {
-        console.error(err);
       }
     })();
 
@@ -523,7 +528,7 @@ export default function Permissions(props: PermissionsProps) {
                     disabled={!isAdmin}
                     placeholder="Manager Address"
                     value={managerEntry.address}
-                    className="border-0 bg-white py-4 rounded-4 fw-semi-bold"
+                    className="border-0 bg-white rounded-4 fw-semi-bold"
                     style={{
                       paddingTop: 12,
                       paddingBottom: 12,

--- a/src/app/flow-councils/permissions/permissions.tsx
+++ b/src/app/flow-councils/permissions/permissions.tsx
@@ -573,7 +573,7 @@ export default function Permissions(props: PermissionsProps) {
                   disabled
                   placeholder="Name"
                   value={managerDisplayName(managerEntry.address)}
-                  className="border-0 bg-white rounded-4 fw-semi-bold"
+                  className="border-0 bg-white rounded-4 fw-semi-bold text-info"
                   style={{
                     ...(isMobile
                       ? { width: 90, flexShrink: 0 }

--- a/src/app/flow-councils/permissions/permissions.tsx
+++ b/src/app/flow-councils/permissions/permissions.tsx
@@ -26,6 +26,8 @@ import {
   DEFAULT_ADMIN_ROLE,
   VOTER_MANAGER_ROLE,
   RECIPIENT_MANAGER_ROLE,
+  FLOW_STATE_BOT_ADDRESS,
+  KNOWN_ADDRESS_NAMES,
 } from "../lib/constants";
 
 type PermissionsProps = {
@@ -223,6 +225,25 @@ export default function Permissions(props: PermissionsProps) {
     return false;
   }, [flowCouncil, managersEntry, findChangedEntry]);
 
+  const isRemovingBotVoterManager = useMemo(() => {
+    for (const managerEntry of managersEntry) {
+      const changedEntries = findChangedEntry(managerEntry);
+
+      if (
+        changedEntries.find(
+          (c) =>
+            c.account.toLowerCase() === FLOW_STATE_BOT_ADDRESS.toLowerCase() &&
+            c.role === VOTER_MANAGER_ROLE &&
+            c.status === StatusChange.REMOVED,
+        )
+      ) {
+        return true;
+      }
+    }
+
+    return false;
+  }, [managersEntry, findChangedEntry]);
+
   useEffect(() => {
     (async () => {
       if (!flowCouncil) {
@@ -408,7 +429,11 @@ export default function Permissions(props: PermissionsProps) {
                 className="justify-content-end align-items-center mt-1 mb-3"
                 key={i}
               >
-                <Stack direction="vertical" className="position-relative w-50">
+                <Stack
+                  direction="vertical"
+                  className="position-relative flex-grow-1"
+                  style={{ minWidth: 0 }}
+                >
                   <Form.Control
                     type="text"
                     disabled={!isAdmin}
@@ -454,6 +479,21 @@ export default function Permissions(props: PermissionsProps) {
                     </Card.Text>
                   ) : null}
                 </Stack>
+                <Form.Control
+                  type="text"
+                  disabled
+                  placeholder="Name"
+                  value={
+                    KNOWN_ADDRESS_NAMES[managerEntry.address.toLowerCase()] ??
+                    ""
+                  }
+                  className="flex-shrink-0 border-0 bg-white py-4 rounded-4 fw-semi-bold"
+                  style={{
+                    width: isMobile ? 90 : 180,
+                    paddingTop: 12,
+                    paddingBottom: 12,
+                  }}
+                />
                 <Stack direction="horizontal" gap={2}>
                   <Form.Check
                     className="d-flex justify-content-center"
@@ -565,6 +605,12 @@ export default function Permissions(props: PermissionsProps) {
           <Card.Text className="text-danger mt-4 mb-0">
             Warning: You've removed your only SuperAdmin. If you proceed, you
             won't be able to make any further changes to permissions
+          </Card.Text>
+        )}
+        {isRemovingBotVoterManager && (
+          <Card.Text className="text-danger mt-4 mb-0">
+            You have an active automated voter eligibility method. Removing this
+            address will cause this to stop working.
           </Card.Text>
         )}
         <Stack direction="vertical" gap={3} className="mt-4 mb-30">

--- a/src/app/flow-councils/permissions/permissions.tsx
+++ b/src/app/flow-councils/permissions/permissions.tsx
@@ -10,6 +10,7 @@ import { writeContract } from "@wagmi/core";
 import { useConnectModal } from "@rainbow-me/rainbowkit";
 import { gql, useQuery } from "@apollo/client";
 import useSiwe from "@/hooks/siwe";
+import { useEnsResolution } from "@/hooks/useEnsResolution";
 import Stack from "react-bootstrap/Stack";
 import Form from "react-bootstrap/Form";
 import Button from "react-bootstrap/Button";
@@ -66,6 +67,7 @@ export default function Permissions(props: PermissionsProps) {
   const [transactionSuccess, setTransactionSuccess] = useState(false);
   const [isTransactionLoading, setIsTransactionLoading] = useState(false);
   const [managersEntry, setManagersEntry] = useState<ManagerEntry[]>([]);
+  const [profileNames, setProfileNames] = useState<Record<string, string>>({});
 
   const router = useRouter();
   const publicClient = usePublicClient();
@@ -244,6 +246,78 @@ export default function Permissions(props: PermissionsProps) {
     return false;
   }, [managersEntry, findChangedEntry]);
 
+  // Joined-string key: managersEntry gets a new identity on every keystroke,
+  // so name lookups gate on the stable key instead of the array.
+  const managerAddressKey = useMemo(
+    () =>
+      [
+        ...new Set(
+          managersEntry
+            .map((managerEntry) => managerEntry.address.trim().toLowerCase())
+            .filter((managerAddress) => isAddress(managerAddress)),
+        ),
+      ]
+        .sort()
+        .join(","),
+    [managersEntry],
+  );
+  const managerAddresses = useMemo(
+    () => (managerAddressKey === "" ? [] : managerAddressKey.split(",")),
+    [managerAddressKey],
+  );
+
+  const { ensByAddress } = useEnsResolution(managerAddresses);
+
+  useEffect(() => {
+    if (managerAddresses.length === 0) {
+      return;
+    }
+
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const res = await fetch("/api/flow-council/voter-groups/profiles", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ addresses: managerAddresses }),
+        });
+        const data = await res.json();
+
+        if (cancelled || !data.success || !data.names) {
+          return;
+        }
+
+        const names: Record<string, string> = {};
+
+        for (const [managerAddress, name] of Object.entries(
+          data.names as Record<string, string>,
+        )) {
+          names[managerAddress.toLowerCase()] = name;
+        }
+
+        setProfileNames(names);
+      } catch (err) {
+        console.error(err);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [managerAddresses]);
+
+  const managerDisplayName = (managerAddress: string) => {
+    const account = managerAddress.trim().toLowerCase();
+
+    return (
+      KNOWN_ADDRESS_NAMES[account] ??
+      profileNames[account] ??
+      ensByAddress?.[account]?.name ??
+      ""
+    );
+  };
+
   useEffect(() => {
     (async () => {
       if (!flowCouncil) {
@@ -391,10 +465,16 @@ export default function Permissions(props: PermissionsProps) {
               gap={isMobile ? 2 : 4}
               className="justify-content-end align-items-center"
             >
-              <span className="flex-grow-1" />
               <span
-                className="flex-shrink-0"
-                style={{ width: isMobile ? 90 : 180 }}
+                className="flex-grow-1"
+                style={{ maxWidth: isMobile ? undefined : 460 }}
+              />
+              <span
+                style={
+                  isMobile
+                    ? { width: 90, flexShrink: 0 }
+                    : { flex: "1 1 180px", minWidth: 0 }
+                }
               />
               <Stack direction="horizontal" gap={2}>
                 <Card.Text
@@ -436,7 +516,7 @@ export default function Permissions(props: PermissionsProps) {
                 <Stack
                   direction="vertical"
                   className="position-relative flex-grow-1"
-                  style={{ minWidth: 0 }}
+                  style={{ minWidth: 0, maxWidth: isMobile ? undefined : 460 }}
                 >
                   <Form.Control
                     type="text"
@@ -487,13 +567,12 @@ export default function Permissions(props: PermissionsProps) {
                   type="text"
                   disabled
                   placeholder="Name"
-                  value={
-                    KNOWN_ADDRESS_NAMES[managerEntry.address.toLowerCase()] ??
-                    ""
-                  }
-                  className="flex-shrink-0 border-0 bg-white rounded-4 fw-semi-bold"
+                  value={managerDisplayName(managerEntry.address)}
+                  className="border-0 bg-white rounded-4 fw-semi-bold"
                   style={{
-                    width: isMobile ? 90 : 180,
+                    ...(isMobile
+                      ? { width: 90, flexShrink: 0 }
+                      : { flex: "1 1 180px", minWidth: 0 }),
                     paddingTop: 12,
                     paddingBottom: 12,
                   }}


### PR DESCRIPTION
## Changes

- Adds a read-only **Name** field to the Council Permissions table, between the address input and the role checkboxes. Names resolve from a new `KNOWN_ADDRESS_NAMES` map in `flow-councils/lib/constants.ts`; currently it labels the Flow State bot address (`0x7F0a...f49D`) as **F(S) Automation Bot**.
- Shows a warning when an admin unchecks the bot's **Voter Review** permission, before submitting:
  > You have an active automated voter eligibility method. Removing this address will cause this to stop working.
- Layout: the address column changes from fixed `w-50` to flex-grow, and the Name column gets a fixed width (180px desktop / 90px mobile), so the row doesn't overflow on mobile.

## Notes

- The warning keys off the staged on-chain change (bot currently holds `VOTER_MANAGER_ROLE` and its Voter Review box is unchecked) — holding the role is the signal that automated eligibility is active, so no extra API fetch is needed on this page.