### PR TITLE
feat: open existing Flow Councils to the Metadata tab by default

### DIFF
--- a/src/app/flow-councils/components/Sidebar.tsx
+++ b/src/app/flow-councils/components/Sidebar.tsx
@@ -309,7 +309,7 @@ function Sidebar() {
             className="text-truncate fw-semi-bold"
             onClick={() =>
               router.push(
-                `/flow-councils/membership/${selectedNetwork.id}/${council.id}`,
+                `/flow-councils/round-metadata/${selectedNetwork.id}/${council.id}`,
               )
             }
           >


### PR DESCRIPTION
## What

When opening/changing an existing Flow Council from the admin sidebar's councils dropdown, the app now lands on the **Metadata** section by default instead of **Voters**.

## Why

Metadata is the more natural starting point when reviewing or editing an existing council.

## Change

- `src/app/flow-councils/components/Sidebar.tsx`: the councils dropdown `onClick` now routes to `/flow-councils/round-metadata/...` instead of `/flow-councils/membership/...`.

The `round-metadata` route already uses the same `/[chainId]/[councilId]` URL pattern, so no other changes are needed. Creating a new council (Create New) is unaffected.

## Verification

- `pnpm lint` passes
- `pnpm typecheck` passes