### PR TITLE
Permissions table: unify column styling and fix alignment across screen sizes (with e2e)

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -46,3 +46,66 @@ jobs:
           TEST_DATABASE_URL: ${{ secrets.TEST_DATABASE_URL }}
           NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
           TEST_PRIVATE_KEY: ${{ secrets.TEST_PRIVATE_KEY }}
+
+  # Mocked E2E suite (includes the cross-viewport alignment spec). Excludes the
+  # @live smoke tests, which hit real RPC/subgraph and stay on main only. Waits
+  # for `test` so it never resets the shared test DB while the integration step
+  # is still using it.
+  e2e:
+    runs-on: ubuntu-latest
+    needs: test
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Build
+        run: pnpm build
+        env:
+          NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID }}
+          NEXT_PUBLIC_POSTHOG_KEY: ${{ secrets.NEXT_PUBLIC_POSTHOG_KEY }}
+          NEXT_PUBLIC_POSTHOG_HOST: ${{ secrets.NEXT_PUBLIC_POSTHOG_HOST }}
+          NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
+          NEXTAUTH_URL: http://localhost:3000
+          COUNCIL_DATABASE_URL: ${{ secrets.TEST_DATABASE_URL }}
+
+      - name: Start server
+        run: pnpm start &
+        env:
+          NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID }}
+          NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
+          NEXTAUTH_URL: http://localhost:3000
+          COUNCIL_DATABASE_URL: ${{ secrets.TEST_DATABASE_URL }}
+
+      - name: Wait for server
+        run: pnpm exec wait-on http://localhost:3000 --timeout 60000
+
+      - name: E2E tests
+        run: pnpm test:e2e
+        env:
+          TEST_DATABASE_URL: ${{ secrets.TEST_DATABASE_URL }}
+          NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
+          TEST_PRIVATE_KEY: ${{ secrets.TEST_PRIVATE_KEY }}
+          E2E_BASE_URL: http://localhost:3000
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -73,6 +73,17 @@ jobs:
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps chromium
 
+      # Reuse the Next.js build cache across runs so `pnpm build` is incremental
+      # instead of compiling every module from scratch. A miss just rebuilds in
+      # full, so this can only speed things up, never break the build.
+      - name: Cache Next.js build
+        uses: actions/cache@v4
+        with:
+          path: .next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('src/**', 'next.config.mjs') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-
+
       - name: Build
         run: pnpm build
         env:

