### PR TITLE
feat: show launched round contract addresses and default existing FCs to Metadata

### DIFF
--- a/src/app/flow-councils/flow-councils.tsx
+++ b/src/app/flow-councils/flow-councils.tsx
@@ -317,7 +317,7 @@ export default function FlowCouncils(props: FlowCouncilsProps) {
               onClick={(e) => {
                 e.stopPropagation();
                 router.push(
-                  `/flow-councils/permissions/${selectedNetwork.id}/${flowCouncil.id}`,
+                  `/flow-councils/round-metadata/${selectedNetwork.id}/${flowCouncil.id}`,
                 );
               }}
             >

--- a/src/app/flow-councils/launch/launch.tsx
+++ b/src/app/flow-councils/launch/launch.tsx
@@ -18,7 +18,8 @@ import Card from "react-bootstrap/Card";
 import Alert from "react-bootstrap/Alert";
 import Image from "react-bootstrap/Image";
 import Sidebar from "@/app/flow-councils/components/Sidebar";
-import { waitForReceipt } from "@/lib/utils";
+import useCouncilMetadata from "@/app/flow-councils/hooks/councilMetadata";
+import { truncateStr, waitForReceipt } from "@/lib/utils";
 import { useSession } from "next-auth/react";
 import { useMediaQuery } from "@/hooks/mediaQuery";
 import useSiwe from "@/hooks/siwe";
@@ -55,6 +56,7 @@ const FLOW_COUNCIL_QUERY = gql`
     flowCouncil(id: $councilId) {
       id
       superToken
+      distributionPool
     }
   }
 `;
@@ -150,6 +152,23 @@ export default function Launch(props: LaunchProps) {
   });
 
   const flowCouncil = flowCouncilQueryRes?.flowCouncil;
