### PR TITLE
Autosave application, comment, and comms inputs to local storage

### DIFF
--- a/src/app/flow-councils/application/[chainId]/[councilId]/[projectId]/application.tsx
+++ b/src/app/flow-councils/application/[chainId]/[councilId]/[projectId]/application.tsx
@@ -30,6 +30,7 @@ import {
   isDynamicApplicationDetails,
 } from "@/app/flow-councils/utils/legacyFormAdapter";
 import { generateApplicationTemplate } from "@/app/flow-councils/lib/generateApplicationTemplate";
+import { generateDraftId } from "@/app/flow-councils/utils/draftId";
 import { networks } from "@/lib/networks";
 import { Project } from "@/types/project";
 import useRequireAuth from "@/hooks/requireAuth";
@@ -43,8 +44,19 @@ type ApplicationDraft = {
   fundingAddress: string;
 };
 
-function generateDraftId() {
-  return `draft_${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+// Order-insensitive serialization for comparing a restored draft against the
+// server baseline: the two objects can carry the same field values in different
+// key orders, which a plain JSON.stringify would report as a difference.
+function stableStringify(value: unknown): string {
+  return JSON.stringify(value, (_key, val) =>
+    val && typeof val === "object" && !Array.isArray(val)
+      ? Object.fromEntries(
+          Object.keys(val as Record<string, unknown>)
+            .sort()
+            .map((k) => [k, (val as Record<string, unknown>)[k]]),
+        )
+      : val,
+  );
 }
 
 function FormSkeleton() {
@@ -347,9 +359,9 @@ export default function Application(props: ApplicationProps) {
 
       const baseline = serverBaselineRef.current;
       const differsFromServer =
-        JSON.stringify(round) !== JSON.stringify(baseline.round ?? {}) ||
-        JSON.stringify(attestation) !==
-          JSON.stringify(baseline.attestation ?? {}) ||
+        stableStringify(round) !== stableStringify(baseline.round ?? {}) ||
+        stableStringify(attestation) !==
+          stableStringify(baseline.attestation ?? {}) ||
         fundingAddress !== (baseline.fundingAddress ?? "");
       setDraftRestored(differsFromServer);
     },

--- a/src/app/flow-councils/application/[chainId]/[councilId]/[projectId]/application.tsx
+++ b/src/app/flow-councils/application/[chainId]/[councilId]/[projectId]/application.tsx
@@ -218,8 +218,9 @@ export default function Application(props: ApplicationProps) {
       );
       const data = await res.json();
       if (!data.success || !data.round?.details) return null;
-      const { name, formSchema: configuredSchema } =
-        parseRoundDetails(data.round);
+      const { name, formSchema: configuredSchema } = parseRoundDetails(
+        data.round,
+      );
       setRoundName(name);
       setFormSchema(configuredSchema ?? MINIMAL_TEMPLATE);
       // Return the raw configured schema (may be null), not the Minimal
@@ -343,30 +344,28 @@ export default function Application(props: ApplicationProps) {
     const storedDraft = draft.readDraft();
     if (!storedDraft) return;
 
-      const round = storedDraft.round ?? {};
-      const attestation = storedDraft.attestation ?? {};
-      const fundingAddress = storedDraft.fundingAddress ?? "";
+    const round = storedDraft.round ?? {};
+    const attestation = storedDraft.attestation ?? {};
+    const fundingAddress = storedDraft.fundingAddress ?? "";
 
-      if (Object.keys(round).length > 0) {
-        setDynamicRoundValues((prev) => ({ ...prev, ...round }));
-      }
-      if (Object.keys(attestation).length > 0) {
-        setDynamicAttestationValues((prev) => ({ ...prev, ...attestation }));
-      }
-      if (fundingAddress) {
-        setDynamicFundingAddress(fundingAddress);
-      }
+    if (Object.keys(round).length > 0) {
+      setDynamicRoundValues((prev) => ({ ...prev, ...round }));
+    }
+    if (Object.keys(attestation).length > 0) {
+      setDynamicAttestationValues((prev) => ({ ...prev, ...attestation }));
+    }
+    if (fundingAddress) {
+      setDynamicFundingAddress(fundingAddress);
+    }
 
-      const baseline = serverBaselineRef.current;
-      const differsFromServer =
-        stableStringify(round) !== stableStringify(baseline.round ?? {}) ||
-        stableStringify(attestation) !==
-          stableStringify(baseline.attestation ?? {}) ||
-        fundingAddress !== (baseline.fundingAddress ?? "");
-      setDraftRestored(differsFromServer);
-    },
-    [draft],
-  );
+    const baseline = serverBaselineRef.current;
+    const differsFromServer =
+      stableStringify(round) !== stableStringify(baseline.round ?? {}) ||
+      stableStringify(attestation) !==
+        stableStringify(baseline.attestation ?? {}) ||
+      fundingAddress !== (baseline.fundingAddress ?? "");
+    setDraftRestored(differsFromServer);
+  }, [draft]);
 
   useEffect(() => {
     if (urlId === "new") {

--- a/src/app/flow-councils/application/[chainId]/[councilId]/[projectId]/application.tsx
+++ b/src/app/flow-councils/application/[chainId]/[councilId]/[projectId]/application.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { useAccount } from "wagmi";
 import Link from "next/link";
@@ -27,6 +27,19 @@ import { generateApplicationTemplate } from "@/app/flow-councils/lib/generateApp
 import { networks } from "@/lib/networks";
 import { Project } from "@/types/project";
 import useRequireAuth from "@/hooks/requireAuth";
+import { useLocalDraft } from "@/hooks/useLocalDraft";
+
+type ApplicationDraft = {
+  savedProjectId?: number | null;
+  applicationId?: number | null;
+  round: Record<string, unknown>;
+  attestation: Record<string, unknown>;
+  fundingAddress: string;
+};
+
+function generateDraftId() {
+  return `draft_${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+}
 
 function FormSkeleton() {
   return (
@@ -118,6 +131,9 @@ export default function Application(props: ApplicationProps) {
   const { address } = useAccount();
   const { hasSession, requireAuth } = useRequireAuth();
 
+  const urlId = projectId && projectId.length > 0 ? projectId : "new";
+  const isExistingApplication = /^\d+$/.test(urlId);
+
   const [activeTab, setActiveTab] = useState("project");
   const [project, setProject] = useState<Project | null>(null);
   const [roundData, setRoundData] = useState<RoundForm | null>(null);
@@ -129,7 +145,7 @@ export default function Application(props: ApplicationProps) {
   );
   const [savedProjectId, setSavedProjectId] = useState<number | null>(null);
   const [editsUnlocked, setEditsUnlocked] = useState(false);
-  const [isLoading, setIsLoading] = useState(!!projectId);
+  const [isLoading, setIsLoading] = useState(isExistingApplication);
 
   const [formSchema, setFormSchema] = useState<FormSchema | null>(null);
   const [dynamicRoundValues, setDynamicRoundValues] = useState<
@@ -143,6 +159,17 @@ export default function Application(props: ApplicationProps) {
   const [dynamicSaving, setDynamicSaving] = useState(false);
   const [dynamicError, setDynamicError] = useState("");
 
+  const draft = useLocalDraft<ApplicationDraft>(
+    `application:${chainId}:${councilId}:${urlId}`,
+  );
+  const userEditedRef = useRef(false);
+  const serverBaselineRef = useRef<ApplicationDraft>({
+    round: {},
+    attestation: {},
+    fundingAddress: "",
+  });
+  const [draftRestored, setDraftRestored] = useState(false);
+
   const [roundName, setRoundName] = useState<string>("");
 
   const [profileData, setProfileData] = useState<{
@@ -154,6 +181,11 @@ export default function Application(props: ApplicationProps) {
   const projectComplete = !!project;
   const roundComplete = !!applicationId;
   const isDynamicFormApp = formSchema != null;
+
+  const isNewDraft = !isExistingApplication && savedProjectId == null;
+  const projectDraftKey = isNewDraft
+    ? `application:${chainId}:${councilId}:${urlId}:project`
+    : undefined;
 
   const isInLockedStatus =
     applicationStatus !== null && LOCKED_STATUSES.includes(applicationStatus);
@@ -197,36 +229,39 @@ export default function Application(props: ApplicationProps) {
     }
   }, [address]);
 
-  const fetchProject = useCallback(async () => {
-    if (!projectId || !address) return;
+  const fetchProject = useCallback(
+    async (realProjectId: number) => {
+      if (!address) return;
 
-    try {
-      const res = await fetch(
-        `/api/flow-council/projects/${projectId}?managerAddress=${address}`,
-      );
-      const data = await res.json();
+      try {
+        const res = await fetch(
+          `/api/flow-council/projects/${realProjectId}?managerAddress=${address}`,
+        );
+        const data = await res.json();
 
-      if (data.success && data.project) {
-        const details =
-          typeof data.project.details === "string"
-            ? JSON.parse(data.project.details)
-            : data.project.details;
+        if (data.success && data.project) {
+          const details =
+            typeof data.project.details === "string"
+              ? JSON.parse(data.project.details)
+              : data.project.details;
 
-        setProject({
-          id: data.project.id,
-          details,
-          managerAddresses: data.project.managerAddresses ?? [],
-          managerEmails: data.project.managerEmails ?? [],
-        });
+          setProject({
+            id: data.project.id,
+            details,
+            managerAddresses: data.project.managerAddresses ?? [],
+            managerEmails: data.project.managerEmails ?? [],
+          });
+        }
+      } catch (err) {
+        console.error("Failed to fetch project:", err);
       }
-    } catch (err) {
-      console.error("Failed to fetch project:", err);
-    }
-  }, [projectId, address]);
+    },
+    [address],
+  );
 
   const fetchApplication = useCallback(
-    async (schema: FormSchema | null) => {
-      if (!projectId || !address) return;
+    async (realProjectId: number, schema: FormSchema | null) => {
+      if (!address) return;
 
       try {
         const res = await fetch("/api/flow-council/applications", {
@@ -237,7 +272,7 @@ export default function Application(props: ApplicationProps) {
 
         if (!data.success || !data.applications) return;
         const app = data.applications.find(
-          (a: { projectId: number }) => a.projectId === parseInt(projectId, 10),
+          (a: { projectId: number }) => a.projectId === realProjectId,
         );
         if (!app) return;
 
@@ -252,12 +287,16 @@ export default function Application(props: ApplicationProps) {
             : app.details;
 
         if (schema) {
-          setDynamicRoundValues(
-            (details.round as Record<string, unknown>) ?? {},
-          );
-          setDynamicAttestationValues(
-            (details.attestation as Record<string, unknown>) ?? {},
-          );
+          const round = (details.round as Record<string, unknown>) ?? {};
+          const attestation =
+            (details.attestation as Record<string, unknown>) ?? {};
+          serverBaselineRef.current = {
+            round,
+            attestation,
+            fundingAddress: app.fundingAddress ?? "",
+          };
+          setDynamicRoundValues(round);
+          setDynamicAttestationValues(attestation);
           if (app.fundingAddress) {
             setDynamicFundingAddress(app.fundingAddress);
           }
@@ -272,46 +311,151 @@ export default function Application(props: ApplicationProps) {
         console.error("Failed to fetch application:", err);
       }
     },
-    [projectId, address, chainId, councilId],
+    [address, chainId, councilId],
+  );
+
+  const restoreDraft = useCallback(
+    (schema: FormSchema | null) => {
+      if (!schema) return;
+      const storedDraft = draft.readDraft();
+      if (!storedDraft) return;
+
+      const round = storedDraft.round ?? {};
+      const attestation = storedDraft.attestation ?? {};
+      const fundingAddress = storedDraft.fundingAddress ?? "";
+
+      if (Object.keys(round).length > 0) {
+        setDynamicRoundValues((prev) => ({ ...prev, ...round }));
+      }
+      if (Object.keys(attestation).length > 0) {
+        setDynamicAttestationValues((prev) => ({ ...prev, ...attestation }));
+      }
+      if (fundingAddress) {
+        setDynamicFundingAddress(fundingAddress);
+      }
+
+      const baseline = serverBaselineRef.current;
+      const differsFromServer =
+        JSON.stringify(round) !== JSON.stringify(baseline.round ?? {}) ||
+        JSON.stringify(attestation) !==
+          JSON.stringify(baseline.attestation ?? {}) ||
+        fundingAddress !== (baseline.fundingAddress ?? "");
+      setDraftRestored(differsFromServer);
+    },
+    [draft],
   );
 
   useEffect(() => {
-    if (projectId && address) {
+    if (urlId === "new") {
+      router.replace(
+        `/flow-councils/application/${chainId}/${councilId}/${generateDraftId()}`,
+      );
+    }
+  }, [urlId, chainId, councilId, router]);
+
+  useEffect(() => {
+    if (urlId === "new") return;
+
+    let cancelled = false;
+    const appDraft = draft.readDraft();
+    const realProjectId = isExistingApplication
+      ? Number(urlId)
+      : (appDraft?.savedProjectId ?? null);
+
+    if (realProjectId != null && address) {
       setIsLoading(true);
       (async () => {
         const schema = await fetchRound();
         await Promise.all([
           fetchProfile(),
-          fetchProject(),
-          fetchApplication(schema),
+          fetchProject(realProjectId),
+          fetchApplication(realProjectId, schema),
         ]);
+        if (cancelled) return;
+        setSavedProjectId(realProjectId);
+        if (appDraft?.applicationId != null) {
+          setApplicationId((prev) => prev ?? appDraft.applicationId ?? null);
+        }
+        restoreDraft(schema);
         setIsLoading(false);
       })();
     } else {
-      fetchRound();
-      fetchProfile();
+      (async () => {
+        const schema = await fetchRound();
+        fetchProfile();
+        if (cancelled) return;
+        restoreDraft(schema);
+      })();
     }
+
+    return () => {
+      cancelled = true;
+    };
   }, [
+    urlId,
+    isExistingApplication,
+    address,
+    draft,
     fetchRound,
     fetchProfile,
     fetchProject,
     fetchApplication,
-    projectId,
-    address,
+    restoreDraft,
+  ]);
+
+  useEffect(() => {
+    if (!isDynamicFormApp) return;
+    const shouldPersist =
+      userEditedRef.current ||
+      (!isExistingApplication && savedProjectId != null);
+    if (!shouldPersist) return;
+    draft.save({
+      savedProjectId,
+      applicationId,
+      round: dynamicRoundValues,
+      attestation: dynamicAttestationValues,
+      fundingAddress: dynamicFundingAddress,
+    });
+  }, [
+    savedProjectId,
+    applicationId,
+    dynamicRoundValues,
+    dynamicAttestationValues,
+    dynamicFundingAddress,
+    isExistingApplication,
+    isDynamicFormApp,
+    draft,
   ]);
 
   const showNudge = !profileData.displayName || !profileData.email;
 
   const handleDynamicRoundChange = useCallback((id: string, value: unknown) => {
+    userEditedRef.current = true;
     setDynamicRoundValues((prev) => ({ ...prev, [id]: value }));
   }, []);
 
   const handleDynamicAttestationChange = useCallback(
     (id: string, value: unknown) => {
+      userEditedRef.current = true;
       setDynamicAttestationValues((prev) => ({ ...prev, [id]: value }));
     },
     [],
   );
+
+  const handleDynamicFundingAddressChange = useCallback((value: string) => {
+    userEditedRef.current = true;
+    setDynamicFundingAddress(value);
+  }, []);
+
+  const handleDiscardDraft = useCallback(() => {
+    draft.clear();
+    const baseline = serverBaselineRef.current;
+    setDynamicRoundValues(baseline.round);
+    setDynamicAttestationValues(baseline.attestation);
+    setDynamicFundingAddress(baseline.fundingAddress);
+    userEditedRef.current = false;
+    setDraftRestored(false);
+  }, [draft]);
 
   const handleBack = () => {
     router.push(`/flow-councils/application/${chainId}/${councilId}`);
@@ -365,6 +509,12 @@ export default function Application(props: ApplicationProps) {
       if (json.application?.id) {
         setApplicationId(json.application.id);
       }
+      serverBaselineRef.current = {
+        round: dynamicRoundValues,
+        attestation: dynamicAttestationValues,
+        fundingAddress: dynamicFundingAddress,
+      };
+      setDraftRestored(false);
       setDynamicSaving(false);
       setActiveTab("eligibility");
       window.scrollTo(0, 0);
@@ -406,6 +556,8 @@ export default function Application(props: ApplicationProps) {
         return;
       }
 
+      draft.clear();
+      setDraftRestored(false);
       setDynamicSaving(false);
       router.push(`/flow-councils/application/${chainId}/${councilId}`);
     } catch (err) {
@@ -426,7 +578,7 @@ export default function Application(props: ApplicationProps) {
     return <span className="m-auto fs-4 fw-bold">Invalid council</span>;
   }
 
-  if (isLoading) {
+  if (isLoading || urlId === "new") {
     return (
       <Stack direction="vertical">
         <Nav className="gap-2 mb-4 border-0">
@@ -509,6 +661,20 @@ export default function Application(props: ApplicationProps) {
           </div>
         )}
 
+        {draftRestored &&
+          (activeTab === "round" || activeTab === "eligibility") && (
+            <div className="d-flex align-items-center gap-2 mb-3 small text-muted">
+              <span>Unsaved changes restored.</span>
+              <Button
+                variant="link"
+                className="p-0 small text-decoration-underline"
+                onClick={handleDiscardDraft}
+              >
+                Discard
+              </Button>
+            </div>
+          )}
+
         <Tab.Content>
           <Tab.Pane eventKey="project">
             <ProjectTab
@@ -516,6 +682,7 @@ export default function Application(props: ApplicationProps) {
               isLoading={isLoading}
               onSave={handleProjectSaved}
               onCancel={handleBack}
+              draftKey={projectDraftKey}
             />
           </Tab.Pane>
           <Tab.Pane eventKey="round">
@@ -524,7 +691,7 @@ export default function Application(props: ApplicationProps) {
                 <>
                   <FundingAddressSection
                     value={dynamicFundingAddress}
-                    onChange={setDynamicFundingAddress}
+                    onChange={handleDynamicFundingAddressChange}
                     defaultFundingAddress={
                       project?.details?.defaultFundingAddress || ""
                     }

--- a/src/app/flow-councils/application/[chainId]/[councilId]/[projectId]/layout.tsx
+++ b/src/app/flow-councils/application/[chainId]/[councilId]/[projectId]/layout.tsx
@@ -93,7 +93,8 @@ export default function ApplicationLayout({
   }, [projectId, session?.address]);
 
   const fetchApplicationStatus = useCallback(async () => {
-    if (!chainId || !councilId || !projectId || !/^\d+$/.test(projectId)) return;
+    if (!chainId || !councilId || !projectId || !/^\d+$/.test(projectId))
+      return;
 
     try {
       const res = await fetch("/api/flow-council/applications", {

--- a/src/app/flow-councils/application/[chainId]/[councilId]/[projectId]/layout.tsx
+++ b/src/app/flow-councils/application/[chainId]/[councilId]/[projectId]/layout.tsx
@@ -73,7 +73,7 @@ export default function ApplicationLayout({
   }, [chainId, councilId]);
 
   const fetchProjectInfo = useCallback(async () => {
-    if (!projectId || projectId === "new" || !session?.address) return;
+    if (!projectId || !/^\d+$/.test(projectId) || !session?.address) return;
 
     try {
       const res = await fetch(
@@ -93,7 +93,7 @@ export default function ApplicationLayout({
   }, [projectId, session?.address]);
 
   const fetchApplicationStatus = useCallback(async () => {
-    if (!chainId || !councilId || !projectId || projectId === "new") return;
+    if (!chainId || !councilId || !projectId || !/^\d+$/.test(projectId)) return;
 
     try {
       const res = await fetch("/api/flow-council/applications", {

--- a/src/app/flow-councils/application/[chainId]/[councilId]/[projectId]/page.tsx
+++ b/src/app/flow-councils/application/[chainId]/[councilId]/[projectId]/page.tsx
@@ -11,7 +11,7 @@ export default async function Page({
     <Application
       chainId={Number(chainId)}
       councilId={councilId}
-      projectId={projectId === "new" ? undefined : projectId}
+      projectId={projectId}
     />
   );
 }

--- a/src/app/flow-councils/application/[chainId]/[councilId]/project-selection.tsx
+++ b/src/app/flow-councils/application/[chainId]/[councilId]/project-selection.tsx
@@ -14,6 +14,7 @@ import Image from "react-bootstrap/Image";
 import ProjectCard from "@/app/flow-councils/components/ProjectCard";
 import type { FormSchema } from "@/app/flow-councils/types/formSchema";
 import { generateApplicationTemplate } from "@/app/flow-councils/lib/generateApplicationTemplate";
+import { generateDraftId } from "@/app/flow-councils/utils/draftId";
 import InfoTooltip from "@/components/InfoTooltip";
 import { useMediaQuery } from "@/hooks/mediaQuery";
 import { networks } from "@/lib/networks";
@@ -528,9 +529,8 @@ export default function ProjectSelection(props: ProjectSelectionProps) {
                     className="d-flex flex-col justify-content-center align-items-center border-2 border-secondary rounded-4 fs-6 cursor-pointer"
                     style={{ height: 430 }}
                     onClick={() => {
-                      const draftId = `draft_${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
                       router.push(
-                        `/flow-councils/application/${chainId}/${councilId}/${draftId}`,
+                        `/flow-councils/application/${chainId}/${councilId}/${generateDraftId()}`,
                       );
                     }}
                   >

--- a/src/app/flow-councils/application/[chainId]/[councilId]/project-selection.tsx
+++ b/src/app/flow-councils/application/[chainId]/[councilId]/project-selection.tsx
@@ -528,8 +528,9 @@ export default function ProjectSelection(props: ProjectSelectionProps) {
                     className="d-flex flex-col justify-content-center align-items-center border-2 border-secondary rounded-4 fs-6 cursor-pointer"
                     style={{ height: 430 }}
                     onClick={() => {
+                      const draftId = `draft_${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
                       router.push(
-                        `/flow-councils/application/${chainId}/${councilId}/new`,
+                        `/flow-councils/application/${chainId}/${councilId}/${draftId}`,
                       );
                     }}
                   >

--- a/src/app/flow-councils/components/ChatView.tsx
+++ b/src/app/flow-councils/components/ChatView.tsx
@@ -281,6 +281,18 @@ export default function ChatView(props: ChatViewProps) {
     );
   }
 
+  const draftKey = [
+    "msg",
+    channelType,
+    chainId,
+    councilId,
+    roundId,
+    applicationId,
+    projectId,
+  ]
+    .filter((part) => part !== undefined && part !== null)
+    .join(":");
+
   const messageInput = canWrite && (
     <MessageInput
       onSend={handleSendMessage}
@@ -292,6 +304,7 @@ export default function ChatView(props: ChatViewProps) {
           : "Sign in to send messages"
       }
       onAuthRequired={onAuthRequired}
+      draftKey={draftKey}
     />
   );
 

--- a/src/app/flow-councils/components/ProjectTab.tsx
+++ b/src/app/flow-councils/components/ProjectTab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useMemo } from "react";
 import { isAddress } from "viem";
 import { useAccount } from "wagmi";
 import { useConnectModal } from "@rainbow-me/rainbowkit";
@@ -20,6 +20,7 @@ import useSiwe from "@/hooks/siwe";
 import MarkdownEditor from "@/components/MarkdownEditor";
 import { normalizeUrl } from "@/app/flow-councils/utils/normalizeUrl";
 import { Project } from "@/types/project";
+import { useLocalDraft } from "@/hooks/useLocalDraft";
 
 async function uploadToS3(file: Blob, fileName: string): Promise<string> {
   const presignRes = await fetch("/api/flow-council/images", {
@@ -57,6 +58,7 @@ type ProjectTabProps = {
   isLoading: boolean;
   onSave: (project: Project) => void;
   onCancel: () => void;
+  draftKey?: string;
 };
 
 type ProjectForm = {
@@ -77,6 +79,32 @@ type ProjectForm = {
   otherLinks: OtherLink[];
 };
 
+type ProjectDraft = {
+  form: ProjectForm;
+  existingLogoUrl: string;
+  existingBannerUrl: string;
+};
+
+const DEFAULT_PROJECT_FORM: ProjectForm = {
+  name: "",
+  managerAddresses: [""],
+  defaultFundingAddress: "",
+  description: "",
+  website: "",
+  demoUrl: "",
+  twitter: "",
+  farcaster: "",
+  telegram: "",
+  discord: "",
+  karmaProfile: "",
+  gardensPool: "",
+  githubRepos: [""],
+  smartContracts: [
+    { type: "projectAddress", network: "Arbitrum One", address: "" },
+  ],
+  otherLinks: [{ description: "", url: "" }],
+};
+
 const isValidGithubRepo = (url: string): boolean => {
   if (!url) return true;
   const normalized = url.replace(/\/+$/, "");
@@ -87,32 +115,23 @@ const isValidGithubRepo = (url: string): boolean => {
 };
 
 export default function ProjectTab(props: ProjectTabProps) {
-  const { project, isLoading, onSave, onCancel } = props;
+  const { project, isLoading, onSave, onCancel, draftKey } = props;
 
-  const [form, setForm] = useState<ProjectForm>({
-    name: "",
-    managerAddresses: [""],
-    defaultFundingAddress: "",
-    description: "",
-    website: "",
-    demoUrl: "",
-    twitter: "",
-    farcaster: "",
-    telegram: "",
-    discord: "",
-    karmaProfile: "",
-    gardensPool: "",
-    githubRepos: [""],
-    smartContracts: [
-      { type: "projectAddress", network: "Arbitrum One", address: "" },
-    ],
-    otherLinks: [{ description: "", url: "" }],
-  });
+  const projectDraft = useLocalDraft<ProjectDraft>(draftKey ?? null);
+  const seededDraft = useMemo(() => projectDraft.readDraft(), [projectDraft]);
+
+  const [form, setForm] = useState<ProjectForm>(
+    () => seededDraft?.form ?? DEFAULT_PROJECT_FORM,
+  );
 
   const [logoBlob, setLogoBlob] = useState<Blob | null>(null);
   const [bannerBlob, setBannerBlob] = useState<Blob | null>(null);
-  const [existingLogoUrl, setExistingLogoUrl] = useState("");
-  const [existingBannerUrl, setExistingBannerUrl] = useState("");
+  const [existingLogoUrl, setExistingLogoUrl] = useState(
+    seededDraft?.existingLogoUrl ?? "",
+  );
+  const [existingBannerUrl, setExistingBannerUrl] = useState(
+    seededDraft?.existingBannerUrl ?? "",
+  );
   const [validated, setValidated] = useState(false);
   const [touched, setTouched] = useState({
     name: false,
@@ -205,6 +224,10 @@ export default function ProjectTab(props: ProjectTabProps) {
       });
     }
   }, [session?.address]);
+
+  useEffect(() => {
+    projectDraft.save({ form, existingLogoUrl, existingBannerUrl });
+  }, [form, existingLogoUrl, existingBannerUrl, projectDraft]);
 
   const hasLogo = !!logoBlob || !!existingLogoUrl;
   const hasBanner = !!bannerBlob || !!existingBannerUrl;
@@ -315,6 +338,7 @@ export default function ProjectTab(props: ProjectTabProps) {
       }
 
       setIsSubmitting(false);
+      projectDraft.clear();
       onSave({
         id: json.project.id,
         details: {

--- a/src/app/flow-councils/components/ProjectTab.tsx
+++ b/src/app/flow-councils/components/ProjectTab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect, useMemo } from "react";
+import { useState, useRef, useEffect, useMemo, useCallback } from "react";
 import { isAddress } from "viem";
 import { useAccount } from "wagmi";
 import { useConnectModal } from "@rainbow-me/rainbowkit";
@@ -120,9 +120,17 @@ export default function ProjectTab(props: ProjectTabProps) {
   const projectDraft = useLocalDraft<ProjectDraft>(draftKey ?? null);
   const seededDraft = useMemo(() => projectDraft.readDraft(), [projectDraft]);
 
-  const [form, setForm] = useState<ProjectForm>(
+  const [form, setFormState] = useState<ProjectForm>(
     () => seededDraft?.form ?? DEFAULT_PROJECT_FORM,
   );
+  const userEditedRef = useRef(false);
+  // User-driven form updates flow through this and mark the form dirty; the
+  // automatic seeds (server project, session address) call setFormState
+  // directly so they don't create a draft the user never touched.
+  const setForm = useCallback((action: Parameters<typeof setFormState>[0]) => {
+    userEditedRef.current = true;
+    setFormState(action);
+  }, []);
 
   const [logoBlob, setLogoBlob] = useState<Blob | null>(null);
   const [bannerBlob, setBannerBlob] = useState<Blob | null>(null);
@@ -158,7 +166,7 @@ export default function ProjectTab(props: ProjectTabProps) {
 
   useEffect(() => {
     if (project && project.details) {
-      setForm({
+      setFormState({
         name: project.details.name ?? "",
         managerAddresses:
           project.managerAddresses && project.managerAddresses.length > 0
@@ -202,7 +210,7 @@ export default function ProjectTab(props: ProjectTabProps) {
   useEffect(() => {
     if (session?.address) {
       const sessionAddr = session.address.toLowerCase();
-      setForm((prev) => {
+      setFormState((prev) => {
         // Filter out any existing instance of session address (case-insensitive)
         const otherAddresses = prev.managerAddresses.filter(
           (a) => a && a.toLowerCase() !== sessionAddr,
@@ -226,6 +234,7 @@ export default function ProjectTab(props: ProjectTabProps) {
   }, [session?.address]);
 
   useEffect(() => {
+    if (!userEditedRef.current) return;
     projectDraft.save({ form, existingLogoUrl, existingBannerUrl });
   }, [form, existingLogoUrl, existingBannerUrl, projectDraft]);
 

--- a/src/app/flow-councils/components/chat/MessageInput.tsx
+++ b/src/app/flow-councils/components/chat/MessageInput.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Form from "react-bootstrap/Form";
 import Stack from "react-bootstrap/Stack";
 import Button from "react-bootstrap/Button";
 import Spinner from "react-bootstrap/Spinner";
 import MarkdownEditor from "@/components/MarkdownEditor";
+import { useLocalDraft } from "@/hooks/useLocalDraft";
 
 type MessageInputProps = {
   onSend: (content: string) => Promise<void>;
@@ -13,6 +14,7 @@ type MessageInputProps = {
   disabled?: boolean;
   placeholder?: string;
   onAuthRequired?: () => void;
+  draftKey?: string;
 };
 
 export default function MessageInput(props: MessageInputProps) {
@@ -22,14 +24,26 @@ export default function MessageInput(props: MessageInputProps) {
     disabled = false,
     placeholder = "Write a message. Markdown is supported.",
     onAuthRequired,
+    draftKey,
   } = props;
 
-  const [content, setContent] = useState("");
+  const draft = useLocalDraft<string>(draftKey ?? null);
+  const [content, setContent] = useState(() => draft.readDraft() ?? "");
+
+  useEffect(() => {
+    setContent(draft.readDraft() ?? "");
+  }, [draft]);
+
+  const handleChange = (value: string) => {
+    setContent(value);
+    draft.save(value);
+  };
 
   const handleSend = async () => {
     if (!content.trim() || disabled) return;
 
     await onSend(content.trim());
+    draft.clear();
     setContent("");
   };
 
@@ -52,7 +66,7 @@ export default function MessageInput(props: MessageInputProps) {
           rows={3}
           value={content}
           placeholder={placeholder}
-          onChange={(e) => setContent(e.target.value)}
+          onChange={(e) => handleChange(e.target.value)}
           disabled={isSending || disabled}
           resizable
         />

--- a/src/app/flow-councils/membership/MetricsIntegrationPanel.tsx
+++ b/src/app/flow-councils/membership/MetricsIntegrationPanel.tsx
@@ -177,8 +177,8 @@ Content-Type: application/json
           </li>
           <li>
             Fetch the recipient list programmatically from{" "}
-            <code>GET /api/flow-council/recipients</code> (no auth), or export it
-            below.
+            <code>GET /api/flow-council/recipients</code> (no auth), or export
+            it below.
           </li>
           <li>
             Submitting a ballot that matches the current one is a no-op (no
@@ -210,7 +210,9 @@ Content-Type: application/json
           gap={2}
           className="align-items-center justify-content-between mb-1"
         >
-          <span className="fw-semi-bold">Recipients and current allocation</span>
+          <span className="fw-semi-bold">
+            Recipients and current allocation
+          </span>
           {rows.length > 0 ? (
             <Stack direction="horizontal" gap={2}>
               <Button

--- a/src/app/flow-councils/review/review.tsx
+++ b/src/app/flow-councils/review/review.tsx
@@ -38,6 +38,7 @@ import InternalComments from "@/app/flow-councils/components/InternalComments";
 import useDistributionPoolQuery from "@/app/flow-councils/hooks/distributionPoolQuery";
 import useSiwe from "@/hooks/siwe";
 import { useMediaQuery } from "@/hooks/mediaQuery";
+import { useLocalDraft } from "@/hooks/useLocalDraft";
 import { flowCouncilAbi } from "@/lib/abi/flowCouncil";
 import { networks } from "@/lib/networks";
 import { SUPERFLUID_CALL_AGREEMENT_OPERATION } from "@/lib/constants";
@@ -142,6 +143,16 @@ export default function Review(props: ReviewProps) {
   const [newStatus, setNewStatus] = useState<Status | null>(null);
   const [reviewComment, setReviewComment] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const reviewDraft = useLocalDraft<string>(
+    selectedApplication
+      ? `review:${chainId}:${councilId}:${selectedApplication.id}`
+      : null,
+  );
+
+  useEffect(() => {
+    setReviewComment(reviewDraft.readDraft() ?? "");
+  }, [reviewDraft]);
   const [isTogglingLock, setIsTogglingLock] = useState(false);
   const [applicationsClosed, setApplicationsClosed] = useState(false);
   const [isTogglingApplicationsClosed, setIsTogglingApplicationsClosed] =
@@ -870,6 +881,7 @@ export default function Review(props: ReviewProps) {
       }
 
       // Success - refresh applications and close panel
+      reviewDraft.clear();
       setSuccess(true);
       fetchApplications();
       handleCloseReview();
@@ -1331,7 +1343,10 @@ export default function Review(props: ReviewProps) {
                       rows={3}
                       value={reviewComment}
                       placeholder="Write a message..."
-                      onChange={(e) => setReviewComment(e.target.value)}
+                      onChange={(e) => {
+                        setReviewComment(e.target.value);
+                        reviewDraft.save(e.target.value);
+                      }}
                       resizable
                     />
                   </Form.Group>

--- a/src/app/flow-councils/review/review.tsx
+++ b/src/app/flow-councils/review/review.tsx
@@ -160,6 +160,7 @@ export default function Review(props: ReviewProps) {
   useEffect(() => {
     setReviewComment(reviewDraft.readDraft() ?? "");
   }, [reviewDraft]);
+
   const [isTogglingLock, setIsTogglingLock] = useState(false);
   const [applicationsClosed, setApplicationsClosed] = useState(false);
   const [isTogglingApplicationsClosed, setIsTogglingApplicationsClosed] =

--- a/src/app/flow-councils/utils/draftId.ts
+++ b/src/app/flow-councils/utils/draftId.ts
@@ -1,0 +1,6 @@
+// Client-generated id used as the URL segment for a not-yet-saved application,
+// replacing the old non-fetchable "new" sentinel. It also namespaces the
+// application's localStorage draft, so two in-progress drafts never collide.
+export function generateDraftId() {
+  return `draft_${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+}

--- a/src/hooks/useLocalDraft.ts
+++ b/src/hooks/useLocalDraft.ts
@@ -59,7 +59,10 @@ export function useLocalDraft<T>(key: string | null, options: Options = {}) {
       const raw = window.localStorage.getItem(storageKey);
       if (!raw) return null;
       const parsed = JSON.parse(raw);
-      return parsed && typeof parsed === "object" && "v" in parsed && "t" in parsed
+      return parsed &&
+        typeof parsed === "object" &&
+        "v" in parsed &&
+        "t" in parsed
         ? (parsed.v as T)
         : (parsed as T);
     } catch {
@@ -112,8 +115,5 @@ export function useLocalDraft<T>(key: string | null, options: Options = {}) {
     };
   }, [storageKey]);
 
-  return useMemo(
-    () => ({ readDraft, save, clear }),
-    [readDraft, save, clear],
-  );
+  return useMemo(() => ({ readDraft, save, clear }), [readDraft, save, clear]);
 }

--- a/src/hooks/useLocalDraft.ts
+++ b/src/hooks/useLocalDraft.ts
@@ -1,0 +1,76 @@
+import { useCallback, useEffect, useMemo, useRef } from "react";
+
+// Lightweight, SSR-safe localStorage draft persistence: keep a serializable
+// value (a form snapshot, a comment body) in the browser between explicit
+// server saves so unsaved input survives a refresh or accidental navigation.
+//
+// The hook owns no state. Consumers read the stored draft once (readDraft) to
+// seed their own state, call save() on every change (debounced), and clear()
+// once the value has been persisted server-side. Pass key=null to disable
+// (e.g. when the identifiers needed to build a stable key aren't known yet).
+
+const KEY_PREFIX = "fc-draft:";
+
+type Options = {
+  debounceMs?: number;
+};
+
+export function useLocalDraft<T>(key: string | null, options: Options = {}) {
+  const { debounceMs = 600 } = options;
+
+  const storageKey = key ? `${KEY_PREFIX}${key}` : null;
+  const storageKeyRef = useRef(storageKey);
+  storageKeyRef.current = storageKey;
+
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const readDraft = useCallback((): T | null => {
+    if (typeof window === "undefined" || !storageKey) return null;
+    try {
+      const raw = window.localStorage.getItem(storageKey);
+      return raw ? (JSON.parse(raw) as T) : null;
+    } catch {
+      return null;
+    }
+  }, [storageKey]);
+
+  const save = useCallback(
+    (value: T) => {
+      if (typeof window === "undefined") return;
+      const target = storageKeyRef.current;
+      if (!target) return;
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => {
+        try {
+          window.localStorage.setItem(target, JSON.stringify(value));
+        } catch {
+          // Ignore quota or serialization failures; a lost draft is recoverable.
+        }
+      }, debounceMs);
+    },
+    [debounceMs],
+  );
+
+  const clear = useCallback(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    if (typeof window === "undefined") return;
+    const target = storageKeyRef.current;
+    if (!target) return;
+    try {
+      window.localStorage.removeItem(target);
+    } catch {
+      // Ignore.
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  return useMemo(
+    () => ({ readDraft, save, clear }),
+    [readDraft, save, clear],
+  );
+}

--- a/src/hooks/useLocalDraft.ts
+++ b/src/hooks/useLocalDraft.ts
@@ -10,10 +10,39 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 // (e.g. when the identifiers needed to build a stable key aren't known yet).
 
 const KEY_PREFIX = "fc-draft:";
+// Drafts untouched for this long are pruned on load so abandoned entries don't
+// accumulate in localStorage indefinitely.
+const TTL_MS = 1000 * 60 * 60 * 24 * 30;
 
 type Options = {
   debounceMs?: number;
 };
+
+let sweptStaleDrafts = false;
+
+function sweepStaleDrafts() {
+  if (sweptStaleDrafts || typeof window === "undefined") return;
+  sweptStaleDrafts = true;
+  try {
+    const now = Date.now();
+    const stale: string[] = [];
+    for (let i = 0; i < window.localStorage.length; i++) {
+      const k = window.localStorage.key(i);
+      if (!k || !k.startsWith(KEY_PREFIX)) continue;
+      try {
+        const parsed = JSON.parse(window.localStorage.getItem(k) ?? "null");
+        if (parsed && typeof parsed.t === "number" && now - parsed.t > TTL_MS) {
+          stale.push(k);
+        }
+      } catch {
+        // Leave unparseable entries untouched.
+      }
+    }
+    stale.forEach((k) => window.localStorage.removeItem(k));
+  } catch {
+    // Ignore.
+  }
+}
 
 export function useLocalDraft<T>(key: string | null, options: Options = {}) {
   const { debounceMs = 600 } = options;
@@ -28,7 +57,11 @@ export function useLocalDraft<T>(key: string | null, options: Options = {}) {
     if (typeof window === "undefined" || !storageKey) return null;
     try {
       const raw = window.localStorage.getItem(storageKey);
-      return raw ? (JSON.parse(raw) as T) : null;
+      if (!raw) return null;
+      const parsed = JSON.parse(raw);
+      return parsed && typeof parsed === "object" && "v" in parsed && "t" in parsed
+        ? (parsed.v as T)
+        : (parsed as T);
     } catch {
       return null;
     }
@@ -42,7 +75,10 @@ export function useLocalDraft<T>(key: string | null, options: Options = {}) {
       if (timerRef.current) clearTimeout(timerRef.current);
       timerRef.current = setTimeout(() => {
         try {
-          window.localStorage.setItem(target, JSON.stringify(value));
+          window.localStorage.setItem(
+            target,
+            JSON.stringify({ v: value, t: Date.now() }),
+          );
         } catch {
           // Ignore quota or serialization failures; a lost draft is recoverable.
         }
@@ -64,10 +100,17 @@ export function useLocalDraft<T>(key: string | null, options: Options = {}) {
   }, []);
 
   useEffect(() => {
+    sweepStaleDrafts();
+  }, []);
+
+  // Cancel any pending write when the key changes (or on unmount) so a debounced
+  // save scheduled for the previous draft never lands after the consumer has
+  // switched to a different one.
+  useEffect(() => {
     return () => {
       if (timerRef.current) clearTimeout(timerRef.current);
     };
-  }, []);
+  }, [storageKey]);
 
   return useMemo(
     () => ({ readDraft, save, clear }),


### PR DESCRIPTION
## What

Autosave in-progress input to the browser's `localStorage` between explicit server saves, so a refresh or accidental navigation no longer loses work. Covers the grant application form, internal comments, comms channels, and the reviewer status comment (per Rael's request).

## How

**`useLocalDraft` hook** — SSR-safe, debounced write, read-once restore, and clear. Owns no state; consumers seed from it, save on change, and clear once the value is persisted server-side.

**Application form**
- New applications now get a stable **draft id in the URL** (`/application/{chain}/{council}/draft_…`) instead of the non-fetchable `new` sentinel. This is the key change: the draft id keeps the URL stable for the whole drafting session, so the draft survives a refresh in every case, including before anything has been saved to the server. Legacy `/new` links self-heal to a draft id.
- The draft holds round/attestation/funding answers **plus pointers** to the real project/application ids once they exist. On load, the form fetches server data (when a real id is known) and overlays the draft on top; a draft only wins where it genuinely differs from the server, which is also when the **"Unsaved changes restored · Discard"** note appears.
- **Project tab** text fields/links autosave while creating a new application; once the project is saved it has a real id and is treated like an existing project.

**Comments / comms** — the shared `MessageInput` drafts its content per channel (keyed by channel type + ids built in `ChatView`), covering both internal comments and comms channels. Cleared on send.

**Review comment** — the reviewer's status comment drafts per application and clears on submit.

## Scope / caveats

- Autosave targets the dynamic (schema-based) application form, which is the active path; legacy `RoundTab`/`AttestationTab` are not wired.
- Freshly picked logo/banner **files** can't be stored in browser storage, so those need re-selecting after a refresh until Save. All text, links, and answers survive.

## Verification

`pnpm typecheck` and `pnpm lint` both pass. Suggest a manual walk-through of the new-application flow before merge: create → fill Project → refresh → save → fill Round → refresh → submit.
