### PR TITLE
feat: full screen review view for recipient applications

### DIFF
--- a/public/fullscreen-exit.svg
+++ b/public/fullscreen-exit.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 -960 960 960" width="24" fill="#000"><path d="m136-80-56-56 264-264H160v-80h320v320h-80v-184L136-80Zm344-400v-320h80v184l264-264 56 56-264 264h184v80H480Z"/></svg>

--- a/public/fullscreen.svg
+++ b/public/fullscreen.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 -960 960 960" width="24" fill="#000"><path d="M120-120v-320h80v184l504-504H520v-80h320v320h-80v-184L256-200h184v80H120Z"/></svg>

--- a/src/app/flow-councils/review/review.tsx
+++ b/src/app/flow-councils/review/review.tsx
@@ -134,6 +134,7 @@ export default function Review(props: ReviewProps) {
   const [selectedApplication, setSelectedApplication] =
     useState<Application | null>(null);
   const [isLoadingDetail, setIsLoadingDetail] = useState(false);
+  const [isFullScreen, setIsFullScreen] = useState(false);
   const [isExportingCsv, setIsExportingCsv] = useState(false);
   const [roundFormSchema, setRoundFormSchema] = useState<FormSchema | null>(
     null,
@@ -558,6 +559,7 @@ export default function Review(props: ReviewProps) {
     setNewStatus(null);
     setReviewComment("");
     setError("");
+    setIsFullScreen(false);
   };
 
   // Deep link from the inbox: /flow-councils/review/[chainId]/[councilId]
@@ -578,6 +580,23 @@ export default function Review(props: ReviewProps) {
     // safe to call here; excluded from deps to avoid re-triggering.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [applications, searchParams]);
+
+  useEffect(() => {
+    if (!isFullScreen) return;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setIsFullScreen(false);
+    };
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isFullScreen]);
 
   const handleToggleEditsUnlocked = async (application: Application) => {
     if (!flowCouncil) return;
@@ -1217,16 +1236,52 @@ export default function Review(props: ReviewProps) {
             )}
 
             {selectedApplication !== null && !isLoadingDetail && (
-              <Stack direction="vertical" gap={4} className="mt-4">
+              <Stack
+                direction="vertical"
+                gap={4}
+                className={
+                  isFullScreen
+                    ? "position-fixed top-0 start-0 w-100 vh-100 overflow-auto p-4 p-md-5"
+                    : "mt-4"
+                }
+                style={
+                  isFullScreen
+                    ? { backgroundColor: "#fbf7ef", zIndex: 1050 }
+                    : undefined
+                }
+              >
                 <div className="bg-lace-100 rounded-4 p-4">
                   <Stack
                     direction="horizontal"
                     className="justify-content-between mb-4"
                   >
-                    <h4 className="fw-bold mb-0">
-                      {selectedApplication.projectDetails?.name ??
-                        "Application Review"}
-                    </h4>
+                    <Stack
+                      direction="horizontal"
+                      gap={3}
+                      className="align-items-center"
+                    >
+                      <h4 className="fw-bold mb-0">
+                        {selectedApplication.projectDetails?.name ??
+                          "Application Review"}
+                      </h4>
+                      <Button
+                        variant="link"
+                        className="d-flex align-items-center gap-1 p-0 text-decoration-none fw-semi-bold text-primary"
+                        onClick={() => setIsFullScreen((prev) => !prev)}
+                      >
+                        <Image
+                          src={
+                            isFullScreen
+                              ? "/fullscreen-exit.svg"
+                              : "/fullscreen.svg"
+                          }
+                          alt=""
+                          width={20}
+                          height={20}
+                        />
+                        {isFullScreen ? "Exit Full Screen" : "Full Screen Review"}
+                      </Button>
+                    </Stack>
                     <Stack direction="horizontal" gap={3}>
                       {["ACCEPTED", "GRADUATED", "REMOVED"].includes(
                         selectedApplication.status,

--- a/src/app/flow-councils/review/review.tsx
+++ b/src/app/flow-councils/review/review.tsx
@@ -160,6 +160,7 @@ export default function Review(props: ReviewProps) {
 
   const queryClient = useQueryClient();
   const topRef = useRef<HTMLDivElement>(null);
+  const fullScreenRef = useRef<HTMLDivElement>(null);
   const publicClient = usePublicClient();
   const wagmiConfig = useConfig();
   const router = useRouter();
@@ -585,7 +586,9 @@ export default function Review(props: ReviewProps) {
     if (!isFullScreen) return;
 
     const previousOverflow = document.body.style.overflow;
+    const previouslyFocused = document.activeElement as HTMLElement | null;
     document.body.style.overflow = "hidden";
+    fullScreenRef.current?.focus();
 
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") setIsFullScreen(false);
@@ -595,6 +598,7 @@ export default function Review(props: ReviewProps) {
     return () => {
       document.body.style.overflow = previousOverflow;
       window.removeEventListener("keydown", handleKeyDown);
+      previouslyFocused?.focus?.();
     };
   }, [isFullScreen]);
 
@@ -1237,18 +1241,23 @@ export default function Review(props: ReviewProps) {
 
             {selectedApplication !== null && !isLoadingDetail && (
               <Stack
+                ref={fullScreenRef}
                 direction="vertical"
                 gap={4}
-                className={
+                tabIndex={isFullScreen ? -1 : undefined}
+                role={isFullScreen ? "dialog" : undefined}
+                aria-modal={isFullScreen ? true : undefined}
+                aria-label={
                   isFullScreen
-                    ? "position-fixed top-0 start-0 w-100 vh-100 overflow-auto p-4 p-md-5"
-                    : "mt-4"
-                }
-                style={
-                  isFullScreen
-                    ? { backgroundColor: "#fbf7ef", zIndex: 1050 }
+                    ? `${selectedApplication.projectDetails?.name ?? "Application"} review`
                     : undefined
                 }
+                className={
+                  isFullScreen
+                    ? "position-fixed top-0 start-0 w-100 vh-100 overflow-auto p-4 p-md-5 bg-lace-50"
+                    : "mt-4"
+                }
+                style={isFullScreen ? { zIndex: 1050 } : undefined}
               >
                 <div className="bg-lace-100 rounded-4 p-4">
                   <Stack


### PR DESCRIPTION
## Summary

Adds a **Full Screen Review** toggle to the Manage Recipients module so reviewers can view an application using the full browser width and height instead of the sidebar-constrained column.

- New "Full Screen Review" button in the review panel header, next to the project name.
- Toggling it lifts both the **status section** (current/new status + review comment + update) and the **application review tabs** (Project / Round / Attestation / Comments) into a full-viewport overlay.
- Three ways back to Recipients: the button flips to "Exit Full Screen", the existing ✕ close, or the **Esc** key.
- Body scroll is locked while full screen is active and restored on exit.

No new route or data fetching: the overlay reuses the existing review state and handlers.

## Testing
- `pnpm typecheck` ✓
- `pnpm lint` ✓