### PR TITLE
Migrate subgraph endpoints to The Graph Network

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,5 @@
 NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=
+NEXT_PUBLIC_GRAPH_API_KEY=
 
 # Secret for signing email notification preference/unsubscribe tokens (HMAC).
 # Required: the notification token module throws if unset.

--- a/src/lib/apollo.ts
+++ b/src/lib/apollo.ts
@@ -16,6 +16,8 @@ const defaultOptions: DefaultOptions = {
   },
   watchQuery: {
     errorPolicy: "all",
+    skipPollAttempt: () =>
+      typeof document !== "undefined" && document.hidden,
   },
 };
 

--- a/src/lib/apollo.ts
+++ b/src/lib/apollo.ts
@@ -16,8 +16,7 @@ const defaultOptions: DefaultOptions = {
   },
   watchQuery: {
     errorPolicy: "all",
-    skipPollAttempt: () =>
-      typeof document !== "undefined" && document.hidden,
+    skipPollAttempt: () => typeof document !== "undefined" && document.hidden,
   },
 };
 

--- a/src/lib/networks.ts
+++ b/src/lib/networks.ts
@@ -5,6 +5,11 @@ import { Network } from "@/types/network";
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 const SPLITTER_FACTORY_NOT_DEPLOYED = "0x";
 
