### PR TITLE
test: serialize test runs on the shared database with an advisory lock

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -66,6 +66,28 @@ pnpm test:live
 The base URL defaults to `http://localhost:3000`. Override with `E2E_BASE_URL`
 to point at a deployed preview instead.
 
+## The shared test database lock
+
+`TEST_DATABASE_URL` points at one Neon database that every local run and every
+CI job shares. Both suites seed it and reset it with `truncate ... cascade`, so
+two runs at once corrupt each other — the tell is a missing seeded row, or a
+duplicate-key/foreign-key error in a test your change never touched.
+
+To prevent that, `globalSetup` takes a Postgres advisory lock and holds it for
+the run. A second run waits instead of clobbering the first, logging:
+
+```
+waiting for the shared test database — held by test-db-lock:vitest-integration, connected 00:00:12
+```
+
+It gives up after 10 minutes (`TEST_DB_LOCK_TIMEOUT_MS` to change that). The
+lock lives on a session, so a crashed or killed run releases it automatically.
+
+The lock sits on a direct connection, not the pooled `-pooler` endpoint:
+PgBouncer runs in transaction mode there, where session-level advisory locks are
+silently lost. Only runs that have this code participate, so a branch predating
+it can still clobber a locked run.
+
 ## How the mock wallet works
 
 `global.ts` seeds the database once before the test run and writes a fixture

--- a/tests/e2e/setup/global.ts
+++ b/tests/e2e/setup/global.ts
@@ -1,6 +1,7 @@
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
 import path from "node:path";
 import { getTestDb, resetDb } from "@tests/helpers/db";
+import { acquireTestDbLock } from "@tests/helpers/dbLock";
 import { seedE2eFixture } from "../helpers/e2eDb";
 import { FIXTURE_FILE } from "./fixtureFile";
 
@@ -32,6 +33,8 @@ export default async function globalSetup() {
       "NEXTAUTH_SECRET is not set — required for SIWE sign-in during E2E",
     );
   }
+
+  await acquireTestDbLock("playwright-e2e");
 
   // Reset before seeding: a prior run's teardown may have been skipped (CI
   // timeout, process crash), leaving rows that would collide on unique

--- a/tests/e2e/setup/teardown.ts
+++ b/tests/e2e/setup/teardown.ts
@@ -1,4 +1,5 @@
 import { rmSync } from "node:fs";
+import { releaseTestDbLock } from "@tests/helpers/dbLock";
 import { teardownE2eDb } from "../helpers/e2eDb";
 import { FIXTURE_FILE } from "./fixtureFile";
 
@@ -8,5 +9,6 @@ export default async function globalTeardown() {
     await teardownE2eDb();
   } finally {
     rmSync(FIXTURE_FILE, { force: true });
+    await releaseTestDbLock();
   }
 }

--- a/tests/helpers/dbLock.ts
+++ b/tests/helpers/dbLock.ts
@@ -53,9 +53,14 @@ export async function acquireTestDbLock(label: string): Promise<void> {
     );
   }
 
