### PR TITLE
fix: show Grow the Pie cap-raise transfer in review and tx count after opt-in

### DIFF
--- a/src/app/flow-councils/components/DistributionPoolFunding.tsx
+++ b/src/app/flow-councils/components/DistributionPoolFunding.tsx
@@ -106,6 +106,8 @@ export default function DistributionPoolFunding(props: {
   const [amountPerTimeInterval, setAmountPerTimeInterval] = useState("");
   const [newFlowRate, setNewFlowRate] = useState("");
   const [wrapAmount, setWrapAmount] = useState("");
+  const [hasAcceptedSplitterCapWarning, setHasAcceptedSplitterCapWarning] =
+    useState(false);
 
   const { isMobile } = useMediaQuery();
   const { address } = useAccount();
@@ -394,7 +396,9 @@ export default function DistributionPoolFunding(props: {
     }
 
     const shouldIncludeTransfer =
-      exceedsSplitterCap && requiredTransferWei > BigInt(0);
+      exceedsSplitterCap &&
+      hasAcceptedSplitterCapWarning &&
+      requiredTransferWei > BigInt(0);
 
     if (shouldIncludeTransfer) {
       const wrapBatchCall = buildBatchCall(wrapBatchOps, chainId);
@@ -444,7 +448,12 @@ export default function DistributionPoolFunding(props: {
     network.id,
     exceedsSplitterCap,
     requiredTransferWei,
+    hasAcceptedSplitterCapWarning,
   ]);
+
+  useEffect(() => {
+    setHasAcceptedSplitterCapWarning(false);
+  }, [newFlowRate]);
 
   useEffect(() => {
     (async () => {
@@ -647,6 +656,10 @@ export default function DistributionPoolFunding(props: {
                 requiredTransferWei={requiredTransferWei}
                 hasSufficientBalanceForTransfer={
                   hasSufficientBalanceForTransfer
+                }
+                hasAcceptedSplitterCapWarning={hasAcceptedSplitterCapWarning}
+                setHasAcceptedSplitterCapWarning={
+                  setHasAcceptedSplitterCapWarning
                 }
               />
               <Success

--- a/src/components/checkout/Review.tsx
+++ b/src/components/checkout/Review.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo } from "react";
 import { useAccount, useSwitchChain } from "wagmi";
 import { formatEther, parseEther } from "viem";
 import dayjs from "dayjs";
@@ -54,6 +54,8 @@ export type ReviewProps = {
   exceedsSplitterCap?: boolean;
   requiredTransferWei?: bigint;
   hasSufficientBalanceForTransfer?: boolean;
+  hasAcceptedSplitterCapWarning?: boolean;
+  setHasAcceptedSplitterCapWarning?: (hasAccepted: boolean) => void;
 };
 
 type TransactionDetailsSnapshot = {
@@ -68,6 +70,7 @@ type TransactionDetailsSnapshot = {
   flowRateToReceiver: string;
   exceedsSplitterCap: boolean;
   requiredTransferWei: bigint;
+  callsCount: number;
 };
 
 export default function Review(props: ReviewProps) {
@@ -97,6 +100,8 @@ export default function Review(props: ReviewProps) {
     exceedsSplitterCap = false,
     requiredTransferWei = BigInt(0),
     hasSufficientBalanceForTransfer = true,
+    hasAcceptedSplitterCapWarning = false,
+    setHasAcceptedSplitterCapWarning,
   } = props;
 
   const [transactionDetailsSnapshot, setTransactionDetailsSnapshot] =
@@ -105,8 +110,6 @@ export default function Review(props: ReviewProps) {
     hasAcceptedCloseLiquidationWarning,
     setHasAcceptedCloseLiquidationWarning,
   ] = useState(false);
-  const [hasAcceptedSplitterCapWarning, setHasAcceptedSplitterCapWarning] =
-    useState(false);
 
   const wrapAmountForDisplay =
     areTransactionsLoading && transactionDetailsSnapshot
@@ -116,7 +119,7 @@ export default function Review(props: ReviewProps) {
   const hasTransfer =
     areTransactionsLoading && transactionDetailsSnapshot
       ? transactionDetailsSnapshot.exceedsSplitterCap
-      : exceedsSplitterCap;
+      : exceedsSplitterCap && hasAcceptedSplitterCapWarning;
   const transferWeiForDisplay =
     areTransactionsLoading && transactionDetailsSnapshot
       ? transactionDetailsSnapshot.requiredTransferWei
@@ -130,10 +133,10 @@ export default function Review(props: ReviewProps) {
       : requiredTransferWei -
         superTokenBalance -
         parseEther(wrapAmount?.replace(/,/g, "") ?? "0");
-
-  useEffect(() => {
-    setHasAcceptedSplitterCapWarning(false);
-  }, [newFlowRate]);
+  const callsCountForDisplay =
+    areTransactionsLoading && transactionDetailsSnapshot
+      ? transactionDetailsSnapshot.callsCount
+      : calls.length;
 
   const { address, chain: connectedChain } = useAccount();
   const { switchChain } = useSwitchChain();
@@ -173,6 +176,7 @@ export default function Review(props: ReviewProps) {
       flowRateToReceiver,
       exceedsSplitterCap,
       requiredTransferWei,
+      callsCount: calls.length,
     });
 
     try {
@@ -630,7 +634,7 @@ export default function Review(props: ReviewProps) {
                   disabled={!hasSufficientBalanceForTransfer}
                   className="border-black"
                   onChange={() =>
-                    setHasAcceptedSplitterCapWarning(
+                    setHasAcceptedSplitterCapWarning?.(
                       !hasAcceptedSplitterCapWarning,
                     )
                   }
@@ -703,16 +707,17 @@ export default function Review(props: ReviewProps) {
                   role="status"
                   className="p-2"
                 />
-                {!shouldUseSendCalls && calls.length > 1 && (
+                {!shouldUseSendCalls && callsCountForDisplay > 1 && (
                   <Card.Text className="m-0 fw-semi-bold">
-                    {completedTransactions + 1}/{calls.length}
+                    {Math.min(completedTransactions + 1, callsCountForDisplay)}/
+                    {callsCountForDisplay}
                   </Card.Text>
                 )}
               </Stack>
             ) : isDeletingStream ? (
               "Cancel Stream"
-            ) : !shouldUseSendCalls && calls.length > 1 ? (
-              `Submit (${calls.length})`
+            ) : !shouldUseSendCalls && callsCountForDisplay > 1 ? (
+              `Submit (${callsCountForDisplay})`
             ) : (
               "Submit"
             )}

--- a/src/components/checkout/Review.tsx
+++ b/src/components/checkout/Review.tsx
@@ -68,7 +68,7 @@ type TransactionDetailsSnapshot = {
   matchingMultiplier: number | null;
   newFlowRate: string;
   flowRateToReceiver: string;
-  exceedsSplitterCap: boolean;
+  hasTransfer: boolean;
   requiredTransferWei: bigint;
   callsCount: number;
 };
@@ -118,7 +118,7 @@ export default function Review(props: ReviewProps) {
   const hasWrap = Number(wrapAmountForDisplay ?? "0") > 0;
   const hasTransfer =
     areTransactionsLoading && transactionDetailsSnapshot
-      ? transactionDetailsSnapshot.exceedsSplitterCap
+      ? transactionDetailsSnapshot.hasTransfer
       : exceedsSplitterCap && hasAcceptedSplitterCapWarning;
   const transferWeiForDisplay =
     areTransactionsLoading && transactionDetailsSnapshot
@@ -174,7 +174,7 @@ export default function Review(props: ReviewProps) {
       netImpact,
       newFlowRate,
       flowRateToReceiver,
-      exceedsSplitterCap,
+      hasTransfer: exceedsSplitterCap && hasAcceptedSplitterCapWarning,
       requiredTransferWei,
       callsCount: calls.length,
     });


### PR DESCRIPTION
## Summary

When a Grow the Pie stream exceeds the splitter's funding-rate cap, raising the cap requires an extra ERC20 `transfer` (the buffer deposit). That transaction was executed but it wasn't consistently reflected in the review/button count, which drifted to `3/2` by the end of the sequence.

Root cause of the `3/2`: the progress counter used the live `calls.length`, which the memo recomputes as balances/flow-rate re-poll. Once the transfer lands and the cap is no longer exceeded, the transfer drops out of `calls`, so the denominator shrank while the originally-captured loop kept running all the calls.

## Changes

- The cap-raise transfer now enters `calls`, the review list, and the transaction count only after the user ticks the "Continue?" checkbox. The checkbox state is lifted to `DistributionPoolFunding` so it can gate the `calls` memo.
- The displayed transaction count is frozen at submit time (`callsCount` snapshot), so the denominator can't shrink mid-execution.
- Everything stays gated on `exceedsSplitterCap`, so Grow the Pie checkouts that don't need a buffer deposit are unchanged.

## Testing

- `pnpm typecheck` and `pnpm lint` pass.
- No unit tests cover these components; manual on-chain verification against a live council (a stream that actually exceeds the cap) is still recommended.