+
+  const councilMetadata = useCouncilMetadata(
+    selectedNetwork.id,
+    councilId ?? "",
+  );
+  const distributionPool = flowCouncil?.distributionPool as Address | undefined;
+  const splitterAddress = councilMetadata.superappSplitterAddress;
+  const superfluidExplorerBase = selectedNetwork.superfluidExplorer.replace(
+    /\/$/,
+    "",
+  );
+  const distributionPoolExplorerHref = distributionPool
+    ? `${superfluidExplorerBase}/pools/${distributionPool}`
+    : null;
+  const splitterExplorerHref = splitterAddress
+    ? `${superfluidExplorerBase}/accounts/${splitterAddress}`
+    : null;
 
   const launchNetworks = useMemo(
     () => networks.filter(isFlowCouncilNetwork),
@@ -548,6 +567,55 @@ export default function Launch(props: LaunchProps) {
             </Stack>
           </Card.Body>
         </Card>
+        {councilId && (
+          <Card className="bg-lace-100 rounded-4 border-0 p-4 mt-4">
+            <Card.Header className="bg-transparent border-0 rounded-4 p-0 fs-5 fw-semi-bold">
+              Contract Addresses
+            </Card.Header>
+            <Card.Body className="p-0">
+              <Card.Text className="text-info">
+                View your Flow Council&apos;s contracts on the Superfluid
+                Explorer.
+              </Card.Text>
+              <Stack direction="vertical" gap={3}>
+                <Stack
+                  direction={isMobile ? "vertical" : "horizontal"}
+                  className={isMobile ? "" : "justify-content-between"}
+                >
+                  <span className="fw-semi-bold">Flow Council GDA</span>
+                  {distributionPoolExplorerHref && distributionPool ? (
+                    <Card.Link
+                      href={distributionPoolExplorerHref}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-primary text-decoration-underline fw-semi-bold"
+                    >
+                      {truncateStr(distributionPool, 16)}
+                    </Card.Link>
+                  ) : (
+                    <Spinner size="sm" />
+                  )}
+                </Stack>
+                {splitterAddress && splitterExplorerHref && (
+                  <Stack
+                    direction={isMobile ? "vertical" : "horizontal"}
+                    className={isMobile ? "" : "justify-content-between"}
+                  >
+                    <span className="fw-semi-bold">Super App Splitter</span>
+                    <Card.Link
+                      href={splitterExplorerHref}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-primary text-decoration-underline fw-semi-bold"
+                    >
+                      {truncateStr(splitterAddress, 16)}
+                    </Card.Link>
+                  </Stack>
+                )}
+              </Stack>
+            </Card.Body>
+          </Card>
+        )}
         <Stack direction="vertical" gap={3} className="mt-4 mb-30">
           <Button
             disabled={

--- a/src/app/flow-councils/launch/launch.tsx
+++ b/src/app/flow-councils/launch/launch.tsx
@@ -592,8 +592,10 @@ export default function Launch(props: LaunchProps) {
                     >
                       {truncateStr(distributionPool, 16)}
                     </Card.Link>
-                  ) : (
+                  ) : flowCouncilQueryLoading ? (
                     <Spinner size="sm" />
+                  ) : (
+                    <span className="text-info">Not available</span>
                   )}
                 </Stack>
                 {splitterAddress && splitterExplorerHref && (

--- a/tests/e2e/helpers/signIn.ts
+++ b/tests/e2e/helpers/signIn.ts
@@ -1,18 +1,19 @@
 import type { Page } from "@playwright/test";
 import { privateKeyToAccount } from "viem/accounts";
 import { createSiweMessage } from "viem/siwe";
-import { getTestAccount, TEST_CHAIN_ID, TEST_PRIVATE_KEY } from "./mockEthereum";
+import { TEST_CHAIN_ID, TEST_PRIVATE_KEY } from "./mockEthereum";
 
 // Wait for the injected wallet to auto-connect. RainbowKit's injected
 // connector picks up window.ethereum on mount, so there is no "Connect
-// Wallet" button to click — the account chip appears directly. Match on the
-// last 4 hex characters of the address, which every truncation scheme
-// (0xf3…2266, 0xf39F…2266, full) contains.
+// Wallet" button to click; the account chip appears directly. Match on the
+// chip button itself rather than the address tail: the chip first shows the
+// truncated address, then swaps to the resolved profile name once
+// /api/flow-council/profile loads, so an address-tail match races that fetch.
+// The chip's accessible name always carries the "account" icon label while
+// connected, regardless of which label is currently shown.
 export async function waitForAutoConnect(page: Page): Promise<void> {
-  const { address } = getTestAccount();
-  const tail = address.slice(-4);
   await page
-    .getByText(new RegExp(tail, "i"))
+    .getByRole("button", { name: /account/i })
     .first()
     .waitFor({ state: "visible", timeout: 15_000 });
 }

--- a/tests/e2e/helpers/signIn.ts
+++ b/tests/e2e/helpers/signIn.ts
@@ -5,12 +5,12 @@ import { TEST_CHAIN_ID, TEST_PRIVATE_KEY } from "./mockEthereum";
 
 // Wait for the injected wallet to auto-connect. RainbowKit's injected
 // connector picks up window.ethereum on mount, so there is no "Connect
-// Wallet" button to click; the account chip appears directly. Match on the
-// chip button itself rather than the address tail: the chip first shows the
-// truncated address, then swaps to the resolved profile name once
-// /api/flow-council/profile loads, so an address-tail match races that fetch.
-// The chip's accessible name always carries the "account" icon label while
-// connected, regardless of which label is currently shown.
+// Wallet" button to click — the account chip appears directly. The chip's
+// label starts as the truncated address and then swaps to the resolved
+// profile/ENS name once a background fetch returns, so matching either text is
+// racy. Wait for the chip button itself instead: its accessible name always
+// carries the "account" icon label once connected, regardless of which label
+// is currently shown.
 export async function waitForAutoConnect(page: Page): Promise<void> {
   await page
     .getByRole("button", { name: /account/i })


### PR DESCRIPTION
## Changes

### 1. Contract addresses on the launch page
Once a round is launched (the launch page opened for an existing council), a new **Contract Addresses** card shows the relevant contracts as links to the Superfluid Explorer:

- **Flow Council GDA** → the distribution pool, linked to `…/pools/{address}`
- **Super App Splitter** → linked to `…/accounts/{address}` (hidden on networks/councils with no splitter)

The GDA pool address is now requested in the launch page's subgraph query; the splitter address comes from the round metadata via the existing `useCouncilMetadata` hook. The GDA row shows a spinner until the subgraph indexes the pool.

### 2. Default to the Metadata step when first opening an existing FC
The "Edit" button on a Flow Council card (the entry point into the admin for an existing FC) routed to the Permissions step. It now opens **Metadata** (`round-metadata`), matching the recent dropdown change (#317) for switching between Flow Councils.

## Verification
`pnpm typecheck`, `pnpm lint`, and `pnpm prettier` all pass.