### PR TITLE
fix: let returning builders see and edit their current-season milestones

### DIFF
--- a/src/app/api/flow-council/applications/[applicationId]/route.ts
+++ b/src/app/api/flow-council/applications/[applicationId]/route.ts
@@ -18,6 +18,7 @@ import {
 import { readJsonBody, PayloadTooLargeError } from "../../../utils";
 import { MINIMAL_TEMPLATE } from "@/app/flow-councils/types/formSchema";
 import { isDynamicApplicationDetails } from "@/app/flow-councils/utils/legacyFormAdapter";
+import { getStoredSection } from "@/app/api/flow-council/utils";
 
 export const dynamic = "force-dynamic";
 
@@ -210,6 +211,7 @@ export async function PATCH(
         "applications.roundId",
         "applications.status",
         "applications.editsUnlocked",
+        "applications.details as storedDetails",
       ])
       .where("applications.id", "=", appId)
       .where(
@@ -264,7 +266,11 @@ export async function PATCH(
           : null);
 
       if (roundSchema) {
-        const validation = validateDynamicRoundDetails(details, roundSchema);
+        const validation = validateDynamicRoundDetails(
+          details,
+          roundSchema,
+          getStoredSection(existingApp.storedDetails, "round"),
+        );
         if (!validation.success) {
           return new Response(
             JSON.stringify({ success: false, error: validation.error }),
@@ -277,6 +283,7 @@ export async function PATCH(
         const validation = validateDynamicAttestationDetails(
           details,
           attestationSchema,
+          getStoredSection(existingApp.storedDetails, "attestation"),
         );
         if (!validation.success) {
           return new Response(

--- a/src/app/api/flow-council/applications/route.ts
+++ b/src/app/api/flow-council/applications/route.ts
@@ -12,6 +12,7 @@ import {
 import { isRoundAdmin, hasOnChainRole } from "../auth";
 import { MINIMAL_TEMPLATE } from "@/app/flow-councils/types/formSchema";
 import { isDynamicApplicationDetails } from "@/app/flow-councils/utils/legacyFormAdapter";
+import { getStoredSection } from "../utils";
 
 export const dynamic = "force-dynamic";
 
@@ -281,6 +282,17 @@ export async function PUT(request: Request) {
         ? JSON.parse(round.details)
         : (round.details ?? {});
 
+    // Fetched before validation so milestone checks can compare submitted
+    // descriptions against what is already stored (unchanged ones pass).
+    const existingApplication = await db
+      .selectFrom("applications")
+      .select(["id", "status", "editsUnlocked", "details"])
+      .where("projectId", "=", projectId)
+      .where("roundId", "=", round.id)
+      .executeTakeFirst();
+
+    const storedRound = getStoredSection(existingApplication?.details, "round");
+
     // A round with a configured formSchema is always dynamic. Rounds without
     // one default to the Minimal template, so dynamic-shaped submissions
     // (carrying _formVersion) are dynamic too; legacy-shaped ones stay legacy.
@@ -305,6 +317,7 @@ export async function PUT(request: Request) {
         const validation = validateDynamicRoundDetails(
           details,
           roundDetails.formSchema?.round ?? MINIMAL_TEMPLATE.round,
+          storedRound,
         );
         if (!validation.success) {
           return new Response(
@@ -322,13 +335,6 @@ export async function PUT(request: Request) {
         }
       }
     }
-
-    const existingApplication = await db
-      .selectFrom("applications")
-      .select(["id", "status", "editsUnlocked"])
-      .where("projectId", "=", projectId)
-      .where("roundId", "=", round.id)
-      .executeTakeFirst();
 
     const LOCKED_STATUSES = ["ACCEPTED", "GRADUATED", "REMOVED"];
     if (

--- a/src/app/api/flow-council/projects/[projectId]/milestones/route.ts
+++ b/src/app/api/flow-council/projects/[projectId]/milestones/route.ts
@@ -429,7 +429,7 @@ export async function PATCH(request: Request, { params }: RouteParams) {
       }
 
       const storedMilestones = isDynamic
-        ? (appDetailsParsed as { round: Record<string, unknown> }).round[
+        ? (appDetailsParsed as { round?: Record<string, unknown> }).round?.[
             milestoneType
           ]
         : milestoneType === "build"

--- a/src/app/api/flow-council/projects/[projectId]/milestones/route.ts
+++ b/src/app/api/flow-council/projects/[projectId]/milestones/route.ts
@@ -5,8 +5,8 @@ import { isProjectManager } from "@/app/api/flow-council/auth";
 import { parseDetails } from "@/app/api/flow-council/utils";
 import {
   milestoneProgressSchema,
-  milestoneDefinitionSchema,
-  makeMilestoneDefinitionSchema,
+  pickMilestoneDefinitionSchema,
+  getStoredMilestoneDescription,
   MAX_STRING_LENGTH,
 } from "@/app/api/flow-council/validation";
 import { CHARACTER_LIMITS } from "@/app/flow-councils/constants";
@@ -24,6 +24,11 @@ import type {
 } from "@/app/projects/[id]/milestones/types";
 
 export const dynamic = "force-dynamic";
+
+// Graduated grantees are still active recipients (see the recipients route and
+// the review unlock route, which both treat GRADUATED like ACCEPTED), so their
+// milestones stay visible and editable.
+const ACTIVE_GRANTEE_STATUSES = ["ACCEPTED", "GRADUATED"] as const;
 
 type RouteParams = { params: Promise<{ projectId: string }> };
 
@@ -125,7 +130,8 @@ export async function GET(_request: Request, { params }: RouteParams) {
         "rounds.flowCouncilAddress as councilId",
       ])
       .where("applications.projectId", "=", pid)
-      .where("applications.status", "=", "ACCEPTED")
+      .where("applications.status", "in", ACTIVE_GRANTEE_STATUSES)
+      .orderBy("applications.roundId", "desc")
       .execute();
 
     if (applications.length === 0) {
@@ -251,9 +257,13 @@ export async function GET(_request: Request, { params }: RouteParams) {
 
 const MILESTONE_AUTHOR_ADDRESS = "0x0000000000000000000000000000000000000000";
 
+// Deep links carry the applicationId so the anchor stays unique when a
+// project has milestones in more than one round (legacy rounds share the
+// "build"/"growth" types, so type+index alone collides across rounds).
 function buildEvidencePostContent(
   verb: "added to" | "updated on",
   roundName: string,
+  applicationId: number,
   milestoneType: string,
   typeLabel: string,
   milestoneIndex: number,
@@ -265,18 +275,19 @@ function buildEvidencePostContent(
 ): string {
   const header = `Evidence ${verb} ${roundName} - ${typeLabel} ${milestoneIndex + 1} - ${itemLabel} ${itemIndex + 1} (${completion}% Complete)`;
   const lines = evidence.map((e) => `- [${e.name}](${e.link})`);
-  return `${header}:\n\n${lines.join("\n")}\n\n[Go to the milestone](/projects/${pid}?tab=milestones&milestone=${milestoneType}-${milestoneIndex})`;
+  return `${header}:\n\n${lines.join("\n")}\n\n[Go to the milestone](/projects/${pid}?tab=milestones&milestone=${applicationId}-${milestoneType}-${milestoneIndex})`;
 }
 
 function buildTextUpdatePostContent(
   roundName: string,
+  applicationId: number,
   milestoneType: string,
   typeLabel: string,
   milestoneIndex: number,
   otherDetails: string,
   pid: number,
 ): string {
-  return `Details updated on ${roundName} - ${typeLabel} ${milestoneIndex + 1}:\n\n${otherDetails}\n\n[Go to the milestone](/projects/${pid}?tab=milestones&milestone=${milestoneType}-${milestoneIndex})`;
+  return `Details updated on ${roundName} - ${typeLabel} ${milestoneIndex + 1}:\n\n${otherDetails}\n\n[Go to the milestone](/projects/${pid}?tab=milestones&milestone=${applicationId}-${milestoneType}-${milestoneIndex})`;
 }
 
 export async function PATCH(request: Request, { params }: RouteParams) {
@@ -341,7 +352,7 @@ export async function PATCH(request: Request, { params }: RouteParams) {
       ])
       .where("id", "=", applicationId)
       .where("projectId", "=", pid)
-      .where("status", "=", "ACCEPTED")
+      .where("status", "in", ACTIVE_GRANTEE_STATUSES)
       .executeTakeFirst();
 
     if (!application) {
@@ -349,6 +360,18 @@ export async function PATCH(request: Request, { params }: RouteParams) {
         success: false,
         error: "Application not found or not accepted",
       });
+    }
+
+    // Graduated grants are a concluded record: visible on the tab, but any
+    // write (progress or definition) requires the admin to unlock edits.
+    if (application.status === "GRADUATED" && !application.editsUnlocked) {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: "Edits are not unlocked for this application",
+        }),
+        { status: 403 },
+      );
     }
 
     const appDetailsParsed = parseDetails<RoundForm & DynamicAppDetails>(
@@ -405,18 +428,31 @@ export async function PATCH(request: Request, { params }: RouteParams) {
         );
       }
 
-      // Dynamic milestones honor the per-element descriptionMin/MaxChars
-      // configured in the round's formSchema. Falling back to the legacy
-      // 500–5000 bounds here would lock applicants out of editing data they
-      // were allowed to submit (e.g. an admin-configured 100–8000 range).
-      const definitionSchema = dynamicMilestoneElement
-        ? makeMilestoneDefinitionSchema({
-            descriptionMinChars:
-              dynamicMilestoneElement.descriptionMinChars ?? 0,
-            descriptionMaxChars:
-              dynamicMilestoneElement.descriptionMaxChars ?? MAX_STRING_LENGTH,
-          })
-        : milestoneDefinitionSchema;
+      const storedMilestones = isDynamic
+        ? (appDetailsParsed as { round: Record<string, unknown> }).round[
+            milestoneType
+          ]
+        : milestoneType === "build"
+          ? (appDetailsParsed as RoundForm)?.buildGoals?.milestones
+          : (appDetailsParsed as RoundForm)?.growthGoals?.milestones;
+      const storedDescription = getStoredMilestoneDescription(
+        storedMilestones,
+        milestoneIndex,
+      );
+      const descriptionUnchanged =
+        storedDescription !== undefined &&
+        (definition as { description?: unknown })?.description ===
+          storedDescription;
+
+      // Descriptions are mandatory, enforced as a ratchet: an unchanged stored
+      // description (e.g. an empty one left by the round-49 backfill) never
+      // blocks saving the rest of the definition, but any edited description
+      // must be non-empty and honor the per-element descriptionMin/MaxChars
+      // from the round's formSchema (legacy apps use the 500-5000 bounds).
+      const definitionSchema = pickMilestoneDefinitionSchema(
+        dynamicMilestoneElement,
+        descriptionUnchanged,
+      );
       const parsedDef = definitionSchema.safeParse(definition);
       if (!parsedDef.success) {
         return Response.json({
@@ -580,6 +616,7 @@ export async function PATCH(request: Request, { params }: RouteParams) {
           buildEvidencePostContent(
             verb,
             roundName,
+            applicationId,
             milestoneType,
             typeLabel,
             milestoneIndex,
@@ -600,6 +637,7 @@ export async function PATCH(request: Request, { params }: RouteParams) {
       feedMessages.push(
         buildTextUpdatePostContent(
           roundName,
+          applicationId,
           milestoneType,
           typeLabel,
           milestoneIndex,

--- a/src/app/api/flow-council/utils.ts
+++ b/src/app/api/flow-council/utils.ts
@@ -14,3 +14,17 @@ export function parseDetails<T>(raw: unknown): T | null {
   }
   return raw as T;
 }
+
+// Extracts a stored application's round/attestation section for the milestone
+// ratchet, tolerating malformed details (returns undefined instead of
+// throwing).
+export function getStoredSection(
+  details: unknown,
+  key: "round" | "attestation",
+): Record<string, unknown> | undefined {
+  const parsed = parseDetails<Record<string, unknown>>(details);
+  const section = parsed?.[key];
+  return section && typeof section === "object" && !Array.isArray(section)
+    ? (section as Record<string, unknown>)
+    : undefined;
+}

--- a/src/app/api/flow-council/validation.milestone.test.ts
+++ b/src/app/api/flow-council/validation.milestone.test.ts
@@ -281,6 +281,182 @@ describe("validateDynamicRoundDetails — milestone entry field presence", () =>
 });
 
 // ---------------------------------------------------------------------------
+// Section 3b: mandatory descriptions with a stored-state ratchet
+// ---------------------------------------------------------------------------
+
+describe("validateDynamicRoundDetails — description ratchet against stored data", () => {
+  it("rejects an empty description on new submissions even when descriptionMinChars is not set", () => {
+    const result = validateDynamicRoundDetails(
+      {
+        round: {
+          [MILESTONE_UUID]: [validMilestoneEntry({ description: "" })],
+        },
+      },
+      [minimalMilestoneElement() as FormElement],
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toMatch(/description is required/i);
+    }
+  });
+
+  it("accepts an empty description when the stored milestone's description is also empty", () => {
+    const stored = {
+      [MILESTONE_UUID]: [validMilestoneEntry({ description: "" })],
+    };
+    const result = validateDynamicRoundDetails(
+      {
+        round: {
+          [MILESTONE_UUID]: [validMilestoneEntry({ description: "" })],
+        },
+      },
+      [minimalMilestoneElement() as FormElement],
+      stored,
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects blanking a stored non-empty description", () => {
+    const stored = {
+      [MILESTONE_UUID]: [validMilestoneEntry({ description: "existing" })],
+    };
+    const result = validateDynamicRoundDetails(
+      {
+        round: {
+          [MILESTONE_UUID]: [validMilestoneEntry({ description: "" })],
+        },
+      },
+      [minimalMilestoneElement() as FormElement],
+      stored,
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts an unchanged stored description that is shorter than descriptionMinChars", () => {
+    const element = { ...fullMilestoneElement(), minCount: 1 };
+    const stored = {
+      [MILESTONE_UUID]: [validMilestoneEntry({ description: "short" })],
+    };
+    const result = validateDynamicRoundDetails(
+      {
+        round: {
+          [MILESTONE_UUID]: [validMilestoneEntry({ description: "short" })],
+        },
+      },
+      [element as FormElement],
+      stored,
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an edited description that violates descriptionMinChars even when the stored one was empty", () => {
+    const element = { ...fullMilestoneElement(), minCount: 1 };
+    const stored = {
+      [MILESTONE_UUID]: [validMilestoneEntry({ description: "" })],
+    };
+    const result = validateDynamicRoundDetails(
+      {
+        round: {
+          [MILESTONE_UUID]: [validMilestoneEntry({ description: "too short" })],
+        },
+      },
+      [element as FormElement],
+      stored,
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("requires a description for milestones added beyond the stored list", () => {
+    const stored = {
+      [MILESTONE_UUID]: [validMilestoneEntry({ description: "" })],
+    };
+    const result = validateDynamicRoundDetails(
+      {
+        round: {
+          [MILESTONE_UUID]: [
+            validMilestoneEntry({ description: "" }),
+            validMilestoneEntry({ description: "" }),
+          ],
+        },
+      },
+      [minimalMilestoneElement() as FormElement],
+      stored,
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("grandfathers unchanged descriptions when an earlier milestone is removed", () => {
+    const element = { ...fullMilestoneElement(), minCount: 1 };
+    const stored = {
+      [MILESTONE_UUID]: [
+        validMilestoneEntry(),
+        validMilestoneEntry({ description: "short" }),
+      ],
+    };
+    const result = validateDynamicRoundDetails(
+      {
+        round: {
+          [MILESTONE_UUID]: [validMilestoneEntry({ description: "short" })],
+        },
+      },
+      [element as FormElement],
+      stored,
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("reports the configured item label and 1-based item index in item errors", () => {
+    const element = { ...fullMilestoneElement(), minCount: 1 };
+    const result = validateDynamicRoundDetails(
+      {
+        round: {
+          [MILESTONE_UUID]: [
+            validMilestoneEntry({ items: ["Valid item", ""] }),
+          ],
+        },
+      },
+      [element as FormElement],
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("Build Milestone 1: Deliverable 2 is required");
+    }
+  });
+
+  it("prefixes per-milestone errors with the milestone label and 1-based index", () => {
+    const element = { ...fullMilestoneElement(), minCount: 1 };
+    const result = validateDynamicRoundDetails(
+      {
+        round: {
+          [MILESTONE_UUID]: [
+            validMilestoneEntry(),
+            validMilestoneEntry({ description: "" }),
+          ],
+        },
+      },
+      [element as FormElement],
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toMatch(/^Build Milestone 2: /);
+    }
+  });
+
+  it("rejects a whitespace-only title", () => {
+    const element = { ...fullMilestoneElement(), minCount: 1 };
+    const result = validateDynamicRoundDetails(
+      {
+        round: {
+          [MILESTONE_UUID]: [validMilestoneEntry({ title: "   " })],
+        },
+      },
+      [element as FormElement],
+    );
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Section 4: descriptionMinChars / descriptionMaxChars
 // ---------------------------------------------------------------------------
 

--- a/src/app/api/flow-council/validation.ts
+++ b/src/app/api/flow-council/validation.ts
@@ -220,12 +220,29 @@ export const milestoneProgressSchema = z.object({
   items: z.array(deliverableProgressSchema),
 });
 
+// Single source of truth for what a valid milestone value looks like. Both
+// write paths (full-application PUT via validateDynamicRoundDetails and the
+// Milestones-tab PATCH) must use this so data saved through one path never
+// becomes uneditable through the other.
+//
+// Descriptions are mandatory, but enforced as a ratchet: a description that is
+// unchanged from what is already stored is accepted even if it violates the
+// current rules (callers express this by validating with descriptionRequired:
+// false and relaxed bounds). Anything the caller is actually changing must
+// comply. This lets grantees fix legacy rows with empty descriptions without
+// letting anyone blank a description or create a new milestone without one.
 export function makeMilestoneDefinitionSchema(opts: {
   descriptionMinChars: number;
   descriptionMaxChars: number;
+  descriptionRequired: boolean;
+  itemLabel?: string;
 }) {
+  const itemLabel = opts.itemLabel ?? "Item";
   return z.object({
-    title: z.string().min(1, "Title is required").max(200),
+    title: z
+      .string()
+      .max(200, "Title exceeds 200 characters")
+      .refine((title) => title.trim() !== "", "Title is required"),
     description: z
       .string()
       .min(
@@ -235,20 +252,89 @@ export function makeMilestoneDefinitionSchema(opts: {
       .max(
         opts.descriptionMaxChars,
         `Description must be at most ${opts.descriptionMaxChars} characters`,
+      )
+      .refine(
+        (description) => !opts.descriptionRequired || description.trim() !== "",
+        {
+          message: "Description is required",
+        },
       ),
     items: z
-      .array(z.string().max(500))
-      .max(50)
-      .refine((items) => items.some((item) => item.trim() !== ""), {
-        message: "At least one item is required",
+      .array(z.string())
+      .min(1, `At least one ${itemLabel} is required`)
+      .max(50, `At most 50 ${itemLabel}s are allowed`)
+      .superRefine((items, ctx) => {
+        items.forEach((item, i) => {
+          if (item.trim() === "") {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: `${itemLabel} ${i + 1} is required`,
+              path: [i],
+            });
+          } else if (item.length > 500) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: `${itemLabel} ${i + 1} exceeds 500 characters`,
+              path: [i],
+            });
+          }
+        });
       }),
   });
+}
+
+// Describes the stored counterpart of a submitted milestone so validation can
+// tell edits from unchanged carry-overs. A stored entry without a string
+// description counts as an empty one, matching how the milestones GET coerces
+// it for clients.
+export function getStoredMilestoneDescription(
+  storedValue: unknown,
+  index: number,
+): string | undefined {
+  if (!Array.isArray(storedValue)) return undefined;
+  const stored = storedValue[index];
+  if (!stored || typeof stored !== "object") return undefined;
+  const description = (stored as { description?: unknown }).description;
+  return typeof description === "string" ? description : "";
 }
 
 export const milestoneDefinitionSchema = makeMilestoneDefinitionSchema({
   descriptionMinChars: CHARACTER_LIMITS.milestoneDescription.min,
   descriptionMaxChars: CHARACTER_LIMITS.milestoneDescription.max,
+  descriptionRequired: true,
 });
+
+// Chooses the schema for a single milestone definition write. Shared by the
+// full-application validator and the Milestones-tab PATCH so the ratchet rule
+// cannot drift between the two write paths: unchanged descriptions validate
+// leniently, edited ones against the element's bounds (or the legacy bounds
+// when there is no dynamic element).
+export function pickMilestoneDefinitionSchema(
+  element:
+    | {
+        descriptionMinChars?: number;
+        descriptionMaxChars?: number;
+        itemLabel?: string;
+      }
+    | undefined,
+  descriptionUnchanged: boolean,
+) {
+  if (descriptionUnchanged) {
+    return makeMilestoneDefinitionSchema({
+      descriptionMinChars: 0,
+      descriptionMaxChars: MAX_STRING_LENGTH,
+      descriptionRequired: false,
+      itemLabel: element?.itemLabel,
+    });
+  }
+  if (!element) return milestoneDefinitionSchema;
+  return makeMilestoneDefinitionSchema({
+    descriptionMinChars: element.descriptionMinChars ?? 0,
+    descriptionMaxChars: element.descriptionMaxChars ?? MAX_STRING_LENGTH,
+    descriptionRequired: true,
+    itemLabel: element.itemLabel,
+  });
+}
 
 export const reactionEmojiSchema = z.enum(ALLOWED_REACTIONS);
 
@@ -428,7 +514,11 @@ export type FormElement = z.infer<typeof formElementSchema>;
 
 export const MAX_DETAILS_SIZE = 512_000; // 512 KB
 
-type FieldValidator = (val: unknown, el: FormElement) => string | null;
+type FieldValidator = (
+  val: unknown,
+  el: FormElement,
+  storedVal?: unknown,
+) => string | null;
 
 function checkStringWithLimit(val: unknown, el: FormElement): string | null {
   if (typeof val !== "string") return `"${el.label}" must be text`;
@@ -502,7 +592,7 @@ const VALIDATORS: Partial<Record<FormElement["type"], FieldValidator>> = {
       : null,
   boolean: (val, el) =>
     typeof val !== "boolean" ? `"${el.label}" must be true or false` : null,
-  milestone: (val, el) => {
+  milestone: (val, el, storedVal) => {
     const minCount = el.minCount ?? 1;
     const milestoneLabel = el.milestoneLabel || el.label || "Milestone";
     if (!Array.isArray(val)) {
@@ -514,51 +604,39 @@ const VALIDATORS: Partial<Record<FormElement["type"], FieldValidator>> = {
     if (val.length > MAX_MILESTONES) {
       return `"${el.label}" allows at most ${MAX_MILESTONES} milestones`;
     }
+    // Grandfathering is a multiset over the stored descriptions, not an
+    // index-by-index comparison: each stored description covers one incoming
+    // milestone, so removing or reordering milestones never re-triggers
+    // validation on descriptions the caller didn't touch, and net-new
+    // milestones cannot inherit another row's exemption.
+    const storedDescriptionCounts = new Map<string, number>();
+    if (Array.isArray(storedVal)) {
+      for (let i = 0; i < storedVal.length; i++) {
+        const stored = getStoredMilestoneDescription(storedVal, i);
+        if (stored !== undefined) {
+          storedDescriptionCounts.set(
+            stored,
+            (storedDescriptionCounts.get(stored) ?? 0) + 1,
+          );
+        }
+      }
+    }
     for (let i = 0; i < val.length; i++) {
-      const m = val[i] as {
-        title?: unknown;
-        description?: unknown;
-        items?: unknown;
-      };
-      if (!m || typeof m !== "object") {
-        return `${milestoneLabel} ${i + 1} is malformed`;
+      const entry = val[i] as { description?: unknown } | null;
+      const description =
+        typeof entry?.description === "string" ? entry.description : undefined;
+      const remaining =
+        description !== undefined
+          ? (storedDescriptionCounts.get(description) ?? 0)
+          : 0;
+      const descriptionUnchanged = remaining > 0;
+      if (descriptionUnchanged && description !== undefined) {
+        storedDescriptionCounts.set(description, remaining - 1);
       }
-      if (typeof m.title !== "string" || m.title.trim() === "") {
-        return `${milestoneLabel} ${i + 1} title is required`;
-      }
-      if (m.title.length > 200) {
-        return `${milestoneLabel} ${i + 1} title exceeds 200 characters`;
-      }
-      if (typeof m.description !== "string" || m.description.trim() === "") {
-        return `${milestoneLabel} ${i + 1} description is required`;
-      }
-      if (
-        typeof el.descriptionMinChars === "number" &&
-        m.description.length < el.descriptionMinChars
-      ) {
-        return `${milestoneLabel} ${i + 1} description must be at least ${el.descriptionMinChars} characters`;
-      }
-      const descMax =
-        typeof el.descriptionMaxChars === "number"
-          ? el.descriptionMaxChars
-          : MAX_STRING_LENGTH;
-      if (m.description.length > descMax) {
-        return `${milestoneLabel} ${i + 1} description exceeds ${descMax} characters`;
-      }
-      if (!Array.isArray(m.items) || m.items.length === 0) {
-        return `${milestoneLabel} ${i + 1} requires at least one ${el.itemLabel ?? "item"}`;
-      }
-      if (m.items.length > 50) {
-        return `${milestoneLabel} ${i + 1} allows at most 50 ${el.itemLabel ?? "item"}s`;
-      }
-      for (let j = 0; j < m.items.length; j++) {
-        const item = m.items[j];
-        if (typeof item !== "string" || item.trim() === "") {
-          return `${milestoneLabel} ${i + 1} ${el.itemLabel ?? "item"} ${j + 1} is required`;
-        }
-        if (item.length > 500) {
-          return `${milestoneLabel} ${i + 1} ${el.itemLabel ?? "item"} ${j + 1} exceeds 500 characters`;
-        }
+      const schema = pickMilestoneDefinitionSchema(el, descriptionUnchanged);
+      const parsed = schema.safeParse(val[i]);
+      if (!parsed.success) {
+        return `${milestoneLabel} ${i + 1}: ${parsed.error.issues[0].message}`;
       }
     }
     return null;
@@ -569,6 +647,7 @@ function validateFormSection(
   values: Record<string, unknown>,
   formElements: FormElement[],
   sectionLabel: string,
+  storedValues?: Record<string, unknown>,
 ): ValidationResult<Record<string, unknown>> {
   const allowedIds = new Set<string>();
 
@@ -595,7 +674,7 @@ function validateFormSection(
 
     const validator = VALIDATORS[el.type];
     if (validator) {
-      const err = validator(val, el);
+      const err = validator(val, el, storedValues?.[el.id]);
       if (err) return { success: false, error: err };
     }
   }
@@ -612,9 +691,13 @@ function validateFormSection(
   return { success: true, data: values };
 }
 
+// storedData is the same section object from the application row currently in
+// the database (if any); it lets milestone validation grandfather unchanged
+// descriptions instead of rejecting rows the caller never touched.
 export function validateDynamicRoundDetails(
   data: Record<string, unknown>,
   formElements: FormElement[],
+  storedData?: Record<string, unknown>,
 ): ValidationResult<Record<string, unknown>> {
   if (JSON.stringify(data).length > MAX_DETAILS_SIZE) {
     return { success: false, error: "Payload too large" };
@@ -629,12 +712,14 @@ export function validateDynamicRoundDetails(
     values as Record<string, unknown>,
     formElements,
     "round",
+    storedData,
   );
 }
 
 export function validateDynamicAttestationDetails(
   data: Record<string, unknown>,
   formElements: FormElement[],
+  storedData?: Record<string, unknown>,
 ): ValidationResult<Record<string, unknown>> {
   if (JSON.stringify(data).length > MAX_DETAILS_SIZE) {
     return { success: false, error: "Payload too large" };
@@ -649,6 +734,7 @@ export function validateDynamicAttestationDetails(
     values as Record<string, unknown>,
     formElements,
     "attestation",
+    storedData,
   );
 }
 

--- a/src/app/flow-councils/application/[chainId]/[councilId]/[projectId]/application.tsx
+++ b/src/app/flow-councils/application/[chainId]/[councilId]/[projectId]/application.tsx
@@ -22,9 +22,11 @@ import type {
   AttestationForm,
 } from "@/app/flow-councils/types/round";
 import {
+  type FormElement,
   type FormSchema,
   MINIMAL_TEMPLATE,
 } from "@/app/flow-councils/types/formSchema";
+import type { DynamicMilestoneValue } from "@/app/flow-councils/components/DynamicMilestoneInput";
 import {
   getApplicationAsDynamic,
   isDynamicApplicationDetails,
@@ -58,6 +60,35 @@ function stableStringify(value: unknown): string {
         )
       : val,
   );
+}
+
+// Blank deliverable rows (e.g. an extra "Add Deliverable" click) are valid
+// while typing but rejected by the server, so drop them at save time, the
+// same behavior as the Milestones-tab definition editor. Non-string rows
+// (possible in an old or hand-edited local draft) are kept for the server to
+// reject with a clear error instead of throwing here.
+function withBlankMilestoneItemsRemoved(
+  values: Record<string, unknown>,
+  elements: FormElement[],
+): Record<string, unknown> {
+  const sanitized = { ...values };
+  for (const element of elements) {
+    if (element.type !== "milestone") continue;
+    const value = sanitized[element.id];
+    if (!Array.isArray(value)) continue;
+    sanitized[element.id] = (value as DynamicMilestoneValue[]).map(
+      (milestone) =>
+        milestone && Array.isArray(milestone.items)
+          ? {
+              ...milestone,
+              items: milestone.items.filter(
+                (item) => typeof item !== "string" || item.trim() !== "",
+              ),
+            }
+          : milestone,
+    );
+  }
+  return sanitized;
 }
 
 function FormSkeleton() {
@@ -507,6 +538,15 @@ export default function Application(props: ApplicationProps) {
     setDynamicSaving(true);
 
     try {
+      const round = withBlankMilestoneItemsRemoved(
+        dynamicRoundValues,
+        formSchema?.round ?? [],
+      );
+      const attestation = withBlankMilestoneItemsRemoved(
+        dynamicAttestationValues,
+        formSchema?.attestation ?? [],
+      );
+
       const res = await fetch("/api/flow-council/applications", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
@@ -516,8 +556,8 @@ export default function Application(props: ApplicationProps) {
           councilId,
           details: {
             _formVersion: FORM_VERSION,
-            round: dynamicRoundValues,
-            attestation: dynamicAttestationValues,
+            round,
+            attestation,
           },
           fundingAddress: dynamicFundingAddress,
         }),
@@ -533,9 +573,11 @@ export default function Application(props: ApplicationProps) {
       if (json.application?.id) {
         setApplicationId(json.application.id);
       }
+      setDynamicRoundValues(round);
+      setDynamicAttestationValues(attestation);
       serverBaselineRef.current = {
-        round: dynamicRoundValues,
-        attestation: dynamicAttestationValues,
+        round,
+        attestation,
         fundingAddress: dynamicFundingAddress,
       };
       setDraftRestored(false);
@@ -564,8 +606,14 @@ export default function Application(props: ApplicationProps) {
           body: JSON.stringify({
             details: {
               _formVersion: FORM_VERSION,
-              round: dynamicRoundValues,
-              attestation: dynamicAttestationValues,
+              round: withBlankMilestoneItemsRemoved(
+                dynamicRoundValues,
+                formSchema?.round ?? [],
+              ),
+              attestation: withBlankMilestoneItemsRemoved(
+                dynamicAttestationValues,
+                formSchema?.attestation ?? [],
+              ),
             },
             fundingAddress: dynamicFundingAddress,
             submit: true,
@@ -728,6 +776,7 @@ export default function Application(props: ApplicationProps) {
                   <DynamicFormSection
                     elements={formSchema.round}
                     values={dynamicRoundValues}
+                    baselineValues={serverBaselineRef.current.round}
                     onChange={handleDynamicRoundChange}
                     validated={dynamicValidated}
                     lockBlockCount={isInLockedStatus && editsUnlocked}
@@ -811,6 +860,7 @@ export default function Application(props: ApplicationProps) {
                   <DynamicFormSection
                     elements={formSchema.attestation}
                     values={dynamicAttestationValues}
+                    baselineValues={serverBaselineRef.current.attestation}
                     onChange={handleDynamicAttestationChange}
                     validated={dynamicValidated}
                     lockBlockCount={isInLockedStatus && editsUnlocked}

--- a/src/app/flow-councils/components/DynamicFormSection.tsx
+++ b/src/app/flow-councils/components/DynamicFormSection.tsx
@@ -16,6 +16,9 @@ import type { FormElement } from "@/app/flow-councils/types/formSchema";
 type Props = {
   elements: FormElement[];
   values: Record<string, unknown>;
+  // Server-stored values, used by milestone questions to tell edited
+  // descriptions from unchanged ones (the validation ratchet).
+  baselineValues?: Record<string, unknown>;
   onChange?: (id: string, value: unknown) => void;
   validated?: boolean;
   readOnly?: boolean;
@@ -26,6 +29,7 @@ type Props = {
 export default function DynamicFormSection({
   elements,
   values,
+  baselineValues,
   onChange,
   validated = false,
   readOnly = false,
@@ -448,11 +452,17 @@ export default function DynamicFormSection({
             const milestoneValues: DynamicMilestoneValue[] = Array.isArray(raw)
               ? (raw as DynamicMilestoneValue[])
               : [];
+            const storedRaw = baselineValues?.[el.id];
             return (
               <DynamicMilestoneInput
                 key={el.id}
                 element={el}
                 values={milestoneValues}
+                storedValues={
+                  Array.isArray(storedRaw)
+                    ? (storedRaw as DynamicMilestoneValue[])
+                    : undefined
+                }
                 onChange={(v) => handleChange(el.id, v)}
                 validated={validated}
                 readOnly={readOnly}

--- a/src/app/flow-councils/components/DynamicMilestoneInput.tsx
+++ b/src/app/flow-councils/components/DynamicMilestoneInput.tsx
@@ -19,6 +19,9 @@ export type DynamicMilestoneValue = {
 type Props = {
   element: MilestoneQuestion;
   values: DynamicMilestoneValue[];
+  // Server-stored milestones, used to tell edited descriptions from unchanged
+  // ones. Absent for new applications (everything validates strictly).
+  storedValues?: DynamicMilestoneValue[];
   onChange: (values: DynamicMilestoneValue[]) => void;
   validated: boolean;
   readOnly?: boolean;
@@ -34,6 +37,7 @@ export default function DynamicMilestoneInput(props: Props) {
   const {
     element,
     values,
+    storedValues,
     onChange,
     validated,
     readOnly = false,
@@ -56,6 +60,29 @@ export default function DynamicMilestoneInput(props: Props) {
       ...Array.from({ length: minCount - values.length }, emptyMilestone),
     ];
   }, [values, minCount]);
+
+  // Mirrors the server's ratchet: each server-stored description covers one
+  // block (a multiset, so reordering or removing blocks keeps untouched
+  // descriptions covered), while edited or net-new descriptions must be
+  // non-empty and within the configured bounds.
+  const descUnchangedFlags = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const stored of storedValues ?? []) {
+      const description =
+        stored && typeof stored.description === "string"
+          ? stored.description
+          : "";
+      counts.set(description, (counts.get(description) ?? 0) + 1);
+    }
+    return blocks.map((milestone) => {
+      const remaining = counts.get(milestone.description) ?? 0;
+      if (remaining > 0) {
+        counts.set(milestone.description, remaining - 1);
+        return true;
+      }
+      return false;
+    });
+  }, [blocks, storedValues]);
 
   const updateMilestone = (index: number, next: DynamicMilestoneValue) => {
     const copy = [...blocks];
@@ -109,6 +136,7 @@ export default function DynamicMilestoneInput(props: Props) {
         </Form.Label>
       )}
       {blocks.map((milestone, i) => {
+        const descUnchanged = descUnchangedFlags[i];
         const descTooShort =
           typeof element.descriptionMinChars === "number" &&
           milestone.description.length > 0 &&
@@ -118,6 +146,7 @@ export default function DynamicMilestoneInput(props: Props) {
           milestone.description.length > element.descriptionMaxChars;
         const descInvalid =
           validated &&
+          !descUnchanged &&
           (!milestone.description.trim() || descTooShort || descTooLong);
         const titleInvalid = validated && !milestone.title.trim();
         const hasValidItem = milestone.items.some((it) => it.trim() !== "");

--- a/src/app/projects/[id]/milestones/MilestoneCard.tsx
+++ b/src/app/projects/[id]/milestones/MilestoneCard.tsx
@@ -237,13 +237,18 @@ function DefinitionEditForm({
   const descMax = milestone.descriptionMaxChars;
 
   const isTitleEmpty = !title.trim();
-  const isDescriptionShort = description.length < descMin;
-  const isDescriptionLong = description.length > descMax;
+  // Ratchet rule (mirrors the server): an unchanged description never blocks
+  // the save, an edited one must be non-empty and within bounds.
+  const descriptionChanged = description !== milestone.description;
+  const isDescriptionInvalid =
+    descriptionChanged &&
+    (!description.trim() ||
+      description.length < descMin ||
+      description.length > descMax);
   const hasValidItem = items.some((item) => item.trim() !== "");
 
   const titleInvalid = validated && isTitleEmpty;
-  const descriptionInvalid =
-    validated && (isDescriptionShort || isDescriptionLong);
+  const descriptionInvalid = validated && isDescriptionInvalid;
   const itemsInvalid = validated && !hasValidItem;
 
   const handleItemChange = (index: number, value: string) => {
@@ -261,13 +266,7 @@ function DefinitionEditForm({
 
   const handleSubmit = () => {
     setValidated(true);
-    if (
-      isTitleEmpty ||
-      isDescriptionShort ||
-      isDescriptionLong ||
-      !hasValidItem
-    )
-      return;
+    if (isTitleEmpty || isDescriptionInvalid || !hasValidItem) return;
     onSave({ title, description, items });
   };
 
@@ -506,7 +505,7 @@ export default function MilestoneCard({
 
   return (
     <div
-      id={`milestone-${milestone.type}-${milestone.index}`}
+      id={`milestone-${applicationId}-${milestone.type}-${milestone.index}`}
       className={`border rounded-4 overflow-hidden mb-4 ${editingDefinition ? "border-primary border-2" : "border border-2"}`}
     >
       <div className="bg-secondary d-flex flex-column flex-sm-row justify-content-between align-items-sm-center gap-1 px-3 px-sm-4 py-3">

--- a/src/app/projects/[id]/milestones/ProjectMilestonesTab.tsx
+++ b/src/app/projects/[id]/milestones/ProjectMilestonesTab.tsx
@@ -44,7 +44,12 @@ export default function ProjectMilestonesTab({
 
   useEffect(() => {
     if (!isLoading && scrollToMilestone && applications.length > 0) {
-      const el = document.getElementById(`milestone-${scrollToMilestone}`);
+      // New links carry "<applicationId>-<type>-<index>" and match the card id
+      // exactly; links from before applicationId was included fall back to a
+      // suffix match (first card wins, as before).
+      const el =
+        document.getElementById(`milestone-${scrollToMilestone}`) ??
+        document.querySelector(`[id$="-${CSS.escape(scrollToMilestone)}"]`);
       if (el) {
         const timeout = setTimeout(
           () => el.scrollIntoView({ behavior: "smooth", block: "center" }),


### PR DESCRIPTION
## Problem
GoodBuilders S3 builders now in S4 reported the Milestones tab kept showing their old Season 3 milestones and that they could not edit.

- The application-form save re-validated every milestone with an unconditional "description required" rule, while the round-49 textarea-to-milestone backfill left descriptions empty. Any full-form save failed on fields the builder never touched, and the milestones-tab PATCH (which allows empty descriptions when the element sets no minimum) disagreed with the PUT about the validity of the same stored data.
- The milestones GET had no ordering, so the Season 3 section often rendered above Season 4.
- The client tolerated blank deliverable rows that the server rejected, so a save could fail with no visible invalid field.

## Fix
- One shared schema (makeMilestoneDefinitionSchema via pickMilestoneDefinitionSchema) now defines milestone validity for the application PUT, the single-application PATCH, and the milestones-tab PATCH, so the write paths cannot drift.
- Descriptions are mandatory, enforced as a ratchet: a description matching one still stored for that question is grandfathered (multiset matching, so adding, removing, or reordering milestones never re-triggers validation on untouched rows and net-new milestones cannot inherit an exemption); any edited or new description must be non-empty and honor the element's configured bounds. Both client forms mirror the rule against the server-stored baseline.
- Milestones tab orders newest round first; GRADUATED applications stay visible and become writable only when the admin unlocks edits (previously they silently vanished from the tab).
- Milestone deep links and card DOM ids now include the applicationId so multi-round projects cannot collide; pre-existing links resolve via a suffix-match fallback.
- Blank deliverable rows are stripped at save time (matching the milestones-tab editor), and item validation errors regained the configured item label and 1-based row index.

## Verification
- Unit 313 passed, integration 141 passed, typecheck / lint / prettier clean.
- Multi-agent adversarial review at high effort; all confirmed findings fixed (index-shift ratchet mismatch, GRADUATED write gate, draft-contaminated client baseline, duplicate DOM ids, error-message regression, unguarded stored-details parsing, exception path in the save handler).

Known edge left as is: stored legacy milestones containing blank item rows would fail an unchanged resubmit, but that is only reachable via raw API clients since both UIs filter blank rows before sending.