+const GRAPH_API_KEY = process.env.NEXT_PUBLIC_GRAPH_API_KEY ?? "";
+
+const graphNetworkSubgraph = (subgraphId: string) =>
+  `https://gateway.thegraph.com/api/${GRAPH_API_KEY}/subgraphs/id/${subgraphId}`;
+
 function isSplitterFactoryDeployed(network: Network | undefined): boolean {
   if (!network) return false;
   const addr = network.superAppSplitterFactory;
@@ -56,11 +61,13 @@ const networks: Network[] = [
       "https://subgraph-endpoints.superfluid.dev/arbitrum-one/protocol-v1",
     onRampLabel: "arbitrum",
     flowSplitter: "0xCbA99f104D17D06Ce4C80Be143f29b6fd44D3Ce9",
-    flowSplitterSubgraph:
-      "https://api.subgraph.ormilabs.com/api/public/f73714f1-9afa-4cd8-99bb-d4c0522c9d2b/subgraphs/flow-splitter-arbitrum-one/v0.0.3/gn",
+    flowSplitterSubgraph: graphNetworkSubgraph(
+      "XPmU91HwWpLGKqokzhpsktuUn5QmRVSBFehfkpFT572",
+    ),
     flowCouncilFactory: "0x589232342bfeCb372dbbc01d17e8D112a27fF125",
-    flowCouncilSubgraph:
-      "https://api.subgraph.ormilabs.com/api/public/f73714f1-9afa-4cd8-99bb-d4c0522c9d2b/subgraphs/flow-council-arbitrum-one/v0.4.2/gn",
+    flowCouncilSubgraph: graphNetworkSubgraph(
+      "5ia6BcTaQvPZAegF5yZLzATK5XpapgNMgqNPbaRp8RK5",
+    ),
     flowStateEligibilityNft: "0x6Ee1Cc715EAB6a1a661d34C1439Fc7f05Aa5f435",
     flowStateEligibilityMinScore: 15,
     superfluidHost: "0xCf8Acb4eF033efF16E8080aed4c7D5B9285D2192",
@@ -107,11 +114,13 @@ const networks: Network[] = [
       "https://subgraph-endpoints.superfluid.dev/base-mainnet/protocol-v1",
     onRampLabel: "base",
     flowSplitter: "0x25B64C200cf3362BaC6961353D38A1dbEB42e60E",
-    flowSplitterSubgraph:
-      "https://api.subgraph.ormilabs.com/api/public/f73714f1-9afa-4cd8-99bb-d4c0522c9d2b/subgraphs/flow-splitter-base/v0.0.2/gn",
+    flowSplitterSubgraph: graphNetworkSubgraph(
+      "6YjyTReJD2e7nksGyqhPA3VWTkAP2sUxqycAMP5MqNjv",
+    ),
     flowCouncilFactory: "0x589232342bfeCb372dbbc01d17e8D112a27fF125",
-    flowCouncilSubgraph:
-      "https://api.subgraph.ormilabs.com/api/public/f73714f1-9afa-4cd8-99bb-d4c0522c9d2b/subgraphs/flow-council-base/v0.4.2/gn",
+    flowCouncilSubgraph: graphNetworkSubgraph(
+      "9CgZ7PHVidLD1cxQ8cHbe7jcUxHBbuBS6JQXPhPUjAEo",
+    ),
     flowStateEligibilityNft: "0xA72c184738842626a920A8935092b7b3f35A3082",
     flowStateEligibilityMinScore: 15,
     superfluidHost: "0x4C073B3baB6d8826b8C5b229f3cfdC1eC6E47E74",
@@ -148,11 +157,13 @@ const networks: Network[] = [
       "https://subgraph-endpoints.superfluid.dev/celo-mainnet/protocol-v1",
     onRampLabel: "celo",
     flowSplitter: "0x0e9ddfd2ffdb0ba1ac3340d865193a7b6d4ea147",
-    flowSplitterSubgraph:
-      "https://api.goldsky.com/api/public/project_cmbkdj2bd7cr601uwafoe4u3y/subgraphs/flow-splitter-celo/v0.0.3/gn",
+    flowSplitterSubgraph: graphNetworkSubgraph(
+      "6LQPPz6wjuA7kfkEHHvShR9JQZ4Dx81J4eryMKU8yDwS",
+    ),
     flowCouncilFactory: "0x589232342bfeCb372dbbc01d17e8D112a27fF125",
-    flowCouncilSubgraph:
-      "https://api.goldsky.com/api/public/project_cmbkdj2bd7cr601uwafoe4u3y/subgraphs/flow-council-celo/v0.4.2/gn",
+    flowCouncilSubgraph: graphNetworkSubgraph(
+      "8QgPMn2diKDXjHFgwXorU9XGT7cW5Se5bLaRn9TAKSjt",
+    ),
     flowStateEligibilityNft: "",
     flowStateEligibilityMinScore: 15,
     superfluidHost: "0xA4Ff07cF81C02CFD356184879D953970cA957585",
@@ -189,11 +200,13 @@ const networks: Network[] = [
       "https://subgraph-endpoints.superfluid.dev/optimism-mainnet/protocol-v1",
     onRampLabel: "optimism",
     flowSplitter: "0x25B64C200cf3362BaC6961353D38A1dbEB42e60E",
-    flowSplitterSubgraph:
-      "https://api.subgraph.ormilabs.com/api/public/f73714f1-9afa-4cd8-99bb-d4c0522c9d2b/subgraphs/flow-splitter-optimism/v0.0.2/gn",
+    flowSplitterSubgraph: graphNetworkSubgraph(
+      "72GBzxX4BookcpjAybQMyuUMfm3gKCoueX5JHBnTt56j",
+    ),
     flowCouncilFactory: "0x589232342bfeCb372dbbc01d17e8D112a27fF125",
-    flowCouncilSubgraph:
-      "https://api.subgraph.ormilabs.com/api/public/f73714f1-9afa-4cd8-99bb-d4c0522c9d2b/subgraphs/flow-council-optimism/v0.4.2/gn",
+    flowCouncilSubgraph: graphNetworkSubgraph(
+      "ALonwCxpffeK1yBRj8ficdCJMcG5Xna1PuF3qgMMBFf2",
+    ),
     flowStateEligibilityNft: "0x09A62710a3BFC83aae2956F1D5B2363e4773Db7a",
     flowStateEligibilityMinScore: 15,
     superfluidHost: "0x567c4B141ED61923967cA25Ef4906C8781069a10",

--- a/src/lib/networks.ts
+++ b/src/lib/networks.ts
@@ -254,10 +254,10 @@ const networks: Network[] = [
     onRampLabel: "optimism",
     flowSplitter: "0xd53B8Bed28E122eA20dCC90d3991a614EC163a21",
     flowSplitterSubgraph:
-      "https://api.subgraph.ormilabs.com/api/public/f73714f1-9afa-4cd8-99bb-d4c0522c9d2b/subgraphs/flow-splitter-optimism-sepolia/v0.0.2/gn",
+      "https://api.goldsky.com/api/public/project_cmbkdj2bd7cr601uwafoe4u3y/subgraphs/flow-splitter-optimism-sepolia/v0.0.3/gn",
     flowCouncilFactory: "0xDD1a61127d910e6a7CD71788F0Ebb5A46DFDB424",
     flowCouncilSubgraph:
-      "https://api.subgraph.ormilabs.com/api/public/f73714f1-9afa-4cd8-99bb-d4c0522c9d2b/subgraphs/flow-council-optimism-sepolia/v0.4.2/gn",
+      "https://api.goldsky.com/api/public/project_cmbkdj2bd7cr601uwafoe4u3y/subgraphs/flow-council-optimism-sepolia/v0.4.2/gn",
     flowStateEligibilityNft: "0x1059A20C7aA0B4576B631d064730dB2E02940535",
     flowStateEligibilityMinScore: 0.5,
     superfluidHost: "0xd399e2Fb5f4cf3722a11F65b88FAB6B2B8621005",

--- a/src/lib/networks.ts
+++ b/src/lib/networks.ts
@@ -157,13 +157,11 @@ const networks: Network[] = [
       "https://subgraph-endpoints.superfluid.dev/celo-mainnet/protocol-v1",
     onRampLabel: "celo",
     flowSplitter: "0x0e9ddfd2ffdb0ba1ac3340d865193a7b6d4ea147",
-    flowSplitterSubgraph: graphNetworkSubgraph(
-      "6LQPPz6wjuA7kfkEHHvShR9JQZ4Dx81J4eryMKU8yDwS",
-    ),
+    flowSplitterSubgraph:
+      "https://api.goldsky.com/api/public/project_cmbkdj2bd7cr601uwafoe4u3y/subgraphs/flow-splitter-celo/v0.0.3/gn",
     flowCouncilFactory: "0x589232342bfeCb372dbbc01d17e8D112a27fF125",
-    flowCouncilSubgraph: graphNetworkSubgraph(
-      "8QgPMn2diKDXjHFgwXorU9XGT7cW5Se5bLaRn9TAKSjt",
-    ),
+    flowCouncilSubgraph:
+      "https://api.goldsky.com/api/public/project_cmbkdj2bd7cr601uwafoe4u3y/subgraphs/flow-council-celo/v0.4.2/gn",
     flowStateEligibilityNft: "",
     flowStateEligibilityMinScore: 15,
     superfluidHost: "0xA4Ff07cF81C02CFD356184879D953970cA957585",

--- a/src/lib/networks.ts
+++ b/src/lib/networks.ts
@@ -252,10 +252,10 @@ const networks: Network[] = [
     onRampLabel: "optimism",
     flowSplitter: "0xd53B8Bed28E122eA20dCC90d3991a614EC163a21",
     flowSplitterSubgraph:
-      "https://api.goldsky.com/api/public/project_cmbkdj2bd7cr601uwafoe4u3y/subgraphs/flow-splitter-optimism-sepolia/v0.0.3/gn",
+      "https://api.goldsky.com/api/public/project_cm2vlxq9s82qo01xtc11y9stm/subgraphs/flow-splitter-optimism-sepolia/v0.0.3/gn",
     flowCouncilFactory: "0xDD1a61127d910e6a7CD71788F0Ebb5A46DFDB424",
     flowCouncilSubgraph:
-      "https://api.goldsky.com/api/public/project_cmbkdj2bd7cr601uwafoe4u3y/subgraphs/flow-council-optimism-sepolia/v0.4.2/gn",
+      "https://api.goldsky.com/api/public/project_cm2vlxq9s82qo01xtc11y9stm/subgraphs/flow-council-optimism-sepolia/v0.4.2/gn",
     flowStateEligibilityNft: "0x1059A20C7aA0B4576B631d064730dB2E02940535",
     flowStateEligibilityMinScore: 0.5,
     superfluidHost: "0xd399e2Fb5f4cf3722a11F65b88FAB6B2B8621005",

--- a/src/lib/networks.ts
+++ b/src/lib/networks.ts
@@ -7,6 +7,12 @@ const SPLITTER_FACTORY_NOT_DEPLOYED = "0x";
 
 const GRAPH_API_KEY = process.env.NEXT_PUBLIC_GRAPH_API_KEY ?? "";
 
+if (!GRAPH_API_KEY) {
+  console.warn(
+    "NEXT_PUBLIC_GRAPH_API_KEY is not set: The Graph Network subgraph queries will fail",
+  );
+}
+
 const graphNetworkSubgraph = (subgraphId: string) =>
   `https://gateway.thegraph.com/api/${GRAPH_API_KEY}/subgraphs/id/${subgraphId}`;
 


### PR DESCRIPTION
Update the subgraph URLs in `networks.ts` to their new endpoints.

Also pauses Apollo polling in hidden tabs (`skipPollAttempt` on `document.hidden`) so backgrounded tabs stop querying while idle.
