### PR TITLE
feat: enable Flow Council launch on Arbitrum, Base, and Optimism

### DIFF
--- a/docs/platform/flow-councils/operators/001-launch.md
+++ b/docs/platform/flow-councils/operators/001-launch.md
@@ -4,22 +4,46 @@ description: How to configure and deploy Flow Councils
 ---
 
 # Launch
-You can deploy a Flow Council yourself—no code required—from the [launchpad](https://flowstate.network/flow-councils/launch). Flow Councils are available on Arbitrum One, Base, Celo, and OP Mainnet.
 
-Each Flow Council is configured to distribute a single [Superfluid Super Token](https://docs.superfluid.org/docs/concepts/overview/super-tokens). Flow State natively supports many popular Super Tokens, but also allows deployers to set any [valid Super Token contract address](https://explorer.superfluid.org/arbitrum-one/supertokens) as the distribution currency. Once deployed, this token selection cannot be changed.
+You can deploy a Flow Council yourself—no code required—from the
+[launchpad](https://flowstate.network/flow-councils/launch). Flow Councils are
+available on Arbitrum One, Base, Celo, and OP Mainnet.
 
-On networks where the SuperApp Splitter factory is deployed (currently Celo), launching a council also deploys a **SuperApp Splitter**—the contract incoming funding streams route through. After launch, operators manage the round's funding from the [Funding](005-funding.md) page: sponsoring the funding stream, topping up the splitter, and scheduling or closing the round. Anyone can add to the funding anytime by [Growing the Pie](../participants/004-grow-the-pie.md).
+Each Flow Council is configured to distribute a single
+[Superfluid Super Token](https://docs.superfluid.org/docs/concepts/overview/super-tokens).
+Flow State natively supports many popular Super Tokens, but also allows
+deployers to set any
+[valid Super Token contract address](https://explorer.superfluid.org/arbitrum-one/supertokens)
+as the distribution currency. Once deployed, this token selection cannot be
+changed.
 
-By default, Flow Councils are open-ended. On councils with a splitter, operators can schedule a round end date from the [Funding](005-funding.md) page—once it passes, the round stops accepting incoming streams.
+Launching a council also deploys a **SuperApp Splitter**—the contract incoming
+funding streams route through. After launch, operators manage the round's
+funding from the [Funding](005-funding.md) page: sponsoring the funding stream,
+topping up the splitter, and scheduling or closing the round. Anyone can add to
+the funding anytime by [Growing the Pie](../participants/004-grow-the-pie.md).
 
-From the **Metadata** page, operators set the round's public name and description and choose whether it is **Listed** (surfaced on public discovery pages) or **Unlisted** (fully functional, reachable by direct link). New rounds default to Unlisted.
+By default, Flow Councils are open-ended. On councils with a splitter, operators
+can schedule a round end date from the [Funding](005-funding.md) page—once it
+passes, the round stops accepting incoming streams.
+
+From the **Metadata** page, operators set the round's public name and
+description and choose whether it is **Listed** (surfaced on public discovery
+pages) or **Unlisted** (fully functional, reachable by direct link). New rounds
+default to Unlisted.
 
 ## Permissions
 
-The deploying address is set as the Flow Council **Super Admin** by default. From the **Permissions** page, a Super Admin can grant any address one or more roles:
+The deploying address is set as the Flow Council **Super Admin** by default.
+From the **Permissions** page, a Super Admin can grant any address one or more
+roles:
 
-- **Super Admin** — full control, including managing other admins and every setting below.
+- **Super Admin** — full control, including managing other admins and every
+  setting below.
 - **Voter Review** — manages Council membership and voter groups.
-- **Recipient Review** — reviews applications and manages the recipients in the distribution pool.
+- **Recipient Review** — reviews applications and manages the recipients in the
+  distribution pool.
 
-Once a voting policy has been set and recipients have been added to the Flow Council, a Super Admin can remove themselves and all other admins to make the configuration immutable. See [Permissions](002-permissions.md) for details.
+Once a voting policy has been set and recipients have been added to the Flow
+Council, a Super Admin can remove themselves and all other admins to make the
+configuration immutable. See [Permissions](002-permissions.md) for details.

--- a/docs/platform/flow-councils/operators/005-funding.md
+++ b/docs/platform/flow-councils/operators/005-funding.md
@@ -65,7 +65,9 @@ batched (up to 1,000 streams per transaction), so very large rounds may need
 more than one pass. You'll be asked to type a confirmation before the
 transaction is submitted.
 
-:::note[Splitter roles] The splitter has its own onchain roles, separate from
-the [council roles](002-permissions.md). The deploying wallet is set as the
+:::note[Splitter roles]
+The splitter has its own onchain roles, separate from the
+[council roles](002-permissions.md). The deploying wallet is set as the
 splitter's admin and stream admin at launch; scheduling the round end and
-closing all streams require one of those roles. :::
+closing all streams require one of those roles.
+:::

--- a/docs/platform/flow-councils/operators/005-funding.md
+++ b/docs/platform/flow-councils/operators/005-funding.md
@@ -1,40 +1,71 @@
 ---
 slug: /flow-councils/funding
-description: Sponsoring the funding stream, managing the SuperApp Splitter, and scheduling the round end
+description:
+  Sponsoring the funding stream, managing the SuperApp Splitter, and scheduling
+  the round end
 ---
 
 # Funding
 
-The **Funding** page of the launchpad is where operators manage the money flowing into a Flow Council. It appears for councils on networks where the SuperApp Splitter factory is deployed (currently **Celo**).
+The **Funding** page of the launchpad is where operators manage the money
+flowing into a Flow Council. Funding actions are available for councils with a
+SuperApp Splitter—every council launched going forward has one.
 
 ## The SuperApp Splitter
 
-On supported networks, launching a council also deploys its **SuperApp Splitter**—a stream-forwarding contract that sits between funders and the council's distribution pool. All incoming funding streams—the operator's sponsor stream and permissionless [Grow the Pie](../participants/004-grow-the-pie.md) streams—route through the splitter, which forwards them to the pool. That indirection is what gives operators control over the round's lifecycle:
+Launching a council also deploys its **SuperApp Splitter**—a stream-forwarding
+contract that sits between funders and the council's distribution pool. All
+incoming funding streams—the operator's sponsor stream and permissionless
+[Grow the Pie](../participants/004-grow-the-pie.md) streams—route through the
+splitter, which forwards them to the pool. That indirection is what gives
+operators control over the round's lifecycle:
 
-- **Close the round.** Admins can close all incoming streams on behalf of every funder—something that isn't possible with streams opened directly to the pool.
-- **Enforce an end date.** Once a scheduled end date passes, the splitter rejects new incoming streams.
-- **Collect the platform sustainability fee.** A small portion of the flow accrues in the contract until round close. The exact fee is shown on the Funding page.
+- **Close the round.** Admins can close all incoming streams on behalf of every
+  funder—something that isn't possible with streams opened directly to the pool.
+- **Enforce an end date.** Once a scheduled end date passes, the splitter
+  rejects new incoming streams.
+- **Collect the platform sustainability fee.** A small portion of the flow
+  accrues in the contract until round close. The exact fee is shown on the
+  Funding page.
 
-The splitter must always hold a small balance of the distribution token (at least four hours' worth at the current funding rate) to keep its outgoing stream solvent.
+The splitter must always hold a small balance of the distribution token (at
+least four hours' worth at the current funding rate) to keep its outgoing stream
+solvent.
 
-The page's information panel shows the splitter's address, the sustainability fee, the contract's current balance, the **implied max funding rate** that balance can support, and the round status (**Open**, **Open – Ends [date]**, or **Closed**).
+The page's information panel shows the splitter's address, the sustainability
+fee, the contract's current balance, the **implied max funding rate** that
+balance can support, and the round status (**Open**, **Open – Ends [date]**, or
+**Closed**).
 
 ## Sponsor stream
 
-Open the round's funding stream by entering a monthly flow rate. The checkout flow wraps underlying tokens into the Super Token if needed and tops up the splitter's buffer in the same batch transaction. The flow rate can be raised or lowered anytime as more funding becomes available or circumstances change.
+Open the round's funding stream by entering a monthly flow rate. The checkout
+flow wraps underlying tokens into the Super Token if needed and tops up the
+splitter's buffer in the same batch transaction. The flow rate can be raised or
+lowered anytime as more funding becomes available or circumstances change.
 
 ## Top up the splitter
 
-The splitter's balance caps the total funding rate it can sustain. The transfer section lets you make a one-time deposit to raise the implied max funding rate without opening or changing a stream.
+The splitter's balance caps the total funding rate it can sustain. The transfer
+section lets you make a one-time deposit to raise the implied max funding rate
+without opening or changing a stream.
 
 ## Round end date
 
-By default, rounds are open-ended. Here you can **schedule** an end date, **reschedule** it, or **remove** it. After the end date passes, the round shows as **Closed** and the splitter stops accepting new incoming streams; rescheduling to a future date or removing the date re-opens the round.
+By default, rounds are open-ended. Here you can **schedule** an end date,
+**reschedule** it, or **remove** it. After the end date passes, the round shows
+as **Closed** and the splitter stops accepting new incoming streams;
+rescheduling to a future date or removing the date re-opens the round.
 
 ## Close all streams
 
-The danger zone at the bottom of the page closes **every** incoming stream to the splitter in a single action—the definitive way to end a round. Closing is batched (up to 1,000 streams per transaction), so very large rounds may need more than one pass. You'll be asked to type a confirmation before the transaction is submitted.
+The danger zone at the bottom of the page closes **every** incoming stream to
+the splitter in a single action—the definitive way to end a round. Closing is
+batched (up to 1,000 streams per transaction), so very large rounds may need
+more than one pass. You'll be asked to type a confirmation before the
+transaction is submitted.
 
-:::note[Splitter roles]
-The splitter has its own onchain roles, separate from the [council roles](002-permissions.md). The deploying wallet is set as the splitter's admin and stream admin at launch; scheduling the round end and closing all streams require one of those roles.
-:::
+:::note[Splitter roles] The splitter has its own onchain roles, separate from
+the [council roles](002-permissions.md). The deploying wallet is set as the
+splitter's admin and stream admin at launch; scheduling the round end and
+closing all streams require one of those roles. :::

--- a/src/app/flow-councils/components/Sidebar.tsx
+++ b/src/app/flow-councils/components/Sidebar.tsx
@@ -14,12 +14,7 @@ import Image from "react-bootstrap/Image";
 import { Network } from "@/types/network";
 import { useMediaQuery } from "@/hooks/mediaQuery";
 import { getApolloClient } from "@/lib/apollo";
-import {
-  networks,
-  isSplitterFactoryDeployed,
-  isFlowCouncilNetwork,
-} from "@/lib/networks";
-import useCouncilMetadata from "@/app/flow-councils/hooks/councilMetadata";
+import { networks, isFlowCouncilNetwork } from "@/lib/networks";
 
 const FLOW_COUNCIL_MANAGER_QUERY = gql`
   query FlowCouncilManagerQuery($address: String!) {
@@ -38,7 +33,6 @@ const SIDEBAR_LINK_DEFS: {
   path: string;
   label: string;
   alwaysEnabled?: boolean;
-  requiresSplitterFactory?: boolean;
 }[] = [
   { path: "launch", label: "Launch", alwaysEnabled: true },
   { path: "round-metadata", label: "Metadata" },
@@ -46,7 +40,7 @@ const SIDEBAR_LINK_DEFS: {
   { path: "form-builder", label: "Form Builder" },
   { path: "review", label: "Recipients" },
   { path: "membership", label: "Voters" },
-  { path: "funding", label: "Funding", requiresSplitterFactory: true },
+  { path: "funding", label: "Funding" },
   { path: "communications", label: "Communications" },
 ];
 
@@ -61,21 +55,9 @@ function SidebarLinks({
   selectedCouncil,
   pathname,
 }: SidebarLinksProps) {
-  const network = chainId ? networks.find((n) => n.id === chainId) : undefined;
-  const splitterFactoryDeployed = isSplitterFactoryDeployed(network);
-  const councilMetadata = useCouncilMetadata(
-    chainId ?? 0,
-    selectedCouncil?.id ?? "",
-  );
-  const hasSplitter =
-    splitterFactoryDeployed && !!councilMetadata.superappSplitterAddress;
-
   return (
     <Stack direction="vertical" gap={3} className="rounded-4 flex-grow-0 mt-3">
-      {SIDEBAR_LINK_DEFS.filter(
-        ({ requiresSplitterFactory }) =>
-          !requiresSplitterFactory || hasSplitter,
-      ).map(({ path, label, alwaysEnabled }) => {
+      {SIDEBAR_LINK_DEFS.map(({ path, label, alwaysEnabled }) => {
         const href =
           alwaysEnabled && chainId && selectedCouncil
             ? `/flow-councils/${path}/${chainId}/${selectedCouncil.id}`

--- a/src/app/flow-councils/funding/funding.tsx
+++ b/src/app/flow-councils/funding/funding.tsx
@@ -27,7 +27,7 @@ import Sidebar from "@/app/flow-councils/components/Sidebar";
 import SuccessCheckmark from "@/app/flow-councils/components/SuccessCheckmark";
 import InfoTooltip from "@/components/InfoTooltip";
 import { getApolloClient } from "@/lib/apollo";
-import { networks, isSplitterFactoryDeployed } from "@/lib/networks";
+import { networks } from "@/lib/networks";
 import { superAppSplitterAbi } from "@/lib/abi/superAppSplitter";
 import {
   buildBatchCall,
@@ -113,11 +113,10 @@ export default function Funding(props: FundingProps) {
     () => networks.find((n) => n.id === chainId),
     [chainId],
   );
-  const factoryDeployed = isSplitterFactoryDeployed(network);
 
   const councilMetadata = useCouncilMetadata(chainId ?? 0, councilId ?? "");
   const splitterAddress = councilMetadata.superappSplitterAddress;
-  const hasSplitter = !!splitterAddress && factoryDeployed;
+  const hasSplitter = !!splitterAddress;
 
   const splitterReads = useSplitterReads({
     splitterAddress,

--- a/src/app/flow-councils/launch/launch.tsx
+++ b/src/app/flow-councils/launch/launch.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Address, parseEventLogs, isAddress } from "viem";
@@ -87,6 +87,8 @@ export default function Launch(props: LaunchProps) {
   });
   const [success, setSuccess] = useState(false);
 
+  const customTokenRequestIdRef = useRef(0);
+
   const router = useRouter();
   const publicClient = usePublicClient();
   const wagmiConfig = useConfig();
@@ -153,10 +155,16 @@ export default function Launch(props: LaunchProps) {
       return;
     }
 
+    let cancelled = false;
+
     (async () => {
       const { data: superTokenQueryRes } = await checkSuperToken({
         variables: { token: flowCouncil.superToken.toLowerCase() },
       });
+
+      if (cancelled) {
+        return;
+      }
 
       setCustomTokenSelection(true);
       setCustomTokenEntry({
@@ -165,10 +173,18 @@ export default function Launch(props: LaunchProps) {
         validationError: "",
       });
     })();
+
+    return () => {
+      cancelled = true;
+    };
   }, [flowCouncil?.superToken, selectedNetwork.tokens, checkSuperToken]);
 
   const handleSubmit = async () => {
     if (!address || !publicClient) {
+      return;
+    }
+
+    if (customTokenSelection && !isAddress(customTokenEntry.address)) {
       return;
     }
 
@@ -372,9 +388,9 @@ export default function Launch(props: LaunchProps) {
                   </Stack>
                 </Dropdown.Toggle>
                 <Dropdown.Menu className="border-0 p-2 lh-lg">
-                  {selectedNetwork.tokens.map((token, i) => (
+                  {selectedNetwork.tokens.map((token) => (
                     <Dropdown.Item
-                      key={i}
+                      key={token.address}
                       className="fw-semi-bold"
                       onClick={() => {
                         setCustomTokenSelection(false);
@@ -417,6 +433,7 @@ export default function Launch(props: LaunchProps) {
                     }}
                     onChange={async (e) => {
                       const value = e.target.value;
+                      const requestId = ++customTokenRequestIdRef.current;
 
                       let validationError = "";
                       let symbol = "";
@@ -428,6 +445,10 @@ export default function Launch(props: LaunchProps) {
                           await checkSuperToken({
                             variables: { token: value.toLowerCase() },
                           });
+
+                        if (requestId !== customTokenRequestIdRef.current) {
+                          return;
+                        }
 
                         if (!superTokenQueryRes?.token?.isSuperToken) {
                           validationError = "Not a SuperToken";

--- a/src/app/flow-councils/launch/launch.tsx
+++ b/src/app/flow-councils/launch/launch.tsx
@@ -35,6 +35,8 @@ import { flowCouncilFactoryAbi } from "@/lib/abi/flowCouncilFactory";
 import { superAppSplitterFactoryAbi } from "@/lib/abi/superAppSplitterFactory";
 
 const SUPERAPP_SPLITTER_FEE_PORTION = BigInt(50);
+const COUNCIL_INDEXING_POLL_MS = 2000;
+const COUNCIL_INDEXING_MAX_ATTEMPTS = 60;
 
 type LaunchProps = {
   defaultNetwork: Network;
@@ -73,6 +75,30 @@ function getDefaultToken(network: Network): Token {
   return network.tokens.find((t) => t.symbol === "G$") ?? network.tokens[0];
 }
 
+async function waitForCouncilIndexing(chainId: number, councilId: string) {
+  const client = getApolloClient("flowCouncil", chainId);
+
+  for (let attempt = 0; attempt < COUNCIL_INDEXING_MAX_ATTEMPTS; attempt++) {
+    try {
+      const { data } = await client.query({
+        query: FLOW_COUNCIL_QUERY,
+        variables: { councilId },
+        fetchPolicy: "network-only",
+      });
+
+      if (data?.flowCouncil) {
+        return;
+      }
+    } catch {
+      // Transient subgraph errors shouldn't abort the wait
+    }
+
+    await new Promise((resolve) =>
+      setTimeout(resolve, COUNCIL_INDEXING_POLL_MS),
+    );
+  }
+}
+
 export default function Launch(props: LaunchProps) {
   const { defaultNetwork, councilId, isChainIdExplicit } = props;
 
@@ -87,6 +113,7 @@ export default function Launch(props: LaunchProps) {
     symbol: "",
     validationError: "",
   });
+  const [isIndexing, setIsIndexing] = useState(false);
   const [success, setSuccess] = useState(false);
 
   const customTokenRequestIdRef = useRef(0);
@@ -272,11 +299,19 @@ export default function Launch(props: LaunchProps) {
         }),
       });
 
+      setIsIndexing(true);
+      await waitForCouncilIndexing(
+        selectedNetwork.id,
+        flowCouncilAddress.toLowerCase(),
+      );
+      setIsIndexing(false);
+
       router.push(
         `/flow-councils/launch/${selectedNetwork.id}/${flowCouncilAddress}`,
       );
       setSuccess(true);
     } catch {
+      setIsIndexing(false);
       // Error state is handled by useTransactionsQueue
     }
   };
@@ -509,6 +544,8 @@ export default function Launch(props: LaunchProps) {
           <Button
             disabled={
               !!councilId ||
+              areTransactionsLoading ||
+              isIndexing ||
               (customTokenSelection &&
                 (customTokenEntry.address === "" ||
                   customTokenEntry.validationError !== ""))
@@ -524,7 +561,7 @@ export default function Launch(props: LaunchProps) {
                     : handleSubmit()
             }
           >
-            {areTransactionsLoading ? (
+            {areTransactionsLoading || isIndexing ? (
               <>
                 <Spinner size="sm" className="ms-2" />
                 {completedTransactions > 0 &&

--- a/src/app/flow-councils/launch/launch.tsx
+++ b/src/app/flow-councils/launch/launch.tsx
@@ -75,7 +75,10 @@ function getDefaultToken(network: Network): Token {
   return network.tokens.find((t) => t.symbol === "G$") ?? network.tokens[0];
 }
 
-async function waitForCouncilIndexing(chainId: number, councilId: string) {
+async function waitForCouncilIndexing(
+  chainId: number,
+  councilId: string,
+): Promise<boolean> {
   const client = getApolloClient("flowCouncil", chainId);
 
   for (let attempt = 0; attempt < COUNCIL_INDEXING_MAX_ATTEMPTS; attempt++) {
@@ -87,7 +90,7 @@ async function waitForCouncilIndexing(chainId: number, councilId: string) {
       });
 
       if (data?.flowCouncil) {
-        return;
+        return true;
       }
     } catch {
       // Transient subgraph errors shouldn't abort the wait
@@ -97,6 +100,8 @@ async function waitForCouncilIndexing(chainId: number, councilId: string) {
       setTimeout(resolve, COUNCIL_INDEXING_POLL_MS),
     );
   }
+
+  return false;
 }
 
 export default function Launch(props: LaunchProps) {
@@ -300,7 +305,7 @@ export default function Launch(props: LaunchProps) {
       });
 
       setIsIndexing(true);
-      await waitForCouncilIndexing(
+      const indexed = await waitForCouncilIndexing(
         selectedNetwork.id,
         flowCouncilAddress.toLowerCase(),
       );
@@ -309,7 +314,10 @@ export default function Launch(props: LaunchProps) {
       router.push(
         `/flow-councils/launch/${selectedNetwork.id}/${flowCouncilAddress}`,
       );
-      setSuccess(true);
+
+      if (indexed) {
+        setSuccess(true);
+      }
     } catch {
       setIsIndexing(false);
       // Error state is handled by useTransactionsQueue

--- a/src/app/flow-councils/launch/launch.tsx
+++ b/src/app/flow-councils/launch/launch.tsx
@@ -3,11 +3,11 @@
 import { useState, useEffect, useMemo } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { Address, parseEventLogs } from "viem";
+import { Address, parseEventLogs, isAddress } from "viem";
 import { useConfig, useAccount, usePublicClient, useSwitchChain } from "wagmi";
 import { writeContract } from "@wagmi/core";
 import { useConnectModal } from "@rainbow-me/rainbowkit";
-import { gql, useQuery } from "@apollo/client";
+import { gql, useQuery, useLazyQuery } from "@apollo/client";
 import Stack from "react-bootstrap/Stack";
 import Form from "react-bootstrap/Form";
 import Toast from "react-bootstrap/Toast";
@@ -24,6 +24,7 @@ import { useMediaQuery } from "@/hooks/mediaQuery";
 import useSiwe from "@/hooks/siwe";
 import useTransactionsQueue from "@/hooks/transactionsQueue";
 import { Network } from "@/types/network";
+import { Token } from "@/types/token";
 import { getApolloClient } from "@/lib/apollo";
 import {
   networks,
@@ -41,6 +42,12 @@ type LaunchProps = {
   isChainIdExplicit?: boolean;
 };
 
+type CustomTokenEntry = {
+  address: string;
+  symbol: string;
+  validationError: string;
+};
+
 const FLOW_COUNCIL_QUERY = gql`
   query FlowCouncilQuery($councilId: String!) {
     flowCouncil(id: $councilId) {
@@ -50,11 +57,34 @@ const FLOW_COUNCIL_QUERY = gql`
   }
 `;
 
+const SUPERTOKEN_QUERY = gql`
+  query SupertokenQuery($token: String!) {
+    token(id: $token) {
+      id
+      isSuperToken
+      symbol
+    }
+  }
+`;
+
+function getDefaultToken(network: Network): Token {
+  return network.tokens.find((t) => t.symbol === "G$") ?? network.tokens[0];
+}
+
 export default function Launch(props: LaunchProps) {
   const { defaultNetwork, councilId, isChainIdExplicit } = props;
 
   const [selectedNetwork, setSelectedNetwork] =
     useState<Network>(defaultNetwork);
+  const [selectedToken, setSelectedToken] = useState<Token>(
+    getDefaultToken(defaultNetwork),
+  );
+  const [customTokenSelection, setCustomTokenSelection] = useState(false);
+  const [customTokenEntry, setCustomTokenEntry] = useState<CustomTokenEntry>({
+    address: "",
+    symbol: "",
+    validationError: "",
+  });
   const [success, setSuccess] = useState(false);
 
   const router = useRouter();
@@ -79,6 +109,9 @@ export default function Launch(props: LaunchProps) {
       pollInterval: 4000,
       skip: !councilId,
     });
+  const [checkSuperToken] = useLazyQuery(SUPERTOKEN_QUERY, {
+    client: getApolloClient("superfluid", selectedNetwork.id),
+  });
 
   const flowCouncil = flowCouncilQueryRes?.flowCouncil;
 
@@ -86,9 +119,6 @@ export default function Launch(props: LaunchProps) {
     () => networks.filter(isFlowCouncilNetwork),
     [],
   );
-  const defaultToken =
-    selectedNetwork.tokens.find((t) => t.symbol === "G$") ??
-    selectedNetwork.tokens[0];
 
   useEffect(() => {
     if (councilId || isChainIdExplicit || !connectedChain) {
@@ -101,15 +131,50 @@ export default function Launch(props: LaunchProps) {
 
     if (userNetwork) {
       setSelectedNetwork(userNetwork);
+      setCustomTokenSelection(false);
+      setSelectedToken(getDefaultToken(userNetwork));
     }
   }, [councilId, isChainIdExplicit, connectedChain, launchNetworks]);
+
+  useEffect(() => {
+    if (!flowCouncil?.superToken) {
+      return;
+    }
+
+    const matchedToken = selectedNetwork.tokens.find(
+      (token) =>
+        token.address.toLowerCase() === flowCouncil.superToken.toLowerCase(),
+    );
+
+    if (matchedToken) {
+      setCustomTokenSelection(false);
+      setSelectedToken(matchedToken);
+
+      return;
+    }
+
+    (async () => {
+      const { data: superTokenQueryRes } = await checkSuperToken({
+        variables: { token: flowCouncil.superToken.toLowerCase() },
+      });
+
+      setCustomTokenSelection(true);
+      setCustomTokenEntry({
+        address: flowCouncil.superToken,
+        symbol: superTokenQueryRes?.token?.symbol ?? "",
+        validationError: "",
+      });
+    })();
+  }, [flowCouncil?.superToken, selectedNetwork.tokens, checkSuperToken]);
 
   const handleSubmit = async () => {
     if (!address || !publicClient) {
       return;
     }
 
-    const token = defaultToken.address;
+    const token = customTokenSelection
+      ? (customTokenEntry.address as Address)
+      : selectedToken.address;
 
     try {
       let flowCouncilAddress: Address = "" as Address;
@@ -254,6 +319,8 @@ export default function Launch(props: LaunchProps) {
                     className="fw-semi-bold"
                     onClick={() => {
                       setSelectedNetwork(network);
+                      setCustomTokenSelection(false);
+                      setSelectedToken(getDefaultToken(network));
                       router.replace(
                         `/flow-councils/launch?chainId=${network.id}`,
                         { scroll: false },
@@ -278,38 +345,138 @@ export default function Launch(props: LaunchProps) {
               gap={isMobile ? 1 : 3}
               className="align-items-start mt-2"
             >
-              <Stack
-                direction="horizontal"
-                gap={1}
-                className="align-items-center bg-white py-4 fw-semi-bold text-dark rounded-2 px-3"
-                style={{ width: 256, paddingTop: 12, paddingBottom: 12 }}
-              >
-                <Image
-                  src={defaultToken.icon}
-                  alt="Token"
-                  width={18}
-                  height={18}
-                />
-                {defaultToken.symbol}
-              </Stack>
-              <Stack direction="vertical" className="align-self-sm-end">
-                <Form.Control
-                  type="text"
-                  disabled
-                  value={defaultToken.address}
-                  className="border-0 fs-lg fw-semi-bold"
-                  style={{
-                    paddingTop: 12,
-                    paddingBottom: 12,
-                  }}
-                />
-              </Stack>
+              <Dropdown>
+                <Dropdown.Toggle
+                  disabled={!!councilId}
+                  className="d-flex justify-content-between align-items-center bg-white py-4 fw-semi-bold text-dark border-0"
+                  style={{ width: 256, paddingTop: 12, paddingBottom: 12 }}
+                >
+                  <Stack
+                    direction="horizontal"
+                    gap={1}
+                    className="align-items-center"
+                  >
+                    {!customTokenSelection && (
+                      <Image
+                        src={selectedToken.icon}
+                        alt="Token Icon"
+                        width={18}
+                        height={18}
+                      />
+                    )}
+                    {customTokenSelection && customTokenEntry.symbol
+                      ? customTokenEntry.symbol
+                      : customTokenSelection
+                        ? "Custom"
+                        : selectedToken.symbol}
+                  </Stack>
+                </Dropdown.Toggle>
+                <Dropdown.Menu className="border-0 p-2 lh-lg">
+                  {selectedNetwork.tokens.map((token, i) => (
+                    <Dropdown.Item
+                      key={i}
+                      className="fw-semi-bold"
+                      onClick={() => {
+                        setCustomTokenSelection(false);
+                        setSelectedToken(token);
+                      }}
+                    >
+                      <Stack direction="horizontal" gap={1}>
+                        <Image
+                          src={token.icon}
+                          alt="Token Icon"
+                          width={16}
+                          height={16}
+                        />
+                        {token.symbol}
+                      </Stack>
+                    </Dropdown.Item>
+                  ))}
+                  <Dropdown.Item
+                    className="fw-semi-bold"
+                    onClick={() => setCustomTokenSelection(true)}
+                  >
+                    Custom
+                  </Dropdown.Item>
+                </Dropdown.Menu>
+              </Dropdown>
+              {customTokenSelection ? (
+                <Stack
+                  direction="vertical"
+                  className="position-relative align-self-sm-end"
+                >
+                  <Form.Control
+                    type="text"
+                    disabled={!!councilId}
+                    placeholder="SuperToken Address"
+                    value={customTokenEntry.address}
+                    className="border-0 fs-lg fw-semi-bold"
+                    style={{
+                      paddingTop: 12,
+                      paddingBottom: 12,
+                    }}
+                    onChange={async (e) => {
+                      const value = e.target.value;
+
+                      let validationError = "";
+                      let symbol = "";
+
+                      if (!isAddress(value)) {
+                        validationError = "Invalid Address";
+                      } else {
+                        const { data: superTokenQueryRes } =
+                          await checkSuperToken({
+                            variables: { token: value.toLowerCase() },
+                          });
+
+                        if (!superTokenQueryRes?.token?.isSuperToken) {
+                          validationError = "Not a SuperToken";
+                        } else {
+                          symbol = superTokenQueryRes.token.symbol;
+                        }
+                      }
+
+                      setCustomTokenEntry({
+                        address: value,
+                        symbol,
+                        validationError,
+                      });
+                    }}
+                  />
+                  {customTokenEntry.validationError && (
+                    <Card.Text
+                      className="position-absolute mb-0 ms-2 ps-1 text-danger"
+                      style={{ bottom: 1, fontSize: "0.7rem" }}
+                    >
+                      {customTokenEntry.validationError}
+                    </Card.Text>
+                  )}
+                </Stack>
+              ) : (
+                <Stack direction="vertical" className="align-self-sm-end">
+                  <Form.Control
+                    type="text"
+                    disabled
+                    value={selectedToken.address}
+                    className="border-0 fs-lg fw-semi-bold"
+                    style={{
+                      paddingTop: 12,
+                      paddingBottom: 12,
+                    }}
+                  />
+                </Stack>
+              )}
             </Stack>
           </Card.Body>
         </Card>
         <Stack direction="vertical" gap={3} className="mt-4 mb-30">
           <Button
-            disabled={!!councilId}
+            disabled={
+              !!councilId ||
+              (customTokenSelection &&
+                (customTokenEntry.address === "" ||
+                  customTokenEntry.validationError !== ""))
+            }
             className="fs-lg fw-semi-bold rounded-4 px-10 py-4"
             onClick={() =>
               !address && openConnectModal

--- a/src/app/flow-councils/launch/launch.tsx
+++ b/src/app/flow-councils/launch/launch.tsx
@@ -67,6 +67,8 @@ const SUPERTOKEN_QUERY = gql`
   }
 `;
 
+const TOKEN_VALIDATING_MESSAGE = "Validating...";
+
 function getDefaultToken(network: Network): Token {
   return network.tokens.find((t) => t.symbol === "G$") ?? network.tokens[0];
 }
@@ -435,38 +437,51 @@ export default function Launch(props: LaunchProps) {
                       const value = e.target.value;
                       const requestId = ++customTokenRequestIdRef.current;
 
-                      let validationError = "";
-                      let symbol = "";
-
                       if (!isAddress(value)) {
-                        validationError = "Invalid Address";
-                      } else {
-                        const { data: superTokenQueryRes } =
-                          await checkSuperToken({
-                            variables: { token: value.toLowerCase() },
-                          });
+                        setCustomTokenEntry({
+                          address: value,
+                          symbol: "",
+                          validationError: "Invalid Address",
+                        });
 
-                        if (requestId !== customTokenRequestIdRef.current) {
-                          return;
-                        }
-
-                        if (!superTokenQueryRes?.token?.isSuperToken) {
-                          validationError = "Not a SuperToken";
-                        } else {
-                          symbol = superTokenQueryRes.token.symbol;
-                        }
+                        return;
                       }
 
                       setCustomTokenEntry({
                         address: value,
-                        symbol,
-                        validationError,
+                        symbol: "",
+                        validationError: TOKEN_VALIDATING_MESSAGE,
+                      });
+
+                      const { data: superTokenQueryRes } =
+                        await checkSuperToken({
+                          variables: { token: value.toLowerCase() },
+                        });
+
+                      if (requestId !== customTokenRequestIdRef.current) {
+                        return;
+                      }
+
+                      const isSuperToken =
+                        !!superTokenQueryRes?.token?.isSuperToken;
+
+                      setCustomTokenEntry({
+                        address: value,
+                        symbol: isSuperToken
+                          ? superTokenQueryRes.token.symbol
+                          : "",
+                        validationError: isSuperToken ? "" : "Not a SuperToken",
                       });
                     }}
                   />
                   {customTokenEntry.validationError && (
                     <Card.Text
-                      className="position-absolute mb-0 ms-2 ps-1 text-danger"
+                      className={`position-absolute mb-0 ms-2 ps-1 ${
+                        customTokenEntry.validationError ===
+                        TOKEN_VALIDATING_MESSAGE
+                          ? "text-info"
+                          : "text-danger"
+                      }`}
                       style={{ bottom: 1, fontSize: "0.7rem" }}
                     >
                       {customTokenEntry.validationError}

--- a/src/app/flow-councils/membership/membership.tsx
+++ b/src/app/flow-councils/membership/membership.tsx
@@ -25,7 +25,6 @@ import Sidebar from "@/app/flow-councils/components/Sidebar";
 import { useMediaQuery } from "@/hooks/mediaQuery";
 import { getApolloClient } from "@/lib/apollo";
 import { flowCouncilAbi } from "@/lib/abi/flowCouncil";
-import { networks, isSplitterFactoryDeployed } from "@/lib/networks";
 import useCouncilMetadata from "@/app/flow-councils/hooks/councilMetadata";
 import { useChunkedTxQueue } from "@/app/flow-councils/hooks/useChunkedTxQueue";
 import { useVoterGroupQueueCleanup } from "@/app/flow-councils/hooks/useVoterGroupQueueCleanup";
@@ -137,13 +136,6 @@ export default function Membership(props: MembershipProps) {
   });
 
   const councilMetadata = useCouncilMetadata(chainId ?? 0, councilId ?? "");
-  const network = useMemo(
-    () => networks.find((n) => n.id === chainId),
-    [chainId],
-  );
-  const hasSplitter =
-    isSplitterFactoryDeployed(network) &&
-    !!councilMetadata.superappSplitterAddress;
   const isCelo = chainId === CELO_CHAIN_ID;
 
   const flowCouncil = flowCouncilQueryRes?.flowCouncil ?? null;
@@ -251,10 +243,8 @@ export default function Membership(props: MembershipProps) {
     await fetchGroups();
   }, [refetch, fetchGroups]);
 
-  const { discard, cleanupError, clearCleanupError } = useVoterGroupQueueCleanup(
-    q,
-    refresh,
-  );
+  const { discard, cleanupError, clearCleanupError } =
+    useVoterGroupQueueCleanup(q, refresh);
 
   // The query pages 1000 voters per request (`first: 1000` above). Fetch the
   // next page only while the loaded count is a full multiple of that page size:
@@ -714,11 +704,7 @@ export default function Membership(props: MembershipProps) {
             disabled={councilMetadata.isPending}
             style={{ pointerEvents: isTransactionLoading ? "none" : "auto" }}
             onClick={() => {
-              router.push(
-                hasSplitter
-                  ? `/flow-councils/funding/${chainId}/${councilId}`
-                  : `/flow-councils/communications/${chainId}/${councilId}`,
-              );
+              router.push(`/flow-councils/funding/${chainId}/${councilId}`);
             }}
           >
             Next

--- a/src/lib/networks.test.ts
+++ b/src/lib/networks.test.ts
@@ -7,8 +7,10 @@ describe("isSplitterFactoryDeployed", () => {
   });
 
   it('returns false for the "0x" sentinel', () => {
-    const network = networks.find((n) => n.label === "base");
-    expect(network?.superAppSplitterFactory).toBe("0x");
+    const network = {
+      ...networks[0],
+      superAppSplitterFactory: "0x" as const,
+    };
     expect(isSplitterFactoryDeployed(network)).toBe(false);
   });
 
@@ -21,7 +23,7 @@ describe("isSplitterFactoryDeployed", () => {
     expect(isSplitterFactoryDeployed(network)).toBe(false);
   });
 
-  it.each(["celo", "optimism-sepolia"])(
+  it.each(["arbitrum-one", "base", "celo", "optimism", "optimism-sepolia"])(
     "returns true for a real factory address on %s",
     (label) => {
       const network = networks.find((n) => n.label === label);

--- a/src/lib/networks.ts
+++ b/src/lib/networks.ts
@@ -12,7 +12,10 @@ function isSplitterFactoryDeployed(network: Network | undefined): boolean {
 }
 
 const FLOW_COUNCIL_NETWORK_LABELS: ReadonlySet<string> = new Set([
+  "arbitrum-one",
+  "base",
   "celo",
+  "optimism",
   "optimism-sepolia",
 ]);
 
@@ -55,9 +58,9 @@ const networks: Network[] = [
     flowSplitter: "0xCbA99f104D17D06Ce4C80Be143f29b6fd44D3Ce9",
     flowSplitterSubgraph:
       "https://api.subgraph.ormilabs.com/api/public/f73714f1-9afa-4cd8-99bb-d4c0522c9d2b/subgraphs/flow-splitter-arbitrum-one/v0.0.3/gn",
-    flowCouncilFactory: "0x46a2496c9df5c00ccc51bcb9b77345410718de26",
+    flowCouncilFactory: "0x589232342bfeCb372dbbc01d17e8D112a27fF125",
     flowCouncilSubgraph:
-      "https://api.subgraph.ormilabs.com/api/public/f73714f1-9afa-4cd8-99bb-d4c0522c9d2b/subgraphs/flow-council-arbitrum-one/v0.3.0/gn",
+      "https://api.subgraph.ormilabs.com/api/public/f73714f1-9afa-4cd8-99bb-d4c0522c9d2b/subgraphs/flow-council-arbitrum-one/v0.4.2/gn",
     flowStateEligibilityNft: "0x6Ee1Cc715EAB6a1a661d34C1439Fc7f05Aa5f435",
     flowStateEligibilityMinScore: 15,
     superfluidHost: "0xCf8Acb4eF033efF16E8080aed4c7D5B9285D2192",
@@ -106,9 +109,9 @@ const networks: Network[] = [
     flowSplitter: "0x25B64C200cf3362BaC6961353D38A1dbEB42e60E",
     flowSplitterSubgraph:
       "https://api.subgraph.ormilabs.com/api/public/f73714f1-9afa-4cd8-99bb-d4c0522c9d2b/subgraphs/flow-splitter-base/v0.0.2/gn",
-    flowCouncilFactory: "0x46a2496c9df5c00ccc51bcb9b77345410718de26",
+    flowCouncilFactory: "0x589232342bfeCb372dbbc01d17e8D112a27fF125",
     flowCouncilSubgraph:
-      "https://api.subgraph.ormilabs.com/api/public/f73714f1-9afa-4cd8-99bb-d4c0522c9d2b/subgraphs/flow-council-base/v0.3.0/gn",
+      "https://api.subgraph.ormilabs.com/api/public/f73714f1-9afa-4cd8-99bb-d4c0522c9d2b/subgraphs/flow-council-base/v0.4.2/gn",
     flowStateEligibilityNft: "0xA72c184738842626a920A8935092b7b3f35A3082",
     flowStateEligibilityMinScore: 15,
     superfluidHost: "0x4C073B3baB6d8826b8C5b229f3cfdC1eC6E47E74",
@@ -147,9 +150,9 @@ const networks: Network[] = [
     flowSplitter: "0x0e9ddfd2ffdb0ba1ac3340d865193a7b6d4ea147",
     flowSplitterSubgraph:
       "https://api.goldsky.com/api/public/project_cmbkdj2bd7cr601uwafoe4u3y/subgraphs/flow-splitter-celo/v0.0.3/gn",
-    flowCouncilFactory: "0x966D8D0B0e39E51f8A965Be1C11b7CFb1707c500",
+    flowCouncilFactory: "0x589232342bfeCb372dbbc01d17e8D112a27fF125",
     flowCouncilSubgraph:
-      "https://api.goldsky.com/api/public/project_cmbkdj2bd7cr601uwafoe4u3y/subgraphs/flow-council-celo/v0.4.1/gn",
+      "https://api.goldsky.com/api/public/project_cmbkdj2bd7cr601uwafoe4u3y/subgraphs/flow-council-celo/v0.4.2/gn",
     flowStateEligibilityNft: "",
     flowStateEligibilityMinScore: 15,
     superfluidHost: "0xA4Ff07cF81C02CFD356184879D953970cA957585",
@@ -188,9 +191,9 @@ const networks: Network[] = [
     flowSplitter: "0x25B64C200cf3362BaC6961353D38A1dbEB42e60E",
     flowSplitterSubgraph:
       "https://api.subgraph.ormilabs.com/api/public/f73714f1-9afa-4cd8-99bb-d4c0522c9d2b/subgraphs/flow-splitter-optimism/v0.0.2/gn",
-    flowCouncilFactory: "0x46a2496c9df5c00ccc51bcb9b77345410718de26",
+    flowCouncilFactory: "0x589232342bfeCb372dbbc01d17e8D112a27fF125",
     flowCouncilSubgraph:
-      "https://api.subgraph.ormilabs.com/api/public/f73714f1-9afa-4cd8-99bb-d4c0522c9d2b/subgraphs/flow-council-optimism/v0.3.0/gn",
+      "https://api.subgraph.ormilabs.com/api/public/f73714f1-9afa-4cd8-99bb-d4c0522c9d2b/subgraphs/flow-council-optimism/v0.4.2/gn",
     flowStateEligibilityNft: "0x09A62710a3BFC83aae2956F1D5B2363e4773Db7a",
     flowStateEligibilityMinScore: 15,
     superfluidHost: "0x567c4B141ED61923967cA25Ef4906C8781069a10",

--- a/src/lib/networks.ts
+++ b/src/lib/networks.ts
@@ -70,7 +70,7 @@ const networks: Network[] = [
     gda: "0x1e299701792a2aF01408B122419d65Fd2dF0Ba02",
     gdaForwarder: "0x6DA13Bde224A05a288748d857b9e7DDEffd1dE08",
     cfaForwarder: "0xcfA132E353cB4E398080B9700609bb008eceB125",
-    superAppSplitterFactory: "0x",
+    superAppSplitterFactory: "0x80F471302dc0e3D7ADc09C3808b9CB2b7C76232b",
     tokens: [
       {
         symbol: "ETHx",
@@ -121,7 +121,7 @@ const networks: Network[] = [
     gda: "0xfE6c87BE05feDB2059d2EC41bA0A09826C9FD7aa",
     gdaForwarder: "0x6DA13Bde224A05a288748d857b9e7DDEffd1dE08",
     cfaForwarder: "0xcfA132E353cB4E398080B9700609bb008eceB125",
-    superAppSplitterFactory: "0x",
+    superAppSplitterFactory: "0x80F471302dc0e3D7ADc09C3808b9CB2b7C76232b",
     tokens: [
       {
         symbol: "ETHx",
@@ -203,7 +203,7 @@ const networks: Network[] = [
     gda: "0x68Ae17fa7a31b86F306c383277552fd4813b0d35",
     gdaForwarder: "0x6DA13Bde224A05a288748d857b9e7DDEffd1dE08",
     cfaForwarder: "0xcfA132E353cB4E398080B9700609bb008eceB125",
-    superAppSplitterFactory: "0x",
+    superAppSplitterFactory: "0x80F471302dc0e3D7ADc09C3808b9CB2b7C76232b",
     tokens: [
       {
         symbol: "ETHx",


### PR DESCRIPTION
## Summary

- Set the new `FlowCouncilFactory` (`0x589232342bfeCb372dbbc01d17e8D112a27fF125`) on Celo, Base, Arbitrum, and Optimism and bump all four `flowCouncilSubgraph` endpoints to v0.4.2 (same hosts as before: Goldsky on Celo, Ormi elsewhere)
- Enable Arbitrum, Base, and Optimism in the Flow Council launcher (`FLOW_COUNCIL_NETWORK_LABELS`)
- Port the token selection from the Flow Splitters launcher: pick from the network token list or enter a custom address validated as a SuperToken via the Superfluid subgraph. Default stays G$ on Celo / first token elsewhere. Revisiting a launched council now displays its actual `superToken` from the subgraph

## Verification

- Factory bytecode confirmed on all four chains
- All four v0.4.2 subgraph endpoints respond
- New Celo subgraph still indexes existing councils (both GoodBuilders addresses resolve), so the factory/subgraph swap doesn't orphan anything
- `pnpm typecheck`, `pnpm lint`, and networks unit tests pass