### PR TITLE
feat: allow moving accepted grantees back to review

### DIFF
--- a/src/app/api/flow-council/review/route.ts
+++ b/src/app/api/flow-council/review/route.ts
@@ -13,6 +13,7 @@ import {
 import { writeInboxItems } from "@/lib/inboxWriter";
 import { errorResponse } from "../../utils";
 import { RECIPIENT_MANAGER_ROLE } from "@/app/flow-councils/lib/constants";
+import { getAllowedStatusTransitions } from "@/app/flow-councils/lib/statusTransitions";
 import { findRoundByCouncil } from "../auth";
 
 export const dynamic = "force-dynamic";
@@ -85,10 +86,10 @@ export async function POST(request: Request) {
       );
     }
 
-    // Get the application to get project ID
+    // Get the application to get project ID and current status
     const application = await db
       .selectFrom("applications")
-      .select(["id", "projectId"])
+      .select(["id", "projectId", "status"])
       .where("id", "=", applicationId)
       .where("roundId", "=", round.id)
       .executeTakeFirst();
@@ -96,6 +97,16 @@ export async function POST(request: Request) {
     if (!application) {
       return new Response(
         JSON.stringify({ success: false, error: "Application not found" }),
+      );
+    }
+
+    if (
+      !getAllowedStatusTransitions(application.status).includes(
+        newStatus as ApplicationStatus,
+      )
+    ) {
+      return new Response(
+        JSON.stringify({ success: false, error: "Invalid status transition" }),
       );
     }
 

--- a/src/app/flow-councils/lib/statusTransitions.test.ts
+++ b/src/app/flow-councils/lib/statusTransitions.test.ts
@@ -19,6 +19,11 @@ describe("getAllowedStatusTransitions", () => {
   });
 
   it("offers accept/changes/reject for not-yet-accepted statuses, excluding the current one", () => {
+    expect(getAllowedStatusTransitions("INCOMPLETE")).toEqual([
+      "ACCEPTED",
+      "CHANGES_REQUESTED",
+      "REJECTED",
+    ]);
     expect(getAllowedStatusTransitions("SUBMITTED")).toEqual([
       "ACCEPTED",
       "CHANGES_REQUESTED",
@@ -27,6 +32,10 @@ describe("getAllowedStatusTransitions", () => {
     expect(getAllowedStatusTransitions("CHANGES_REQUESTED")).toEqual([
       "ACCEPTED",
       "REJECTED",
+    ]);
+    expect(getAllowedStatusTransitions("REJECTED")).toEqual([
+      "ACCEPTED",
+      "CHANGES_REQUESTED",
     ]);
   });
 

--- a/src/app/flow-councils/lib/statusTransitions.test.ts
+++ b/src/app/flow-councils/lib/statusTransitions.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { getAllowedStatusTransitions } from "./statusTransitions";
+
+describe("getAllowedStatusTransitions", () => {
+  it("lets an accepted grantee move back to review, removed, or graduated", () => {
+    expect(getAllowedStatusTransitions("ACCEPTED")).toEqual([
+      "SUBMITTED",
+      "REMOVED",
+      "GRADUATED",
+    ]);
+  });
+
+  it("lets removed and graduated grantees be re-accepted", () => {
+    expect(getAllowedStatusTransitions("REMOVED")).toEqual(["ACCEPTED"]);
+    expect(getAllowedStatusTransitions("GRADUATED")).toEqual([
+      "ACCEPTED",
+      "REMOVED",
+    ]);
+  });
+
+  it("offers accept/changes/reject for not-yet-accepted statuses, excluding the current one", () => {
+    expect(getAllowedStatusTransitions("SUBMITTED")).toEqual([
+      "ACCEPTED",
+      "CHANGES_REQUESTED",
+      "REJECTED",
+    ]);
+    expect(getAllowedStatusTransitions("CHANGES_REQUESTED")).toEqual([
+      "ACCEPTED",
+      "REJECTED",
+    ]);
+  });
+
+  it("never allows a no-op transition to the same status", () => {
+    for (const status of [
+      "INCOMPLETE",
+      "SUBMITTED",
+      "ACCEPTED",
+      "CHANGES_REQUESTED",
+      "REJECTED",
+      "REMOVED",
+      "GRADUATED",
+    ] as const) {
+      expect(getAllowedStatusTransitions(status)).not.toContain(status);
+    }
+  });
+});

--- a/src/app/flow-councils/lib/statusTransitions.ts
+++ b/src/app/flow-councils/lib/statusTransitions.ts
@@ -13,6 +13,8 @@ export function getAllowedStatusTransitions(
       return ["ACCEPTED"];
     case "GRADUATED":
       return ["ACCEPTED", "REMOVED"];
+    // Pre-acceptance statuses (INCOMPLETE, SUBMITTED, CHANGES_REQUESTED,
+    // REJECTED) can be accepted, asked for changes, or rejected.
     default:
       return (
         ["ACCEPTED", "CHANGES_REQUESTED", "REJECTED"] as ApplicationStatus[]

--- a/src/app/flow-councils/lib/statusTransitions.ts
+++ b/src/app/flow-councils/lib/statusTransitions.ts
@@ -1,0 +1,21 @@
+import { ApplicationStatus } from "@/generated/kysely";
+
+// Status changes a recipient manager may apply from the review UI, keyed by
+// current status. Shared by the client dropdown and the server route so the
+// allowed set cannot drift between them.
+export function getAllowedStatusTransitions(
+  currentStatus: ApplicationStatus,
+): ApplicationStatus[] {
+  switch (currentStatus) {
+    case "ACCEPTED":
+      return ["SUBMITTED", "REMOVED", "GRADUATED"];
+    case "REMOVED":
+      return ["ACCEPTED"];
+    case "GRADUATED":
+      return ["ACCEPTED", "REMOVED"];
+    default:
+      return (
+        ["ACCEPTED", "CHANGES_REQUESTED", "REJECTED"] as ApplicationStatus[]
+      ).filter((status) => status !== currentStatus);
+  }
+}

--- a/src/app/flow-councils/review/review.tsx
+++ b/src/app/flow-councils/review/review.tsx
@@ -51,6 +51,7 @@ import type {
 } from "@/app/flow-councils/types/round";
 import type { FormSchema } from "@/app/flow-councils/types/formSchema";
 import { getApplicationAsDynamic } from "@/app/flow-councils/utils/legacyFormAdapter";
+import { getAllowedStatusTransitions } from "@/app/flow-councils/lib/statusTransitions";
 import { ProjectDetails } from "@/types/project";
 
 type ReviewProps = {
@@ -501,27 +502,7 @@ export default function Review(props: ReviewProps) {
   // Get available statuses based on current status
   const availableStatuses = useMemo(() => {
     if (!selectedApplication) return [];
-    const currentStatus = selectedApplication.status;
-
-    // If accepted, can be moved back to review, removed, or graduated
-    if (currentStatus === "ACCEPTED") {
-      return ["SUBMITTED", "REMOVED", "GRADUATED"] as Status[];
-    }
-
-    // If removed, can only be re-accepted
-    if (currentStatus === "REMOVED") {
-      return ["ACCEPTED"] as Status[];
-    }
-
-    // If graduated, can be re-accepted or removed
-    if (currentStatus === "GRADUATED") {
-      return ["ACCEPTED", "REMOVED"] as Status[];
-    }
-
-    // If not yet accepted, can accept, request changes, or reject
-    return (["ACCEPTED", "CHANGES_REQUESTED", "REJECTED"] as Status[]).filter(
-      (s) => s !== currentStatus,
-    );
+    return getAllowedStatusTransitions(selectedApplication.status);
   }, [selectedApplication]);
 
   const handleSelectApplication = async (summary: ApplicationSummary) => {

--- a/src/app/flow-councils/review/review.tsx
+++ b/src/app/flow-councils/review/review.tsx
@@ -503,9 +503,9 @@ export default function Review(props: ReviewProps) {
     if (!selectedApplication) return [];
     const currentStatus = selectedApplication.status;
 
-    // If accepted, can be removed or graduated
+    // If accepted, can be moved back to review, removed, or graduated
     if (currentStatus === "ACCEPTED") {
-      return ["REMOVED", "GRADUATED"] as Status[];
+      return ["SUBMITTED", "REMOVED", "GRADUATED"] as Status[];
     }
 
     // If removed, can only be re-accepted
@@ -820,13 +820,12 @@ export default function Review(props: ReviewProps) {
       // Check if on-chain transaction is needed
       // Only need on-chain tx when actually changing on-chain state:
       // - Adding: ACCEPTED (and not already on-chain)
-      // - Removing: REMOVED/GRADUATED from ACCEPTED state
+      // - Removing: leaving ACCEPTED for any non-accepted status
       const currentStatus = selectedApplication.status;
       const isAddingOnChain =
         newStatus === "ACCEPTED" && currentStatus !== "ACCEPTED";
       const isRemovingOnChain =
-        (newStatus === "REMOVED" || newStatus === "GRADUATED") &&
-        currentStatus === "ACCEPTED";
+        currentStatus === "ACCEPTED" && newStatus !== "ACCEPTED";
 
       if (isAddingOnChain || isRemovingOnChain) {
         const recipientStatus = isAddingOnChain ? 0 : 1; // 0 = ADDED, 1 = REMOVED


### PR DESCRIPTION
Adds the ability to move an accepted grantee directly back into the review queue after an accidental acceptance.

## Approach
Reuses the existing `SUBMITTED` status (the "awaiting a decision" state) rather than introducing a new `UNDER_REVIEW` enum value. This avoids a DB migration and avoids touching the many status switch-sites (labels, badges, filters, apply/unlock rules) where partial coverage would risk bugs. The status appears as **"Submitted"** in the UI.

## Changes (`src/app/flow-councils/review/review.tsx`)
- `ACCEPTED` applications can now transition to **Submitted**, in addition to Removed/Graduated.
- Generalized the on-chain trigger: leaving `ACCEPTED` for **any** non-accepted status now fires the GDA removal transaction (`updateRecipients` with status `1`), instead of only Removed/Graduated.

## Works for free
The `/api/flow-council/review` route is status-agnostic, so this automatically: updates the DB, posts the automated status-change message in the project channel, emails project managers, and writes inbox items. Recipient-counting hooks correctly stop treating a re-opened application as an active recipient.

## Verification
`pnpm typecheck` and `pnpm lint` both pass.