### PR TITLE
Hide apply link when applications locked + lock toggle tooltips

### DIFF
--- a/src/app/flow-councils/components/RoundBanner.tsx
+++ b/src/app/flow-councils/components/RoundBanner.tsx
@@ -38,7 +38,8 @@ export default function PoolInfo(props: PoolInfoProps) {
     showDistributionPoolFunding,
   } = props;
 
-  const { council, projects, superAppFunderData } = useFlowCouncil();
+  const { council, councilMetadata, projects, superAppFunderData } =
+    useFlowCouncil();
   const { isMobile } = useMediaQuery();
   const { address } = useAccount();
 
@@ -94,11 +95,15 @@ export default function PoolInfo(props: PoolInfoProps) {
           }
         />
       </Stack>
-      <Card.Text className="mb-8 fs-lg">
-        <Card.Link href={`/flow-councils/application/${chainId}/${councilId}`}>
-          Apply to the Round
-        </Card.Link>
-      </Card.Text>
+      {!councilMetadata.applicationsClosed && (
+        <Card.Text className="mb-8 fs-lg">
+          <Card.Link
+            href={`/flow-councils/application/${chainId}/${councilId}`}
+          >
+            Apply to the Round
+          </Card.Link>
+        </Card.Text>
+      )}
       <Table borderless className="fs-lg">
         <thead className="border-bottom border-dark">
           <tr>

--- a/src/app/flow-councils/hooks/councilMetadata.ts
+++ b/src/app/flow-councils/hooks/councilMetadata.ts
@@ -9,6 +9,7 @@ const DEFAULT_METADATA: RoundMetadata = {
   description: "",
   logoUrl: "",
   superappSplitterAddress: null,
+  applicationsClosed: false,
 };
 
 export default function useCouncilMetadata(chainId: number, councilId: string) {

--- a/src/app/flow-councils/lib/fetchRoundMetadata.ts
+++ b/src/app/flow-councils/lib/fetchRoundMetadata.ts
@@ -5,6 +5,7 @@ export type RoundMetadata = {
   description: string;
   logoUrl: string;
   superappSplitterAddress: Address | null;
+  applicationsClosed: boolean;
 };
 
 const DEFAULT_METADATA: RoundMetadata = {
@@ -12,6 +13,7 @@ const DEFAULT_METADATA: RoundMetadata = {
   description: "",
   logoUrl: "",
   superappSplitterAddress: null,
+  applicationsClosed: false,
 };
 
 export async function fetchRoundMetadata(
@@ -24,11 +26,12 @@ export async function fetchRoundMetadata(
     );
     const data = await res.json();
 
-    if (data.success && data.round?.details) {
-      const details =
-        typeof data.round.details === "string"
+    if (data.success && data.round) {
+      const details = data.round.details
+        ? typeof data.round.details === "string"
           ? JSON.parse(data.round.details)
-          : data.round.details;
+          : data.round.details
+        : null;
 
       const raw = data.round.superappSplitterAddress;
       const splitter: Address | null =
@@ -39,6 +42,7 @@ export async function fetchRoundMetadata(
         description: details?.description ?? DEFAULT_METADATA.description,
         logoUrl: details?.logoUrl ?? DEFAULT_METADATA.logoUrl,
         superappSplitterAddress: splitter,
+        applicationsClosed: data.round.applicationsClosed ?? false,
       };
     }
   } catch (err) {

--- a/src/app/flow-councils/review/review.tsx
+++ b/src/app/flow-councils/review/review.tsx
@@ -962,7 +962,14 @@ export default function Review(props: ReviewProps) {
               gap={2}
               className="align-items-center mb-4"
             >
-              <Image src="/unlock.svg" alt="Open" width={20} height={20} />
+              <InfoTooltip
+                position={{ top: true }}
+                wrapperClassName="d-flex align-items-center"
+                content={<>Open Applications</>}
+                target={
+                  <Image src="/unlock.svg" alt="Open" width={20} height={20} />
+                }
+              />
               <div
                 className="form-switch"
                 style={{
@@ -981,7 +988,14 @@ export default function Review(props: ReviewProps) {
                   onChange={handleToggleApplicationsClosed}
                 />
               </div>
-              <Image src="/lock.svg" alt="Closed" width={20} height={20} />
+              <InfoTooltip
+                position={{ top: true }}
+                wrapperClassName="d-flex align-items-center"
+                content={<>Close Applications</>}
+                target={
+                  <Image src="/lock.svg" alt="Closed" width={20} height={20} />
+                }
+              />
             </Stack>
 
             {/* Applications Table */}

--- a/src/app/flow-councils/review/review.tsx
+++ b/src/app/flow-councils/review/review.tsx
@@ -9,6 +9,7 @@ import { writeContract } from "@wagmi/core";
 import { useSession } from "next-auth/react";
 import { useConnectModal } from "@rainbow-me/rainbowkit";
 import { gql, useQuery } from "@apollo/client";
+import { useQueryClient } from "@tanstack/react-query";
 import Stack from "react-bootstrap/Stack";
 import Form from "react-bootstrap/Form";
 import Button from "react-bootstrap/Button";
@@ -156,6 +157,7 @@ export default function Review(props: ReviewProps) {
     Map<string, "connected" | "slots-full">
   >(new Map());
 
+  const queryClient = useQueryClient();
   const topRef = useRef<HTMLDivElement>(null);
   const publicClient = usePublicClient();
   const wagmiConfig = useConfig();
@@ -644,6 +646,7 @@ export default function Review(props: ReviewProps) {
       }
 
       setApplicationsClosed(!applicationsClosed);
+      queryClient.invalidateQueries({ queryKey: ["councilMetadata"] });
       setIsTogglingApplicationsClosed(false);
     } catch (err) {
       console.error(err);

--- a/src/context/FlowCouncil.tsx
+++ b/src/context/FlowCouncil.tsx
@@ -36,6 +36,7 @@ export const FlowCouncilContext = createContext<{
     description: string;
     logoUrl: string;
     superappSplitterAddress: Address | null;
+    applicationsClosed: boolean;
   };
   councilMember?: CouncilMember;
   currentBallot?: CurrentBallot;


### PR DESCRIPTION
## What

Two small admin/voting UX changes around locking applications:

1. **Hide the "Apply to the Round" link on the public voting UI when an admin has locked applications.** Previously the link was always shown even when applications were closed.
2. **Add hover tooltips to the lock/unlock icons on the Recipients tab** so admins know what the toggle does: "Open Applications" (unlock icon) and "Close Applications" (lock icon).

## How

The lock state already lives in the `rounds.applicationsClosed` column and is returned by `GET /api/flow-council/rounds`. The voting page already fetches that round via `fetchRoundMetadata`, so the flag is threaded through the existing data path (no extra request):

- `lib/fetchRoundMetadata.ts` — add `applicationsClosed` to `RoundMetadata` and read it from the round response (also made `details` optional so the flag is read whenever the round exists).
- `hooks/councilMetadata.ts` + `context/FlowCouncil.tsx` — add `applicationsClosed` to the default and the context's `councilMetadata` type.
- `components/RoundBanner.tsx` — render the "Apply to the Round" link only when `!councilMetadata.applicationsClosed`.
- `review/review.tsx` — wrap the two toggle icons with the existing `InfoTooltip`.

## Notes

`councilMetadata` is cached with `staleTime: 60s`, so a voter with the page already open sees the link disappear within ~60s (or immediately on reload) after an admin locks applications.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — no warnings/errors