### PR TITLE
feat: fall back to ENS for voter table and public profile names

### DIFF
--- a/src/app/flow-councils/components/chat/MessageItem.tsx
+++ b/src/app/flow-councils/components/chat/MessageItem.tsx
@@ -9,6 +9,7 @@ import ProfilePic from "./ProfilePic";
 import MessageActions from "./MessageActions";
 import ReactionBar, { type ReactionSummary } from "./ReactionBar";
 import type { EnsData } from "@/hooks/useEnsResolution";
+import { resolveDisplayName } from "@/lib/utils";
 
 export type Message = {
   id: number;
@@ -48,11 +49,6 @@ type MessageItemProps = {
 };
 
 const SYSTEM_ADDRESS = "0x0000000000000000000000000000000000000000";
-
-function shortenAddress(address: string): string {
-  if (address.length <= 10) return address;
-  return `${address.slice(0, 6)}...${address.slice(-4)}`;
-}
 
 function formatTimestamp(dateString: string): string {
   const date = new Date(dateString);
@@ -100,9 +96,11 @@ export default function MessageItem(props: MessageItemProps) {
     ? (projectSource ?? "Milestone Update")
     : isSystemMessage
       ? "System"
-      : customDisplayName ||
-        ensData?.name ||
-        shortenAddress(message.authorAddress);
+      : resolveDisplayName(
+          customDisplayName,
+          ensData?.name,
+          message.authorAddress,
+        );
   const showAddressTooltip = !isMilestoneUpdate && !isSystemMessage;
   const edited = isEdited(message.createdAt, message.updatedAt);
 

--- a/src/app/flow-councils/membership/VoterTable.tsx
+++ b/src/app/flow-councils/membership/VoterTable.tsx
@@ -19,6 +19,7 @@ import Alert from "react-bootstrap/Alert";
 import Pagination from "react-bootstrap/Pagination";
 import { flowCouncilAbi } from "@/lib/abi/flowCouncil";
 import { truncateAddress } from "@/lib/utils";
+import { useEnsResolution } from "@/hooks/useEnsResolution";
 import {
   CHUNK_SIZE,
   splitIntoChunks,
@@ -284,6 +285,23 @@ export default function VoterTable(props: VoterTableProps) {
 
     return filteredVoters.slice(start, start + PAGE_SIZE);
   }, [filteredVoters, page]);
+
+  // Resolve ENS only for the addresses actually on screen: the roster can run to
+  // thousands of voters, so resolving the whole list would fan out that many
+  // mainnet reverse lookups. The visible page (≤ PAGE_SIZE) is all we render.
+  const pageAddressKey = useMemo(
+    () =>
+      [...new Set(pageVoters.map((voter) => voter.account.toLowerCase()))]
+        .sort()
+        .join(","),
+    [pageVoters],
+  );
+  const pageAddresses = useMemo(
+    () => (pageAddressKey === "" ? [] : pageAddressKey.split(",")),
+    [pageAddressKey],
+  );
+
+  const { ensByAddress } = useEnsResolution(pageAddresses);
 
   const otherGroups = useMemo(
     () => allGroups.filter((g) => g.id !== groupId),
@@ -1042,7 +1060,9 @@ export default function VoterTable(props: VoterTableProps) {
                   </td>
                   <td>
                     <span className="fw-semi-bold text-break">
-                      {name ? name : truncateAddress(account)}
+                      {name ??
+                        ensByAddress?.[account]?.name ??
+                        truncateAddress(account)}
                     </span>
                   </td>
                   <td className="text-end" style={{ maxWidth: 120 }}>

--- a/src/app/flow-councils/membership/VoterTable.tsx
+++ b/src/app/flow-councils/membership/VoterTable.tsx
@@ -1060,8 +1060,8 @@ export default function VoterTable(props: VoterTableProps) {
                   </td>
                   <td>
                     <span className="fw-semi-bold text-break">
-                      {name ??
-                        ensByAddress?.[account]?.name ??
+                      {name ||
+                        ensByAddress?.[account]?.name ||
                         truncateAddress(account)}
                     </span>
                   </td>

--- a/src/app/flow-councils/membership/VoterTable.tsx
+++ b/src/app/flow-councils/membership/VoterTable.tsx
@@ -18,7 +18,8 @@ import Dropdown from "react-bootstrap/Dropdown";
 import Alert from "react-bootstrap/Alert";
 import Pagination from "react-bootstrap/Pagination";
 import { flowCouncilAbi } from "@/lib/abi/flowCouncil";
-import { truncateAddress } from "@/lib/utils";
+import { resolveDisplayName, truncateAddress } from "@/lib/utils";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { useEnsResolution } from "@/hooks/useEnsResolution";
 import {
   CHUNK_SIZE,
@@ -133,6 +134,11 @@ export default function VoterTable(props: VoterTableProps) {
   const [pctFilter, setPctFilter] = useState<string>("all");
   const [page, setPage] = useState(1);
 
+  // Filtering is debounced so a narrowing keystroke doesn't re-page the table
+  // and fan out a fresh page of ENS lookups per character typed.
+  const debouncedAddressSearch = useDebouncedValue(addressSearch, 300);
+  const debouncedNameSearch = useDebouncedValue(nameSearch, 300);
+
   // Staged edits — committed together by Save.
   // editedPower: acct(lowercase) -> new votes string (only present when changed).
   // removed: accts staged for removal (onchain power → 0 + DB classification drop).
@@ -238,8 +244,8 @@ export default function VoterTable(props: VoterTableProps) {
   );
 
   const filteredVoters = useMemo(() => {
-    const { list, needle } = parseAddressSearch(addressSearch);
-    const nameNeedle = nameSearch.trim().toLowerCase();
+    const { list, needle } = parseAddressSearch(debouncedAddressSearch);
+    const nameNeedle = debouncedNameSearch.trim().toLowerCase();
 
     return voters.filter((voter) => {
       const account = voter.account.toLowerCase();
@@ -272,7 +278,7 @@ export default function VoterTable(props: VoterTableProps) {
 
       return true;
     });
-  }, [voters, addressSearch, nameSearch, pctFilter, names]);
+  }, [voters, debouncedAddressSearch, debouncedNameSearch, pctFilter, names]);
 
   const pageCount = totalPages(filteredVoters.length, PAGE_SIZE);
 
@@ -289,19 +295,14 @@ export default function VoterTable(props: VoterTableProps) {
   // Resolve ENS only for the addresses actually on screen: the roster can run to
   // thousands of voters, so resolving the whole list would fan out that many
   // mainnet reverse lookups. The visible page (≤ PAGE_SIZE) is all we render.
-  const pageAddressKey = useMemo(
-    () =>
-      [...new Set(pageVoters.map((voter) => voter.account.toLowerCase()))]
-        .sort()
-        .join(","),
+  // Sorted so an Apollo re-poll that reorders the same membership doesn't
+  // change the hook's key and refetch.
+  const pageAddresses = useMemo(
+    () => pageVoters.map((voter) => voter.account.toLowerCase()).sort(),
     [pageVoters],
   );
-  const pageAddresses = useMemo(
-    () => (pageAddressKey === "" ? [] : pageAddressKey.split(",")),
-    [pageAddressKey],
-  );
 
-  const { ensByAddress } = useEnsResolution(pageAddresses);
+  const { ensByAddress } = useEnsResolution(pageAddresses, { avatars: false });
 
   const otherGroups = useMemo(
     () => allGroups.filter((g) => g.id !== groupId),
@@ -1060,9 +1061,11 @@ export default function VoterTable(props: VoterTableProps) {
                   </td>
                   <td>
                     <span className="fw-semi-bold text-break">
-                      {name ||
-                        ensByAddress?.[account]?.name ||
-                        truncateAddress(account)}
+                      {resolveDisplayName(
+                        name,
+                        ensByAddress?.[account]?.name,
+                        account,
+                      )}
                     </span>
                   </td>
                   <td className="text-end" style={{ maxWidth: 120 }}>

--- a/src/app/flow-councils/permissions/permissions.tsx
+++ b/src/app/flow-councils/permissions/permissions.tsx
@@ -277,7 +277,9 @@ export default function Permissions(props: PermissionsProps) {
     [managerAddressKey],
   );
 
-  const { ensByAddress } = useEnsResolution(managerAddresses);
+  const { ensByAddress } = useEnsResolution(managerAddresses, {
+    avatars: false,
+  });
 
   useEffect(() => {
     if (managerAddresses.length === 0) {

--- a/src/app/profile/[address]/public-profile.tsx
+++ b/src/app/profile/[address]/public-profile.tsx
@@ -6,6 +6,7 @@ import Spinner from "react-bootstrap/Spinner";
 import Stack from "react-bootstrap/Stack";
 import Link from "next/link";
 import { useEnsResolution } from "@/hooks/useEnsResolution";
+import { resolveDisplayName } from "@/lib/utils";
 
 type PublicProfileData = {
   address: string;
@@ -24,10 +25,6 @@ const SOCIAL_LABELS: Record<string, string> = {
   farcaster: "Farcaster",
 };
 
-function truncateAddress(addr: string) {
-  return `${addr.slice(0, 6)}...${addr.slice(-4)}`;
-}
-
 function isSafeHttpsUrl(url: string): boolean {
   try {
     return new URL(url).protocol === "https:";
@@ -40,7 +37,7 @@ export default function PublicProfile({ address }: { address: string }) {
   const [profile, setProfile] = useState<PublicProfileData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
-  const { ensByAddress } = useEnsResolution([address]);
+  const { ensByAddress } = useEnsResolution([address], { avatars: false });
 
   useEffect(() => {
     (async () => {
@@ -71,9 +68,11 @@ export default function PublicProfile({ address }: { address: string }) {
   return (
     <Container className="py-5" style={{ maxWidth: 600 }}>
       <h2 className="mb-4">
-        {profile?.displayName ||
-          ensByAddress?.[address.toLowerCase()]?.name ||
-          truncateAddress(address)}
+        {resolveDisplayName(
+          profile?.displayName,
+          ensByAddress?.[address.toLowerCase()]?.name,
+          address,
+        )}
       </h2>
 
       <div className="mb-4">

--- a/src/app/profile/[address]/public-profile.tsx
+++ b/src/app/profile/[address]/public-profile.tsx
@@ -5,6 +5,7 @@ import Container from "react-bootstrap/Container";
 import Spinner from "react-bootstrap/Spinner";
 import Stack from "react-bootstrap/Stack";
 import Link from "next/link";
+import { useEnsResolution } from "@/hooks/useEnsResolution";
 
 type PublicProfileData = {
   address: string;
@@ -39,6 +40,8 @@ export default function PublicProfile({ address }: { address: string }) {
   const [profile, setProfile] = useState<PublicProfileData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
+  const { ensByAddress } = useEnsResolution([address]);
+
   useEffect(() => {
     (async () => {
       try {
@@ -68,7 +71,9 @@ export default function PublicProfile({ address }: { address: string }) {
   return (
     <Container className="py-5" style={{ maxWidth: 600 }}>
       <h2 className="mb-4">
-        {profile?.displayName || truncateAddress(address)}
+        {profile?.displayName ||
+          ensByAddress?.[address.toLowerCase()]?.name ||
+          truncateAddress(address)}
       </h2>
 
       <div className="mb-4">

--- a/src/app/profile/profile.tsx
+++ b/src/app/profile/profile.tsx
@@ -130,7 +130,7 @@ export default function Profile() {
   const [saved, setSaved] = useState(false);
 
   const addresses = address ? [address] : [];
-  const { ensByAddress } = useEnsResolution(addresses);
+  const { ensByAddress } = useEnsResolution(addresses, { avatars: false });
   const ensName = address ? ensByAddress?.[address.toLowerCase()]?.name : null;
 
   const fetchProfile = useCallback(async () => {

--- a/src/hooks/useDebouncedValue.ts
+++ b/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,13 @@
+import { useState, useEffect } from "react";
+
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => setDebounced(value), delayMs);
+
+    return () => clearTimeout(timeout);
+  }, [value, delayMs]);
+
+  return debounced;
+}

--- a/src/hooks/useEnsResolution.ts
+++ b/src/hooks/useEnsResolution.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect } from "react";
 import { Address, createPublicClient, http } from "viem";
 import { mainnet } from "viem/chains";
 import { normalize } from "viem/ens";
@@ -23,77 +23,123 @@ const publicClient = createPublicClient({
   }),
 });
 
-export function useEnsResolution(addresses: string[]): {
+// Session-wide caches so re-resolving the same addresses (e.g. paging a table
+// back and forth) never refetches. Failed lookups are left uncached so a
+// transient RPC error is retried on the next resolution.
+const nameCache = new Map<string, string | null>();
+const avatarCache = new Map<string, string | null>();
+
+export function useEnsResolution(
+  addresses: string[],
+  options?: { avatars?: boolean },
+): {
   ensByAddress: EnsByAddress | null;
   isLoading: boolean;
 } {
   const [ensByAddress, setEnsByAddress] = useState<EnsByAddress | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
+  const withAvatars = options?.avatars !== false;
+
   // Create a stable key for the addresses array
   const addressesKey = addresses.join(",").toLowerCase();
 
-  const resolveAddresses = useCallback(async () => {
-    if (!addresses || addresses.length === 0) {
+  useEffect(() => {
+    if (addressesKey === "") {
       setEnsByAddress({});
+      setIsLoading(false);
       return;
     }
 
-    // Deduplicate addresses
-    const uniqueAddresses = [...new Set(addresses.map((a) => a.toLowerCase()))];
+    const uniqueAddresses = [...new Set(addressesKey.split(","))];
 
-    setIsLoading(true);
+    let cancelled = false;
 
-    const result: EnsByAddress = {};
-
-    try {
-      const ensNames = await Promise.all(
-        uniqueAddresses.map((address) =>
-          publicClient
-            .getEnsName({
-              address: address as Address,
-            })
-            .catch(() => null),
-        ),
+    const resolve = async () => {
+      const uncachedNames = uniqueAddresses.filter(
+        (address) => !nameCache.has(address),
       );
 
-      const ensAvatars = await Promise.all(
-        ensNames.map((ensName) => {
-          if (!ensName) return Promise.resolve(null);
-          return publicClient
-            .getEnsAvatar({
-              name: normalize(ensName),
-              gatewayUrls: ["https://ccip.ens.xyz"],
-              assetGatewayUrls: {
-                ipfs: IPFS_GATEWAYS[0],
-              },
-            })
-            .catch(() => null);
+      if (uncachedNames.length > 0) {
+        setIsLoading(true);
+      }
+
+      const nameResults = await Promise.all(
+        uncachedNames.map(async (address) => {
+          try {
+            const name = await publicClient.getEnsName({
+              address: address as Address,
+            });
+
+            return { address, name, ok: true };
+          } catch {
+            return { address, name: null, ok: false };
+          }
         }),
       );
 
-      for (let i = 0; i < uniqueAddresses.length; i++) {
-        result[uniqueAddresses[i]] = {
-          name: ensNames[i] ?? null,
-          avatar: ensAvatars[i] ?? null,
+      for (const { address, name, ok } of nameResults) {
+        if (ok) {
+          nameCache.set(address, name);
+        }
+      }
+
+      if (withAvatars) {
+        const uncachedAvatars = uniqueAddresses.filter(
+          (address) =>
+            nameCache.get(address) != null && !avatarCache.has(address),
+        );
+
+        const avatarResults = await Promise.all(
+          uncachedAvatars.map(async (address) => {
+            try {
+              const avatar = await publicClient.getEnsAvatar({
+                name: normalize(nameCache.get(address)!),
+                gatewayUrls: ["https://ccip.ens.xyz"],
+                assetGatewayUrls: {
+                  ipfs: IPFS_GATEWAYS[0],
+                },
+              });
+
+              return { address, avatar, ok: true };
+            } catch {
+              return { address, avatar: null, ok: false };
+            }
+          }),
+        );
+
+        for (const { address, avatar, ok } of avatarResults) {
+          if (ok) {
+            avatarCache.set(address, avatar);
+          }
+        }
+      }
+
+      // A newer resolution for a different address set has taken over this
+      // hook's state; writing now would show the wrong page's names.
+      if (cancelled) {
+        return;
+      }
+
+      const result: EnsByAddress = {};
+
+      for (const address of uniqueAddresses) {
+        result[address] = {
+          name: nameCache.get(address) ?? null,
+          avatar: withAvatars ? (avatarCache.get(address) ?? null) : null,
         };
       }
-    } catch (err) {
-      console.error("Error resolving ENS:", err);
-      // Populate with null values on error
-      for (const address of uniqueAddresses) {
-        result[address] = { name: null, avatar: null };
-      }
-    }
 
-    setEnsByAddress(result);
-    setIsLoading(false);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [addressesKey]);
+      setEnsByAddress(result);
+      setIsLoading(false);
+    };
 
-  useEffect(() => {
-    resolveAddresses();
-  }, [resolveAddresses]);
+    resolve();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [addressesKey, withAvatars]);
 
   return { ensByAddress, isLoading };
 }

--- a/src/hooks/useEnsResolution.ts
+++ b/src/hooks/useEnsResolution.ts
@@ -25,9 +25,24 @@ const publicClient = createPublicClient({
 
 // Session-wide caches so re-resolving the same addresses (e.g. paging a table
 // back and forth) never refetches. Failed lookups are left uncached so a
-// transient RPC error is retried on the next resolution.
+// transient RPC error is retried on the next resolution. Capped with
+// oldest-first eviction so a session that walks a huge roster can't grow
+// them without bound.
+const MAX_CACHE_ENTRIES = 10_000;
 const nameCache = new Map<string, string | null>();
 const avatarCache = new Map<string, string | null>();
+
+function cacheSet(
+  cache: Map<string, string | null>,
+  key: string,
+  value: string | null,
+) {
+  if (cache.size >= MAX_CACHE_ENTRIES) {
+    cache.delete(cache.keys().next().value!);
+  }
+
+  cache.set(key, value);
+}
 
 export function useEnsResolution(
   addresses: string[],
@@ -80,7 +95,7 @@ export function useEnsResolution(
 
       for (const { address, name, ok } of nameResults) {
         if (ok) {
-          nameCache.set(address, name);
+          cacheSet(nameCache, address, name);
         }
       }
 
@@ -110,7 +125,7 @@ export function useEnsResolution(
 
         for (const { address, avatar, ok } of avatarResults) {
           if (ok) {
-            avatarCache.set(address, avatar);
+            cacheSet(avatarCache, address, avatar);
           }
         }
       }

--- a/src/hooks/useProfileDisplayName.ts
+++ b/src/hooks/useProfileDisplayName.ts
@@ -11,7 +11,9 @@ export function useProfileDisplayName(): {
   const [profileLoaded, setProfileLoaded] = useState(false);
 
   const addresses = useMemo(() => (address ? [address] : []), [address]);
-  const { ensByAddress, isLoading: ensLoading } = useEnsResolution(addresses);
+  const { ensByAddress, isLoading: ensLoading } = useEnsResolution(addresses, {
+    avatars: false,
+  });
   const ensName = address
     ? (ensByAddress?.[address.toLowerCase()]?.name ?? null)
     : null;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -28,6 +28,16 @@ export function truncateAddress(address: string): string {
   return `${address.slice(0, 6)}…${address.slice(-4)}`;
 }
 
+// The one place that defines the display-name fallback order:
+// profile name, then ENS name, then the truncated address.
+export function resolveDisplayName(
+  profileName: string | null | undefined,
+  ensName: string | null | undefined,
+  address: string,
+): string {
+  return profileName || ensName || truncateAddress(address);
+}
+
 export function extractGithubUsername(url: string) {
   if (!url) {
     return null;


### PR DESCRIPTION
Anywhere the app renders a wallet's platform name, the display now falls back to its ENS name before the truncated address, matching what the comms feeds and the Permissions table already do. Order everywhere: platform name, then ENS name, then truncated address.

## Changes
- Voter table (Flow Councils membership): the Name column now falls back to ENS when a voter has no platform profile name. ENS resolution is scoped to the visible page (up to 50 rows) so a large roster does not fan out thousands of mainnet reverse lookups.
- Public profile page (`/profile/[address]`): the heading falls back to ENS between the platform display name and the truncated address.

## Already correct (unchanged)
Permissions table, comms feed messages, `useProfileDisplayName`, and `AccountDropdown`.

## Out of scope
The flow-splitters and flow-guilds graphs and activity feeds resolve ENS but never use the platform name (the opposite gap), so they were left as-is.