--- a/src/app/flow-councils/permissions/permissions.tsx
+++ b/src/app/flow-councils/permissions/permissions.tsx
@@ -470,17 +470,25 @@ export default function Permissions(props: PermissionsProps) {
               gap={isMobile ? 2 : 4}
               className="justify-content-end align-items-center"
             >
-              <span
-                className="flex-grow-1"
-                style={{ maxWidth: isMobile ? undefined : 460 }}
-              />
-              <span
+              <Card.Text
+                className="m-0 flex-grow-1 ps-3"
+                style={{
+                  maxWidth: isMobile ? undefined : 460,
+                  fontSize: isMobile ? "0.7rem" : "inherit",
+                }}
+              >
+                Address
+              </Card.Text>
+              <Card.Text
+                className="m-0 ps-3"
                 style={
                   isMobile
-                    ? { width: 90, flexShrink: 0 }
+                    ? { width: 90, flexShrink: 0, fontSize: "0.7rem" }
                     : { flex: "1 1 180px", minWidth: 0 }
                 }
-              />
+              >
+                Profile Name
+              </Card.Text>
               <Stack direction="horizontal" gap={2}>
                 <Card.Text
                   className="m-0 text-center flex-shrink-0"
@@ -571,8 +579,7 @@ export default function Permissions(props: PermissionsProps) {
                 <Form.Control
                   type="text"
                   disabled
-                  placeholder="Name"
-                  value={managerDisplayName(managerEntry.address)}
+                  value={managerDisplayName(managerEntry.address) || "N/A"}
                   className="border-0 bg-white rounded-4 fw-semi-bold text-info"
                   style={{
                     ...(isMobile

--- a/src/app/flow-councils/permissions/permissions.tsx
+++ b/src/app/flow-councils/permissions/permissions.tsx
@@ -580,6 +580,7 @@ export default function Permissions(props: PermissionsProps) {
                 <Form.Control
                   type="text"
                   disabled
+                  aria-label="Profile Name"
                   value={managerDisplayName(managerEntry.address) || "N/A"}
                   className="border-0 bg-white rounded-4 fw-semi-bold text-info"
                   style={{

--- a/src/app/flow-councils/permissions/permissions.tsx
+++ b/src/app/flow-councils/permissions/permissions.tsx
@@ -76,6 +76,7 @@ export default function Permissions(props: PermissionsProps) {
   const publicClient = usePublicClient();
   const wagmiConfig = useConfig();
   const { isMobile } = useMediaQuery();
+  const headerFontSize = isMobile ? "0.7rem" : "inherit";
   const { address, chain: connectedChain } = useAccount();
   const { openConnectModal } = useConnectModal();
   const { switchChain } = useSwitchChain();
@@ -474,7 +475,7 @@ export default function Permissions(props: PermissionsProps) {
                 className="m-0 flex-grow-1 ps-3"
                 style={{
                   maxWidth: isMobile ? undefined : 460,
-                  fontSize: isMobile ? "0.7rem" : "inherit",
+                  fontSize: headerFontSize,
                 }}
               >
                 Address
@@ -483,7 +484,7 @@ export default function Permissions(props: PermissionsProps) {
                 className="m-0 ps-3"
                 style={
                   isMobile
-                    ? { width: 90, flexShrink: 0, fontSize: "0.7rem" }
+                    ? { width: 90, flexShrink: 0, fontSize: headerFontSize }
                     : { flex: "1 1 180px", minWidth: 0 }
                 }
               >
@@ -494,7 +495,7 @@ export default function Permissions(props: PermissionsProps) {
                   className="m-0 text-center flex-shrink-0"
                   style={{
                     width: isMobile ? 52 : 70,
-                    fontSize: isMobile ? "0.7rem" : "inherit",
+                    fontSize: headerFontSize,
                   }}
                 >
                   Super Admin
@@ -503,7 +504,7 @@ export default function Permissions(props: PermissionsProps) {
                   className="m-0 text-center flex-shrink-0"
                   style={{
                     width: isMobile ? 52 : 70,
-                    fontSize: isMobile ? "0.7rem" : "inherit",
+                    fontSize: headerFontSize,
                   }}
                 >
                   Voter Review
@@ -512,7 +513,7 @@ export default function Permissions(props: PermissionsProps) {
                   className="m-0 text-center flex-shrink-0"
                   style={{
                     width: isMobile ? 52 : 70,
-                    fontSize: isMobile ? "0.7rem" : "inherit",
+                    fontSize: headerFontSize,
                   }}
                 >
                   Recipient Review

--- a/src/app/flow-councils/permissions/permissions.tsx
+++ b/src/app/flow-councils/permissions/permissions.tsx
@@ -77,6 +77,13 @@ export default function Permissions(props: PermissionsProps) {
   const wagmiConfig = useConfig();
   const { isMobile } = useMediaQuery();
   const headerFontSize = isMobile ? "0.7rem" : "inherit";
+  const addressColumnStyle = isMobile
+    ? { minWidth: 0 }
+    : { flex: "1 1 460px", minWidth: 0, maxWidth: 460 };
+  const nameColumnStyle = isMobile
+    ? { width: 90, flexShrink: 0 }
+    : { flex: "1 1 180px", minWidth: 0 };
+  const checkColumnWidth = isMobile ? 50 : 70;
   const { address, chain: connectedChain } = useAccount();
   const { openConnectModal } = useConnectModal();
   const { switchChain } = useSwitchChain();
@@ -473,20 +480,13 @@ export default function Permissions(props: PermissionsProps) {
             >
               <Card.Text
                 className="m-0 flex-grow-1 ps-3"
-                style={{
-                  maxWidth: isMobile ? undefined : 460,
-                  fontSize: headerFontSize,
-                }}
+                style={{ ...addressColumnStyle, fontSize: headerFontSize }}
               >
                 Address
               </Card.Text>
               <Card.Text
                 className="m-0 ps-3"
-                style={
-                  isMobile
-                    ? { width: 90, flexShrink: 0, fontSize: headerFontSize }
-                    : { flex: "1 1 180px", minWidth: 0 }
-                }
+                style={{ ...nameColumnStyle, fontSize: headerFontSize }}
               >
                 Profile Name
               </Card.Text>
@@ -494,7 +494,7 @@ export default function Permissions(props: PermissionsProps) {
                 <Card.Text
                   className="m-0 text-center flex-shrink-0"
                   style={{
-                    width: isMobile ? 52 : 70,
+                    width: checkColumnWidth,
                     fontSize: headerFontSize,
                   }}
                 >
@@ -503,7 +503,7 @@ export default function Permissions(props: PermissionsProps) {
                 <Card.Text
                   className="m-0 text-center flex-shrink-0"
                   style={{
-                    width: isMobile ? 52 : 70,
+                    width: checkColumnWidth,
                     fontSize: headerFontSize,
                   }}
                 >
@@ -512,7 +512,7 @@ export default function Permissions(props: PermissionsProps) {
                 <Card.Text
                   className="m-0 text-center flex-shrink-0"
                   style={{
-                    width: isMobile ? 52 : 70,
+                    width: checkColumnWidth,
                     fontSize: headerFontSize,
                   }}
                 >
@@ -530,7 +530,7 @@ export default function Permissions(props: PermissionsProps) {
                 <Stack
                   direction="vertical"
                   className="position-relative flex-grow-1"
-                  style={{ minWidth: 0, maxWidth: isMobile ? undefined : 460 }}
+                  style={addressColumnStyle}
                 >
                   <Form.Control
                     type="text"
@@ -583,9 +583,7 @@ export default function Permissions(props: PermissionsProps) {
                   value={managerDisplayName(managerEntry.address) || "N/A"}
                   className="border-0 bg-white rounded-4 fw-semi-bold text-info"
                   style={{
-                    ...(isMobile
-                      ? { width: 90, flexShrink: 0 }
-                      : { flex: "1 1 180px", minWidth: 0 }),
+                    ...nameColumnStyle,
                     paddingTop: 12,
                     paddingBottom: 12,
                   }}
@@ -594,7 +592,7 @@ export default function Permissions(props: PermissionsProps) {
                   <Form.Check
                     className="d-flex justify-content-center"
                     style={{
-                      width: isMobile ? 50 : 70,
+                      width: checkColumnWidth,
                     }}
                   >
                     <Form.Check.Input
@@ -620,7 +618,7 @@ export default function Permissions(props: PermissionsProps) {
                   <Form.Check
                     className="d-flex justify-content-center"
                     style={{
-                      width: isMobile ? 50 : 70,
+                      width: checkColumnWidth,
                     }}
                   >
                     <Form.Check.Input
@@ -646,7 +644,7 @@ export default function Permissions(props: PermissionsProps) {
                   <Form.Check
                     className="d-flex justify-content-center"
                     style={{
-                      width: isMobile ? 50 : 70,
+                      width: checkColumnWidth,
                     }}
                   >
                     <Form.Check.Input

--- a/tests/e2e/permissions-layout.e2e.ts
+++ b/tests/e2e/permissions-layout.e2e.ts
@@ -44,8 +44,13 @@ for (const viewport of VIEWPORTS) {
       `/flow-councils/permissions/${fx.chainId}/${fx.councilAddress}`,
     );
 
-    const addressCell = page.getByPlaceholder("Manager Address");
-    const nameCell = page.locator("input.text-info");
+    const row = page.locator(".hstack", {
+      has: page.getByPlaceholder("Manager Address"),
+    });
+    const addressCell = row.getByPlaceholder("Manager Address");
+    // Profile-name input is the row's only direct-child input (the address
+    // input is nested in a wrapper), so this stays correct if its CSS changes.
+    const nameCell = row.locator(":scope > input");
     await expect(addressCell).toBeVisible();
     await expect(nameCell).toBeVisible();
 
@@ -75,7 +80,6 @@ for (const viewport of VIEWPORTS) {
       ).toBeLessThanOrEqual(TOLERANCE);
     }
 
-    const row = page.locator(".hstack", { has: addressCell });
     const checkboxes = row.locator('input[type="checkbox"]');
     const roleHeaders = ["Super Admin", "Voter Review", "Recipient Review"];
     await expect(checkboxes).toHaveCount(roleHeaders.length);

--- a/tests/e2e/permissions-layout.e2e.ts
+++ b/tests/e2e/permissions-layout.e2e.ts
@@ -1,0 +1,96 @@
+import { test, expect, type Locator } from "@playwright/test";
+import { installMockWallet, readFixture } from "./helpers/setup";
+import { installSubgraphMock } from "./helpers/subgraphMock";
+
+const VIEWPORTS = [
+  { name: "desktop", width: 1440, height: 900 },
+  { name: "mobile", width: 390, height: 844 },
+];
+
+// Header and body share the same flex/width constants, so any drift is
+// sub-pixel rounding. The bug this guards against shifted columns by tens of
+// pixels, so a tight bound still separates pass from fail unambiguously.
+const TOLERANCE = 1.5;
+
+test.beforeEach(async ({ page }) => {
+  await installMockWallet(page);
+  await installSubgraphMock(page);
+  await page.route("**/api/flow-council/voter-groups/profiles", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ success: true, names: {} }),
+    }),
+  );
+});
+
+async function box(locator: Locator) {
+  const rect = await locator.boundingBox();
+  if (!rect) {
+    throw new Error("expected a visible element with a bounding box");
+  }
+  return rect;
+}
+
+for (const viewport of VIEWPORTS) {
+  test(`permissions header columns align with their cells (${viewport.name})`, async ({
+    page,
+  }) => {
+    const fx = readFixture();
+    await page.setViewportSize({
+      width: viewport.width,
+      height: viewport.height,
+    });
+    await page.goto(
+      `/flow-councils/permissions/${fx.chainId}/${fx.councilAddress}`,
+    );
+
+    const addressCell = page.getByPlaceholder("Manager Address");
+    const nameCell = page.locator("input.text-info");
+    await expect(addressCell).toBeVisible();
+    await expect(nameCell).toBeVisible();
+
+    const columns = [
+      {
+        label: "Address",
+        header: page.getByText("Address", { exact: true }),
+        cell: addressCell,
+      },
+      {
+        label: "Profile Name",
+        header: page.getByText("Profile Name", { exact: true }),
+        cell: nameCell,
+      },
+    ];
+
+    for (const { label, header, cell } of columns) {
+      const headerBox = await box(header);
+      const cellBox = await box(cell);
+      expect(
+        Math.abs(headerBox.x - cellBox.x),
+        `${viewport.name}: "${label}" header left edge vs cell`,
+      ).toBeLessThanOrEqual(TOLERANCE);
+      expect(
+        Math.abs(headerBox.width - cellBox.width),
+        `${viewport.name}: "${label}" header width vs cell`,
+      ).toBeLessThanOrEqual(TOLERANCE);
+    }
+
+    const row = page.locator(".hstack", { has: addressCell });
+    const checkboxes = row.locator('input[type="checkbox"]');
+    const roleHeaders = ["Super Admin", "Voter Review", "Recipient Review"];
+    await expect(checkboxes).toHaveCount(roleHeaders.length);
+
+    for (let i = 0; i < roleHeaders.length; i++) {
+      const headerBox = await box(
+        page.getByText(roleHeaders[i], { exact: true }),
+      );
+      const checkboxBox = await box(checkboxes.nth(i));
+      const headerCenter = headerBox.x + headerBox.width / 2;
+      const checkboxCenter = checkboxBox.x + checkboxBox.width / 2;
+      expect(
+        Math.abs(headerCenter - checkboxCenter),
+        `${viewport.name}: "${roleHeaders[i]}" header center vs checkbox`,
+      ).toBeLessThanOrEqual(TOLERANCE);
+    }
+  });
+}

--- a/tests/e2e/permissions-layout.e2e.ts
+++ b/tests/e2e/permissions-layout.e2e.ts
@@ -48,9 +48,7 @@ for (const viewport of VIEWPORTS) {
       has: page.getByPlaceholder("Manager Address"),
     });
     const addressCell = row.getByPlaceholder("Manager Address");
-    // Profile-name input is the row's only direct-child input (the address
-    // input is nested in a wrapper), so this stays correct if its CSS changes.
-    const nameCell = row.locator(":scope > input");
+    const nameCell = row.getByLabel("Profile Name");
     await expect(addressCell).toBeVisible();
     await expect(nameCell).toBeVisible();
 


### PR DESCRIPTION
## Summary
Addresses confusion on the Permissions page where the empty "Name" cell rendered darker than populated profile names, and where the Address / Name columns had no headers.

## Changes
- **Uniform light-grey Name column.** The dark "Name" was the input's `placeholder` attribute (rendered in the browser's darker placeholder grey), while real names render as the `value` styled `text-info`. The empty state is now the value `"N/A"` instead of a placeholder, so every cell, names and the fallback, uses the same `text-info` light grey. New rows (no address yet) show `N/A` in the same grey.
- **"N/A" instead of "Name".** The empty-state text is now `N/A`.
- **Column labels.** The two empty header spacers are now real labels: **Address** and **Profile Name**, so every column on the page has a header (Address, Profile Name, Super Admin, Voter Review, Recipient Review). They reuse the existing role-label styling and keep the original column widths, so row alignment is unchanged.

## Testing
- `tsc --noEmit` passes
- `next lint` on the changed file: no warnings or errors