### PR TITLE
feat: default applications to Minimal template when no form is configured

### DIFF
--- a/src/app/api/flow-council/applications/[applicationId]/route.ts
+++ b/src/app/api/flow-council/applications/[applicationId]/route.ts
@@ -16,6 +16,8 @@ import {
   MAX_DETAILS_SIZE,
 } from "../../validation";
 import { readJsonBody, PayloadTooLargeError } from "../../../utils";
+import { MINIMAL_TEMPLATE } from "@/app/flow-councils/types/formSchema";
+import { isDynamicApplicationDetails } from "@/app/flow-councils/utils/legacyFormAdapter";
 
 export const dynamic = "force-dynamic";
 
@@ -250,11 +252,19 @@ export async function PATCH(
           ? JSON.parse(roundRow.details)
           : (roundRow?.details ?? {});
 
-      if (roundDetails.formSchema?.round) {
-        const validation = validateDynamicRoundDetails(
-          details,
-          roundDetails.formSchema.round,
-        );
+      // Configured formSchema wins; otherwise dynamic-shaped submissions
+      // (carrying _formVersion) validate against the default Minimal template.
+      const roundSchema =
+        roundDetails.formSchema?.round ??
+        (isDynamicApplicationDetails(details) ? MINIMAL_TEMPLATE.round : null);
+      const attestationSchema =
+        roundDetails.formSchema?.attestation ??
+        (isDynamicApplicationDetails(details)
+          ? MINIMAL_TEMPLATE.attestation
+          : null);
+
+      if (roundSchema) {
+        const validation = validateDynamicRoundDetails(details, roundSchema);
         if (!validation.success) {
           return new Response(
             JSON.stringify({ success: false, error: validation.error }),
@@ -263,10 +273,10 @@ export async function PATCH(
         }
       }
 
-      if (roundDetails.formSchema?.attestation) {
+      if (attestationSchema) {
         const validation = validateDynamicAttestationDetails(
           details,
-          roundDetails.formSchema.attestation,
+          attestationSchema,
         );
         if (!validation.success) {
           return new Response(

--- a/src/app/api/flow-council/applications/route.integration.test.ts
+++ b/src/app/api/flow-council/applications/route.integration.test.ts
@@ -34,8 +34,11 @@ import {
   type SeededFixture,
 } from "@tests/helpers/db";
 import { mockSession, mockUnauthenticated } from "@tests/helpers/session";
+import { MINIMAL_TEMPLATE } from "@/app/flow-councils/types/formSchema";
 
 const db = getTestDb();
+
+const MINIMAL_ROUND_FIELD_ID = MINIMAL_TEMPLATE.round[0].id;
 
 let fixture: SeededFixture;
 
@@ -254,6 +257,66 @@ describe("PUT /api/flow-council/applications", () => {
     const body = await readJson(res);
     expect(body.success).toBe(true);
     expect(body.application.id).toBe(fixture.submittedApplicationId);
+  });
+
+  it("accepts a dynamic-shaped submission on a round with no formSchema (Minimal default)", async () => {
+    mockSession(TEST_MANAGER_ADDRESS);
+    const res = await PUT(
+      putRequest({
+        projectId: fixture.alphaProjectId,
+        chainId: TEST_CHAIN_ID,
+        councilId: TEST_COUNCIL_ADDRESS,
+        fundingAddress: TEST_MANAGER_ADDRESS,
+        details: {
+          _formVersion: 1,
+          round: { [MINIMAL_ROUND_FIELD_ID]: "test" },
+          attestation: {},
+        },
+      }),
+    );
+    const body = await readJson(res);
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.application.id).toBe(fixture.submittedApplicationId);
+  });
+
+  it("rejects a dynamic-shaped submission without a funding address", async () => {
+    mockSession(TEST_MANAGER_ADDRESS);
+    const res = await PUT(
+      putRequest({
+        projectId: fixture.alphaProjectId,
+        chainId: TEST_CHAIN_ID,
+        councilId: TEST_COUNCIL_ADDRESS,
+        details: {
+          _formVersion: 1,
+          round: { [MINIMAL_ROUND_FIELD_ID]: "test" },
+          attestation: {},
+        },
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await readJson(res);
+    expect(body.error).toMatch(/funding address/i);
+  });
+
+  it("rejects a dynamic-shaped submission missing the required Minimal round field", async () => {
+    mockSession(TEST_MANAGER_ADDRESS);
+    const res = await PUT(
+      putRequest({
+        projectId: fixture.alphaProjectId,
+        chainId: TEST_CHAIN_ID,
+        councilId: TEST_COUNCIL_ADDRESS,
+        fundingAddress: TEST_MANAGER_ADDRESS,
+        details: {
+          _formVersion: 1,
+          round: {},
+          attestation: {},
+        },
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await readJson(res);
+    expect(body.error).toMatch(/required/i);
   });
 
   it("returns 409 when the application is ACCEPTED and editsUnlocked is false", async () => {

--- a/src/app/api/flow-council/applications/route.ts
+++ b/src/app/api/flow-council/applications/route.ts
@@ -10,6 +10,8 @@ import {
   MAX_DETAILS_SIZE,
 } from "../validation";
 import { isRoundAdmin, hasOnChainRole } from "../auth";
+import { MINIMAL_TEMPLATE } from "@/app/flow-councils/types/formSchema";
+import { isDynamicApplicationDetails } from "@/app/flow-councils/utils/legacyFormAdapter";
 
 export const dynamic = "force-dynamic";
 
@@ -279,7 +281,13 @@ export async function PUT(request: Request) {
         ? JSON.parse(round.details)
         : (round.details ?? {});
 
-    const isDynamicFlow = !!roundDetails.formSchema?.round;
+    // A round with a configured formSchema is always dynamic. Rounds without
+    // one default to the Minimal template, so dynamic-shaped submissions
+    // (carrying _formVersion) are dynamic too; legacy-shaped ones stay legacy.
+    const isDynamicFlow =
+      !!roundDetails.formSchema?.round || isDynamicApplicationDetails(details);
+    const dynamicRoundSchema =
+      roundDetails.formSchema?.round ?? MINIMAL_TEMPLATE.round;
 
     if (isDynamicFlow) {
       if (
@@ -298,7 +306,7 @@ export async function PUT(request: Request) {
       if (isDynamicFlow) {
         const validation = validateDynamicRoundDetails(
           details,
-          roundDetails.formSchema.round,
+          dynamicRoundSchema,
         );
         if (!validation.success) {
           return new Response(

--- a/src/app/api/flow-council/applications/route.ts
+++ b/src/app/api/flow-council/applications/route.ts
@@ -286,8 +286,6 @@ export async function PUT(request: Request) {
     // (carrying _formVersion) are dynamic too; legacy-shaped ones stay legacy.
     const isDynamicFlow =
       !!roundDetails.formSchema?.round || isDynamicApplicationDetails(details);
-    const dynamicRoundSchema =
-      roundDetails.formSchema?.round ?? MINIMAL_TEMPLATE.round;
 
     if (isDynamicFlow) {
       if (
@@ -306,7 +304,7 @@ export async function PUT(request: Request) {
       if (isDynamicFlow) {
         const validation = validateDynamicRoundDetails(
           details,
-          dynamicRoundSchema,
+          roundDetails.formSchema?.round ?? MINIMAL_TEMPLATE.round,
         );
         if (!validation.success) {
           return new Response(

--- a/src/app/flow-councils/application/[chainId]/[councilId]/[projectId]/application.tsx
+++ b/src/app/flow-councils/application/[chainId]/[councilId]/[projectId]/application.tsx
@@ -21,8 +21,14 @@ import type {
   RoundForm,
   AttestationForm,
 } from "@/app/flow-councils/types/round";
-import type { FormSchema } from "@/app/flow-councils/types/formSchema";
-import { getApplicationAsDynamic } from "@/app/flow-councils/utils/legacyFormAdapter";
+import {
+  type FormSchema,
+  MINIMAL_TEMPLATE,
+} from "@/app/flow-councils/types/formSchema";
+import {
+  getApplicationAsDynamic,
+  isDynamicApplicationDetails,
+} from "@/app/flow-councils/utils/legacyFormAdapter";
 import { generateApplicationTemplate } from "@/app/flow-councils/lib/generateApplicationTemplate";
 import { networks } from "@/lib/networks";
 import { Project } from "@/types/project";
@@ -170,7 +176,7 @@ export default function Application(props: ApplicationProps) {
       if (!data.success || !data.round?.details) return null;
       const { name, formSchema: schema } = parseRoundDetails(data.round);
       setRoundName(name);
-      if (schema) setFormSchema(schema);
+      setFormSchema(schema ?? MINIMAL_TEMPLATE);
       return schema;
     } catch (err) {
       console.error("Failed to fetch form schema:", err);
@@ -251,7 +257,7 @@ export default function Application(props: ApplicationProps) {
             ? JSON.parse(app.details)
             : app.details;
 
-        if (schema) {
+        if (schema || isDynamicApplicationDetails(details)) {
           setDynamicRoundValues(
             (details.round as Record<string, unknown>) ?? {},
           );
@@ -262,6 +268,7 @@ export default function Application(props: ApplicationProps) {
             setDynamicFundingAddress(app.fundingAddress);
           }
         } else {
+          setFormSchema(null);
           setRoundData(details as unknown as RoundForm);
           const attestation = details.attestation ?? details.eligibility;
           if (attestation) {

--- a/src/app/flow-councils/application/[chainId]/[councilId]/[projectId]/application.tsx
+++ b/src/app/flow-councils/application/[chainId]/[councilId]/[projectId]/application.tsx
@@ -178,6 +178,9 @@ export default function Application(props: ApplicationProps) {
         parseRoundDetails(data.round);
       setRoundName(name);
       setFormSchema(configuredSchema ?? MINIMAL_TEMPLATE);
+      // Return the raw configured schema (may be null), not the Minimal
+      // default: fetchApplication needs the null to detect legacy submissions
+      // and undo the default via setFormSchema(null).
       return configuredSchema;
     } catch (err) {
       console.error("Failed to fetch form schema:", err);

--- a/src/app/flow-councils/application/[chainId]/[councilId]/[projectId]/application.tsx
+++ b/src/app/flow-councils/application/[chainId]/[councilId]/[projectId]/application.tsx
@@ -174,10 +174,11 @@ export default function Application(props: ApplicationProps) {
       );
       const data = await res.json();
       if (!data.success || !data.round?.details) return null;
-      const { name, formSchema: schema } = parseRoundDetails(data.round);
+      const { name, formSchema: configuredSchema } =
+        parseRoundDetails(data.round);
       setRoundName(name);
-      setFormSchema(schema ?? MINIMAL_TEMPLATE);
-      return schema;
+      setFormSchema(configuredSchema ?? MINIMAL_TEMPLATE);
+      return configuredSchema;
     } catch (err) {
       console.error("Failed to fetch form schema:", err);
       return null;
@@ -231,7 +232,7 @@ export default function Application(props: ApplicationProps) {
   }, [projectId, address]);
 
   const fetchApplication = useCallback(
-    async (schema: FormSchema | null) => {
+    async (configuredSchema: FormSchema | null) => {
       if (!projectId || !address) return;
 
       try {
@@ -257,7 +258,7 @@ export default function Application(props: ApplicationProps) {
             ? JSON.parse(app.details)
             : app.details;
 
-        if (schema || isDynamicApplicationDetails(details)) {
+        if (configuredSchema || isDynamicApplicationDetails(details)) {
           setDynamicRoundValues(
             (details.round as Record<string, unknown>) ?? {},
           );
@@ -268,6 +269,8 @@ export default function Application(props: ApplicationProps) {
             setDynamicFundingAddress(app.fundingAddress);
           }
         } else {
+          // Existing legacy submission: undo the Minimal default from fetchRound
+          // so the legacy form (not the dynamic one) renders.
           setFormSchema(null);
           setRoundData(details as unknown as RoundForm);
           const attestation = details.attestation ?? details.eligibility;
@@ -286,11 +289,11 @@ export default function Application(props: ApplicationProps) {
     if (projectId && address) {
       setIsLoading(true);
       (async () => {
-        const schema = await fetchRound();
+        const configuredSchema = await fetchRound();
         await Promise.all([
           fetchProfile(),
           fetchProject(),
-          fetchApplication(schema),
+          fetchApplication(configuredSchema),
         ]);
         setIsLoading(false);
       })();

--- a/src/app/flow-councils/review/review.tsx
+++ b/src/app/flow-councils/review/review.tsx
@@ -50,7 +50,7 @@ import type {
 } from "@/app/flow-councils/types/round";
 import {
   type FormSchema,
-  MINIMAL_TEMPLATE,
+  type FormElement,
 } from "@/app/flow-councils/types/formSchema";
 import {
   getApplicationAsDynamic,
@@ -363,13 +363,11 @@ export default function Review(props: ReviewProps) {
     let headers: string[];
     let rows: string[][];
 
-    const effectiveSchema =
-      roundFormSchema ??
-      (fullApplications.some((app) => isDynamicApplicationDetails(app.details))
-        ? MINIMAL_TEMPLATE
-        : null);
+    const hasDynamicForm =
+      !!roundFormSchema ||
+      fullApplications.some((app) => isDynamicApplicationDetails(app.details));
 
-    if (!effectiveSchema) {
+    if (!hasDynamicForm) {
       headers = [
         "application_status",
         "project_name",
@@ -393,18 +391,33 @@ export default function Review(props: ReviewProps) {
         ].map(escCsv);
       });
     } else {
-      const roundQuestions = effectiveSchema.round.filter(
-        (el) => !["section", "divider", "description"].includes(el.type),
-      );
-      const attestationQuestions = effectiveSchema.attestation.filter(
-        (el) => !["section", "divider", "description"].includes(el.type),
-      );
-
       const formatVal = (val: unknown) => {
         if (Array.isArray(val)) return val.join("|");
         if (typeof val === "boolean") return val ? "Yes" : "No";
         return String(val ?? "");
       };
+
+      const appViews = fullApplications.map((app) => ({
+        app,
+        ...getApplicationAsDynamic(app.details, roundFormSchema),
+      }));
+
+      const isQuestion = (el: FormElement) =>
+        !["section", "divider", "description"].includes(el.type);
+      const unionQuestions = (pick: (schema: FormSchema) => FormElement[]) => {
+        const byId = new Map<string, FormElement>();
+        for (const { schema } of appViews) {
+          for (const el of pick(schema).filter(isQuestion)) {
+            if (!byId.has(el.id)) byId.set(el.id, el);
+          }
+        }
+        return [...byId.values()];
+      };
+
+      const roundQuestions = unionQuestions((schema) => schema.round);
+      const attestationQuestions = unionQuestions(
+        (schema) => schema.attestation,
+      );
 
       headers = [
         "application_status",
@@ -416,12 +429,8 @@ export default function Review(props: ReviewProps) {
         ...attestationQuestions.map((q) => q.label),
       ];
 
-      rows = fullApplications.map((app) => {
+      rows = appViews.map(({ app, roundValues, attestationValues }) => {
         const projectDetails = app.projectDetails;
-        const { roundValues, attestationValues } = getApplicationAsDynamic(
-          app.details,
-          effectiveSchema,
-        );
         return [
           STATUS_LABELS[app.status] || app.status,
           projectDetails?.name ?? "",

--- a/src/app/flow-councils/review/review.tsx
+++ b/src/app/flow-councils/review/review.tsx
@@ -51,6 +51,7 @@ import type {
 import {
   type FormSchema,
   type FormElement,
+  STRUCTURAL_TYPES,
 } from "@/app/flow-councils/types/formSchema";
 import {
   getApplicationAsDynamic,
@@ -402,8 +403,7 @@ export default function Review(props: ReviewProps) {
         ...getApplicationAsDynamic(app.details, roundFormSchema),
       }));
 
-      const isQuestion = (el: FormElement) =>
-        !["section", "divider", "description"].includes(el.type);
+      const isQuestion = (el: FormElement) => !STRUCTURAL_TYPES.has(el.type);
       const unionQuestions = (pick: (schema: FormSchema) => FormElement[]) => {
         const byId = new Map<string, FormElement>();
         for (const { schema } of appViews) {

--- a/src/app/flow-councils/review/review.tsx
+++ b/src/app/flow-councils/review/review.tsx
@@ -48,8 +48,14 @@ import type {
   RoundForm,
   AttestationForm,
 } from "@/app/flow-councils/types/round";
-import type { FormSchema } from "@/app/flow-councils/types/formSchema";
-import { getApplicationAsDynamic } from "@/app/flow-councils/utils/legacyFormAdapter";
+import {
+  type FormSchema,
+  MINIMAL_TEMPLATE,
+} from "@/app/flow-councils/types/formSchema";
+import {
+  getApplicationAsDynamic,
+  isDynamicApplicationDetails,
+} from "@/app/flow-councils/utils/legacyFormAdapter";
 import { ProjectDetails } from "@/types/project";
 
 type ReviewProps = {
@@ -357,7 +363,13 @@ export default function Review(props: ReviewProps) {
     let headers: string[];
     let rows: string[][];
 
-    if (!roundFormSchema) {
+    const effectiveSchema =
+      roundFormSchema ??
+      (fullApplications.some((app) => isDynamicApplicationDetails(app.details))
+        ? MINIMAL_TEMPLATE
+        : null);
+
+    if (!effectiveSchema) {
       headers = [
         "application_status",
         "project_name",
@@ -381,10 +393,10 @@ export default function Review(props: ReviewProps) {
         ].map(escCsv);
       });
     } else {
-      const roundQuestions = roundFormSchema.round.filter(
+      const roundQuestions = effectiveSchema.round.filter(
         (el) => !["section", "divider", "description"].includes(el.type),
       );
-      const attestationQuestions = roundFormSchema.attestation.filter(
+      const attestationQuestions = effectiveSchema.attestation.filter(
         (el) => !["section", "divider", "description"].includes(el.type),
       );
 
@@ -408,7 +420,7 @@ export default function Review(props: ReviewProps) {
         const projectDetails = app.projectDetails;
         const { roundValues, attestationValues } = getApplicationAsDynamic(
           app.details,
-          roundFormSchema,
+          effectiveSchema,
         );
         return [
           STATUS_LABELS[app.status] || app.status,

--- a/src/app/flow-councils/utils/legacyFormAdapter.ts
+++ b/src/app/flow-councils/utils/legacyFormAdapter.ts
@@ -10,6 +10,7 @@ import {
 } from "@/app/flow-councils/types/round";
 import {
   GOODBUILDERS_TEMPLATE,
+  MINIMAL_TEMPLATE,
   type FormSchema,
 } from "@/app/flow-councils/types/formSchema";
 
@@ -144,6 +145,12 @@ type DetailsShape = {
   eligibility?: Partial<AttestationForm> | Record<string, unknown>;
 };
 
+export function isDynamicApplicationDetails(details: unknown): boolean {
+  return (
+    typeof details === "object" && details !== null && "_formVersion" in details
+  );
+}
+
 export function getApplicationAsDynamic(
   details: unknown,
   roundFormSchema: FormSchema | null | undefined,
@@ -152,13 +159,18 @@ export function getApplicationAsDynamic(
   roundValues: Record<string, unknown>;
   attestationValues: Record<string, unknown>;
 } {
-  const schema = roundFormSchema ?? GOODBUILDERS_TEMPLATE;
+  const isDynamic = !!roundFormSchema || isDynamicApplicationDetails(details);
+  const schema =
+    roundFormSchema ??
+    (isDynamicApplicationDetails(details)
+      ? MINIMAL_TEMPLATE
+      : GOODBUILDERS_TEMPLATE);
 
   if (!details) {
     return { schema, roundValues: {}, attestationValues: {} };
   }
 
-  if (roundFormSchema) {
+  if (isDynamic) {
     const d = details as DetailsShape;
     return {
       schema,

--- a/src/app/flow-councils/utils/legacyFormAdapter.ts
+++ b/src/app/flow-councils/utils/legacyFormAdapter.ts
@@ -159,12 +159,11 @@ export function getApplicationAsDynamic(
   roundValues: Record<string, unknown>;
   attestationValues: Record<string, unknown>;
 } {
-  const isDynamic = !!roundFormSchema || isDynamicApplicationDetails(details);
+  const detailsAreDynamic = isDynamicApplicationDetails(details);
+  const isDynamic = !!roundFormSchema || detailsAreDynamic;
   const schema =
     roundFormSchema ??
-    (isDynamicApplicationDetails(details)
-      ? MINIMAL_TEMPLATE
-      : GOODBUILDERS_TEMPLATE);
+    (detailsAreDynamic ? MINIMAL_TEMPLATE : GOODBUILDERS_TEMPLATE);
 
   if (!details) {
     return { schema, roundValues: {}, attestationValues: {} };


### PR DESCRIPTION
## What

When a round has no configured form (no template selected or created in the form builder), the applicant application now defaults to the **Minimal** template instead of the legacy GoodBuilders form.

## Why

GoodBuilders is a program-specific form, so falling back to it for any unconfigured round is a poor default. Minimal is a short, generic form that suits an arbitrary new council.

## Changes

- **`application.tsx`**: the applicant form defaults to the Minimal template when the round has no `formSchema`. Already-submitted legacy applications are preserved (detected via the absence of the `_formVersion` marker), so they still render and edit against their original GoodBuilders fields.
- **`legacyFormAdapter.ts`**: new `isDynamicApplicationDetails()` helper. `getApplicationAsDynamic()` now returns the Minimal schema for dynamic (`_formVersion`) submissions and keeps GoodBuilders for legacy ones, so the admin review detail view renders the new Minimal submissions correctly.
- **`review.tsx`**: the CSV export computes an effective schema, so unconfigured rounds that collected Minimal submissions export the Minimal questions and answers, while legacy-only rounds keep the legacy column layout.

## Behavior

- Round with a configured schema: uses that schema (unchanged).
- Round without a schema, new or dynamic submission: Minimal.
- Round without a schema, existing legacy submission: legacy GoodBuilders (unchanged).

## Testing

`pnpm typecheck` and `pnpm lint` both pass.
