### PR TITLE
Point Flow QF docs links to new /flow-qf slug

### DIFF
--- a/src/app/home-page.tsx
+++ b/src/app/home-page.tsx
@@ -314,7 +314,7 @@ export default function HomePage() {
                     className="flex-wrap flex-sm-nowrap"
                   >
                     <Link
-                      href="https://docs.flowstate.network/platform/streaming-qf"
+                      href="https://docs.flowstate.network/flow-qf"
                       target="_blank"
                       className={isMobile ? "w-100" : "w-50"}
                     >

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -65,7 +65,7 @@ export default function Footer() {
               Flow Council
             </Link>
             <Link
-              href="https://docs.flowstate.network/platform/streaming-qf/"
+              href="https://docs.flowstate.network/flow-qf"
               className="text-decoration-none text-white fs-5 fw-bold"
             >
               Flow QF


### PR DESCRIPTION
Updates the two "Flow QF" links in the app to the renamed docs page.

- `src/app/home-page.tsx` — "Flow QF" button (Funders panel)
- `src/components/Footer.tsx` — "Flow QF" footer link

Both pointed at `docs.flowstate.network/platform/streaming-qf`, which is renamed/moved to `docs.flowstate.network/flow-qf` by [flow-state-coop/docs#10](https://github.com/flow-state-coop/docs/pull/10) ("rename Streaming Quadratic Funding to Flow QF"). Without this they would 404 once that PR merges.

The two generic "Docs" buttons (hero + Members panel) point at the docs root and are unaffected.

Note: live-correct once flow-state-coop/docs#10 is merged and deployed. If the app deploys first, the links briefly 404.