-  const timeoutMs = Number(
-    process.env.TEST_DB_LOCK_TIMEOUT_MS ?? DEFAULT_TIMEOUT_MS,
-  );
+  // NaN would make every `Date.now() >= deadline` check false and spin forever.
+  const configuredTimeout = process.env.TEST_DB_LOCK_TIMEOUT_MS;
+  const timeoutMs = Number(configuredTimeout ?? DEFAULT_TIMEOUT_MS);
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new Error(
+      `TEST_DB_LOCK_TIMEOUT_MS must be a positive number of milliseconds, got ${configuredTimeout}`,
+    );
+  }
 
   const client = new Client({
     connectionString: directConnectionString(connectionString),

--- a/tests/helpers/dbLock.ts
+++ b/tests/helpers/dbLock.ts
@@ -1,0 +1,113 @@
+import { Client } from "@neondatabase/serverless";
+
+// Every local and CI test run contends on this one key. The value is arbitrary
+// but must never change, or old and new runs would stop excluding each other.
+const LOCK_KEY = 8147326905;
+
+const DEFAULT_TIMEOUT_MS = 10 * 60_000;
+const POLL_INTERVAL_MS = 2_000;
+
+let holder: Client | null = null;
+
+// Session-level advisory locks are silently useless on Neon's pooled endpoint:
+// PgBouncer runs in transaction mode, so the statement after the lock can land
+// on a different server connection. The lock must sit on a direct connection.
+function directConnectionString(urlString: string): string {
+  const url = new URL(urlString);
+  url.hostname = url.hostname.replace("-pooler", "");
+  return url.toString();
+}
+
+// pg_locks splits the 64-bit advisory key across classid (high word) and objid
+// (low word), so recombine before matching — otherwise this reports unrelated
+// advisory locks, including PgBouncer's own.
+async function describeHolders(client: Client): Promise<string> {
+  const { rows } = await client.query(
+    `select coalesce(nullif(a.application_name, ''), 'an unnamed session') as who,
+            date_trunc('second', now() - a.backend_start)::text as held
+       from pg_locks l
+       join pg_stat_activity a on a.pid = l.pid
+      where l.locktype = 'advisory'
+        and l.granted
+        and a.pid <> pg_backend_pid()
+        and (l.classid::bigint << 32) + l.objid::bigint = $1::bigint`,
+    [LOCK_KEY],
+  );
+
+  if (rows.length === 0) return "no visible holder";
+
+  return rows
+    .map((r: { who: string; held: string }) => `${r.who}, connected ${r.held}`)
+    .join("; ");
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function acquireTestDbLock(label: string): Promise<void> {
+  const connectionString = process.env.TEST_DATABASE_URL;
+  if (!connectionString) {
+    throw new Error(
+      "TEST_DATABASE_URL is not set — put it in .env.test.local at the repo root",
+    );
+  }
+
+  const timeoutMs = Number(
+    process.env.TEST_DB_LOCK_TIMEOUT_MS ?? DEFAULT_TIMEOUT_MS,
+  );
+
+  const client = new Client({
+    connectionString: directConnectionString(connectionString),
+    application_name: `test-db-lock:${label}`,
+  });
+  await client.connect();
+
+  const deadline = Date.now() + timeoutMs;
+  let warned = false;
+
+  for (;;) {
+    const { rows } = await client.query(
+      "select pg_try_advisory_lock($1::bigint) as locked",
+      [LOCK_KEY],
+    );
+
+    if (rows[0].locked) {
+      holder = client;
+      return;
+    }
+
+    if (Date.now() >= deadline) {
+      const who = await describeHolders(client);
+      await client.end();
+      throw new Error(
+        `Timed out after ${Math.round(timeoutMs / 1000)}s waiting for the shared test database. ` +
+          `Held by: ${who}. Another test run (local or CI) is using it; wait for it to finish.`,
+      );
+    }
+
+    if (!warned) {
+      warned = true;
+      console.warn(
+        `waiting for the shared test database — held by ${await describeHolders(client)}`,
+      );
+    }
+
+    await sleep(POLL_INTERVAL_MS);
+  }
+}
+
+// A dropped connection releases the lock, so a crashed or killed run cannot
+// wedge it; this is only the tidy path.
+export async function releaseTestDbLock(): Promise<void> {
+  if (!holder) return;
+
+  const client = holder;
+  holder = null;
+
+  try {
+    await client.query("select pg_advisory_unlock($1::bigint)", [LOCK_KEY]);
+  } finally {
+    await client.end();
+  }
+}

--- a/tests/setup/global.ts
+++ b/tests/setup/global.ts
@@ -1,6 +1,7 @@
 import { execSync } from "node:child_process";
 import { config } from "dotenv";
 import { fileURLToPath, URL } from "node:url";
+import { acquireTestDbLock, releaseTestDbLock } from "../helpers/dbLock";
 
 export default async function globalSetup() {
   config({
@@ -15,6 +16,8 @@ export default async function globalSetup() {
     );
   }
 
+  await acquireTestDbLock("vitest-integration");
+
   // Neon computes auto-suspend when idle; Prisma's default connect timeout can
   // fire before a cold compute finishes booting. Ensure connect_timeout is
   // generous enough to ride out the wake.
@@ -23,13 +26,15 @@ export default async function globalSetup() {
   // prisma.config.ts reads COUNCIL_DATABASE_URL — override it (not DATABASE_URL)
   // so `migrate deploy` targets the test branch, not production.
   await migrateDeploy({ ...process.env, COUNCIL_DATABASE_URL: migrateUrl });
+
+  return async () => {
+    await releaseTestDbLock();
+  };
 }
 
-// PR and main runs share one test database, so concurrent `migrate deploy`
-// invocations contend on Prisma's migration advisory lock; the loser times out
-// after 10s ("P1002 … Timed out trying to acquire a postgres advisory lock").
-// Neon can also drop the first connection to a cold compute (P1001). Both are
-// transient, so retry with linear backoff before failing. Genuine migration
+// Neon can drop the first connection to a cold compute (P1001), and a compute
+// still waking can time out on Prisma's migration advisory lock (P1002). Both
+// are transient, so retry with linear backoff before failing. Genuine migration
 // errors don't match these patterns and surface on the first attempt.
 const TRANSIENT_PATTERNS = [
   "P1002", // server reached but timed out (advisory-lock contention)


### PR DESCRIPTION
One Neon database backs every local test run and every CI job. Both suites seed it and reset it with `truncate ... cascade`, so two runs at once corrupt each other. `test-pr.yml` already serializes CI against CI with the `shared-test-db` concurrency group, but nothing stops a developer's `pnpm test:e2e` or `pnpm test:integration` from wiping a CI run's fixture mid-test, or the reverse.

This bit us on #342: CI failed on a new e2e test *and* on `submit-application.e2e.ts`, which that diff never touched, both with `element(s) not found` on a seeded row. A later run failed with `duplicate key ... rounds_chain_id_flow_council_address_key` and FK violations across `round_admins` / `applications` / `project_managers`, caused by a second worktree running the integration suite. Re-running on a quiet database went green with no code change.

## What this does

`globalSetup` (both vitest integration and Playwright) takes a Postgres session-level advisory lock and holds it for the run; teardown releases it. A second run waits rather than clobbering the first, and says so:

```
waiting for the shared test database — held by test-db-lock:vitest-integration, connected 00:00:12
```

It gives up after 10 minutes with an error naming the holder (`TEST_DB_LOCK_TIMEOUT_MS` to tune). Because the lock is session-scoped, a crashed or `kill -9`'d run releases it automatically — no stale-lock reaper needed.

Two details worth calling out:

- **The lock uses a direct connection, not the pooled `-pooler` endpoint.** Neon runs PgBouncer in transaction mode there, where session-level advisory locks are silently lost because the next statement can land on a different server connection. `directConnectionString()` strips `-pooler` from the host.
- **`pg_locks` splits the 64-bit advisory key** across `classid` (high word) and `objid` (low word). The holder query recombines them, otherwise it reports unrelated advisory locks, including PgBouncer's own.

Acquiring before `prisma migrate deploy` also removes the `P1002` migration-advisory-lock contention that `tests/setup/global.ts` currently retries around, since runs no longer overlap. The retry loop stays for genuinely transient cold-compute errors (`P1001`).

## Testing

Verified the lock directly against the real Neon database:

- **Mutual exclusion** — a second process waits and acquires only after the first releases (waited 9.09s behind a 9s holder).
- **Crash safety** — `kill -9` on the holder frees the lock; the next acquire returns in ~0.5s with no wait.
- **Timeout** — with `TEST_DB_LOCK_TIMEOUT_MS=4000` behind a longer holder, it fails with `Held by: test-db-lock:longHolder, connected 00:00:06`.
- **Holder reporting** — names only our key's holder (an earlier draft also blamed `pgbouncer`).
- **Suite wiring** — `pnpm test:integration` logs the wait line when the lock is held, and both the vitest teardown and the Playwright `globalTeardown` release it (confirmed by a fast re-acquire afterwards).

I could not get a green full integration run locally to demonstrate the end state: another worktree was running the suite throughout, and a run without this code does not participate in the lock. Baseline `main` fails identically under that interference, so it is not a regression from this change. CI is the real check.

## Limits

Only runs that have this code take the lock, so a branch predating it can still clobber a locked run. That resolves once this is on `main`. The durable fix is a Neon branch per run (`neondatabase/create-branch-action`), which needs a `NEON_API_KEY` and project id we do not currently have in repo secrets; this lock is complementary and costs nothing.
