### PR TITLE
Header product links: Flow Council, Flow Splitter, Flow QF

### DIFF
--- a/docs/platform/flow-qf.md
+++ b/docs/platform/flow-qf.md
@@ -6,8 +6,8 @@ sidebar_position: 3
 
 # Flow QF
 
-:::tip[Want to run a round?]
-We've designed and run Flow QF rounds, and we're happy to set one up for your ecosystem or community. [Get in touch on Telegram](https://t.me/+U6ZFRmOnFWo1ZGUx) if you want to run a round.
+:::tip[Want to run a Flow QF round?]
+Flow QF rounds aren't self-serve: we design and run them with you. [Get in touch on Telegram](https://t.me/+U6ZFRmOnFWo1ZGUx) or email [info@flowstate.network](mailto:info@flowstate.network) and we'll set one up for your ecosystem or community. More on [what that looks like](#run-a-flow-qf-round) below.
 :::
 
 Flow QF (aka Streaming Quadratic Funding, or SQF) is a novel implementation of [quadratic funding (QF)](https://www.wtfisqf.com/?grant=&grant=&grant=&grant=&match=1000), the public goods funding mechanism [introduced by Vitalik Buterin, Zoe Hitzig, & Glen Weyl](https://arxiv.org/pdf/1809.06421) and popularized in web3 by [Gitcoin](https://www.gitcoin.co/).
@@ -33,3 +33,17 @@ The periodic round structure also asks a lot of donors/voters. It’s difficult 
 Flow QF’s continuous model can also provide more funding predictability for grantees. Funds streamed through a Flow QF pool immediately hit the grantee’s account with incremental shifts in receipts.
 
 This velocity means amplified impact and efficiency with limited capital from funders. Take the [Geo Web](https://geoweb.network) protocol (where [Flow QF was invented](https://geoweb.land/governance)) for example. It generates ETH streams from its [PCO land market](https://docs.geoweb.network/concepts/partial-common-ownership/). Before Flow QF, these funds would idly accumulate in the treasury until being periodically dispersed. Now, the Geo Web’s ETH can immediately help grow the network (i.e., grow the ETH revenue the land market generates) and drive a public goods flywheel. This is how scrappy public goods can outcompete lavishly-funded behemoths.
+
+## Run a Flow QF round
+
+Unlike [Flow Councils](flow-councils/index.md) and [Flow Splitters](flow-splitters/index.md), Flow QF isn't a no-code launchpad. We run each round together with the funder, from design through wrap-up:
+
+- **Round design**: matching pool size and duration, network and token, eligibility criteria, and the matching parameters that fit your goals.
+- **Applications & review**: grantee onboarding, application collection, and review with your team.
+- **A round page**: where donors discover grantees and open their donation streams, with matching updating in real time.
+- **Donor & grantee support**: onboarding both sides of the round and keeping streams healthy while it runs.
+
+We've designed and run rounds like the [Geo Web](https://geoweb.land/governance)'s and the Octant Builder Accelerator. Tell us about your ecosystem, your budget, and when you'd like to start:
+
+- **Telegram**: [message us](https://t.me/+U6ZFRmOnFWo1ZGUx)
+- **Email**: [info@flowstate.network](mailto:info@flowstate.network)

--- a/src/app/home-page.tsx
+++ b/src/app/home-page.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect } from "react";
 import Link from "next/link";
-import { useRouter, useSearchParams } from "next/navigation";
 import { usePostHog } from "posthog-js/react";
 import Stack from "react-bootstrap/Stack";
 import Image from "react-bootstrap/Image";
@@ -21,8 +20,6 @@ export default function HomePage() {
     TargetAudience.FUNDERS,
   );
 
-  const router = useRouter();
-  const searchParams = useSearchParams();
   const { isMobile, isTablet, isSmallScreen, isBigScreen } = useMediaQuery();
   const postHog = usePostHog();
 
@@ -31,21 +28,6 @@ export default function HomePage() {
       postHog.startSessionRecording();
     }
   }, [postHog, postHog.decideEndpointWasHit]);
-
-  useEffect(() => {
-    const targetAudienceElem = document.getElementById("target-audience");
-
-    if (searchParams.get("for-funders")) {
-      setShowTargetAudience(TargetAudience.FUNDERS);
-      targetAudienceElem?.scrollIntoView();
-    } else if (searchParams.get("for-builders")) {
-      setShowTargetAudience(TargetAudience.BUILDERS);
-      targetAudienceElem?.scrollIntoView();
-    } else if (searchParams.get("for-everyone")) {
-      setShowTargetAudience(TargetAudience.EVERYONE);
-      targetAudienceElem?.scrollIntoView();
-    }
-  }, [router, searchParams]);
 
   return (
     <div className="hero-background w-100">
@@ -384,38 +366,26 @@ export default function HomePage() {
                       </Button>
                     </Link>
                     <Link
-                      href="https://farcaster.xyz/miniapps/0EyeQpCD0lSP/flowcaster"
-                      target="_blank"
+                      href="#schedule-consultation"
+                      onNavigate={(e) => {
+                        e.preventDefault();
+                        const elem = document.getElementById(
+                          "schedule-consultation",
+                        );
+                        elem?.scrollIntoView({
+                          behavior: "smooth",
+                        });
+                      }}
                       className={isMobile ? "w-100" : "w-50"}
                     >
                       <Button
                         variant="outline-secondary"
                         className="w-100 px-10 py-3 border-4 rounded-4 fs-lg fw-semi-bold"
                       >
-                        Flow Caster
+                        Custom
                       </Button>
                     </Link>
                   </Stack>
-                  <Link
-                    href="#schedule-consultation"
-                    onNavigate={(e) => {
-                      e.preventDefault();
-                      const elem = document.getElementById(
-                        "schedule-consultation",
-                      );
-                      elem?.scrollIntoView({
-                        behavior: "smooth",
-                      });
-                    }}
-                    className={isMobile ? "w-100" : "w-50"}
-                  >
-                    <Button
-                      variant="outline-secondary"
-                      className="w-100 mt-sm-4 px-10 py-3 border-4 rounded-4 fs-lg fw-semi-bold"
-                    >
-                      Custom
-                    </Button>
-                  </Link>
                 </>
               ) : (
                 <>
@@ -459,36 +429,6 @@ export default function HomePage() {
                         className="w-100 px-10 py-3 border-4 rounded-4 fs-lg fw-semi-bold"
                       >
                         Explore
-                      </Button>
-                    </Link>
-                  </Stack>
-                  <Stack
-                    direction="horizontal"
-                    gap={2}
-                    className="flex-wrap flex-sm-nowrap"
-                  >
-                    <Link
-                      href="https://farcaster.xyz/miniapps/0EyeQpCD0lSP/flowcaster"
-                      target="_blank"
-                      className={isMobile ? "w-100" : "w-50"}
-                    >
-                      <Button
-                        variant="outline-secondary"
-                        className="w-100 mt-4 px-10 py-3 border-4 rounded-4 fs-lg fw-semi-bold"
-                      >
-                        Flow Caster
-                      </Button>
-                    </Link>
-                    <Link
-                      href="https://farcaster.xyz/beamr"
-                      target="_blank"
-                      className={isMobile ? "w-100" : "w-50"}
-                    >
-                      <Button
-                        variant="outline-secondary"
-                        className="w-100 mt-4 px-10 py-3 border-4 rounded-4 fs-lg fw-semi-bold"
-                      >
-                        Beamr
                       </Button>
                     </Link>
                   </Stack>

--- a/src/app/home-page.tsx
+++ b/src/app/home-page.tsx
@@ -8,6 +8,7 @@ import Image from "react-bootstrap/Image";
 import Dropdown from "react-bootstrap/Dropdown";
 import Button from "react-bootstrap/Button";
 import { useMediaQuery } from "@/hooks/mediaQuery";
+import { FLOW_QF_DOCS_URL } from "@/lib/constants";
 
 enum TargetAudience {
   FUNDERS = "For funders",
@@ -296,7 +297,7 @@ export default function HomePage() {
                     className="flex-wrap flex-sm-nowrap"
                   >
                     <Link
-                      href="https://docs.flowstate.network/flow-qf"
+                      href={FLOW_QF_DOCS_URL}
                       target="_blank"
                       className={isMobile ? "w-100" : "w-50"}
                     >

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -10,6 +10,7 @@ import Toast from "react-bootstrap/Toast";
 import Alert from "react-bootstrap/Alert";
 import { useMediaQuery } from "@/hooks/mediaQuery";
 import useMailingList from "@/hooks/mailingList";
+import { FLOW_QF_DOCS_URL } from "@/lib/constants";
 
 export default function Footer() {
   const { isMobile } = useMediaQuery();
@@ -65,7 +66,7 @@ export default function Footer() {
               Flow Council
             </Link>
             <Link
-              href="https://docs.flowstate.network/flow-qf"
+              href={FLOW_QF_DOCS_URL}
               className="text-decoration-none text-white fs-5 fw-bold"
             >
               Flow QF

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -70,13 +70,6 @@ export default function Footer() {
             >
               Flow QF
             </Link>
-            <Link
-              href="https://farcaster.xyz/miniapps/0EyeQpCD0lSP/flowcaster"
-              target="_blank"
-              className="text-decoration-none text-white fs-5 fw-bold"
-            >
-              Flow Caster
-            </Link>
           </Stack>
           <Stack direction="vertical" gap={8} className="mb-30 mb-lg-0 me-10">
             <Link

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -22,10 +22,8 @@ export default function Header() {
   const { isMobile, isTablet, isSmallScreen } = useMediaQuery();
 
   const isHome = pathname === "/";
-  const flowCouncilHref = isHome ? "/flow-councils/launch" : "/flow-councils";
-  const flowSplitterHref = isHome
-    ? "/flow-splitters/launch"
-    : "/flow-splitters";
+  const flowCouncilHref = "/flow-councils";
+  const flowSplitterHref = "/flow-splitters";
 
   return (
     <header className="w-100">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -12,6 +12,8 @@ import Image from "react-bootstrap/Image";
 import Offcanvas from "react-bootstrap/Offcanvas";
 import { useMediaQuery } from "@/hooks/mediaQuery";
 
+const FLOW_QF_DOCS_URL = "https://docs.flowstate.network/flow-qf";
+
 export default function Header() {
   const [showMobileMenu, setShowMobileMenu] = useState(false);
 
@@ -19,6 +21,12 @@ export default function Header() {
   const pathname = usePathname();
   const params = useParams();
   const { isMobile, isTablet, isSmallScreen } = useMediaQuery();
+
+  const isHome = pathname === "/";
+  const flowCouncilHref = isHome ? "/flow-councils/launch" : "/flow-councils";
+  const flowSplitterHref = isHome
+    ? "/flow-splitters/launch"
+    : "/flow-splitters";
 
   return (
     <header className="w-100">
@@ -49,64 +57,35 @@ export default function Header() {
           )}
           {!isMobile && !isTablet && (
             <>
-              {pathname === "/" ? (
-                <Stack direction="horizontal" gap={2}>
-                  <Button
-                    variant="transparent"
-                    className={`${isSmallScreen ? "px-6" : "px-10"} py-4 fs-lg fw-bold`}
-                    style={{ whiteSpace: "nowrap" }}
-                    onClick={() => router.push("/?for-funders=true")}
-                  >
-                    For funders
-                  </Button>
-                  <Button
-                    variant="transparent"
-                    className={`${isSmallScreen ? "px-6" : "px-10"} py-4 fs-lg fw-bold`}
-                    style={{ whiteSpace: "nowrap" }}
-                    onClick={() => router.push("/?for-builders=true")}
-                  >
-                    For builders
-                  </Button>
-                  <Button
-                    variant="transparent"
-                    className={`${isSmallScreen ? "px-6" : "px-10"} py-4 fs-lg fw-bold`}
-                    style={{ whiteSpace: "nowrap" }}
-                    onClick={() => router.push("/?for-everyone=true")}
-                  >
-                    For everyone
-                  </Button>
-                </Stack>
-              ) : (
-                <Stack direction="horizontal" gap={2}>
-                  <Button
-                    variant="transparent"
-                    className={`${isSmallScreen ? "px-6" : "px-10"} py-4 fs-lg fw-bold border-0`}
-                    style={{ whiteSpace: "nowrap" }}
-                    onClick={() => router.push("/flow-councils")}
-                  >
-                    Flow Council
-                  </Button>
-                  <Button
-                    variant="transparent"
-                    className={`${isSmallScreen ? "px-6" : "px-10"} py-4 fs-lg fw-bold border-0`}
-                    style={{ whiteSpace: "nowrap" }}
-                    onClick={() => router.push("/flow-splitters")}
-                  >
-                    Flow Splitter
-                  </Button>
-                  <Button
-                    variant="link"
-                    href="https://farcaster.xyz/miniapps/0EyeQpCD0lSP/flowcaster"
-                    target="_blank"
-                    className={`${isSmallScreen ? "px-6" : "px-10"} py-4 fs-lg fw-bold border-0 text-decoration-none`}
-                    style={{ whiteSpace: "nowrap" }}
-                  >
-                    Flow Caster
-                  </Button>
-                </Stack>
-              )}
+              <Stack direction="horizontal" gap={2}>
+                <Button
+                  variant="transparent"
+                  className={`${isSmallScreen ? "px-6" : "px-10"} py-4 fs-lg fw-bold border-0`}
+                  style={{ whiteSpace: "nowrap" }}
+                  onClick={() => router.push(flowCouncilHref)}
+                >
+                  Flow Council
+                </Button>
+                <Button
+                  variant="transparent"
+                  className={`${isSmallScreen ? "px-6" : "px-10"} py-4 fs-lg fw-bold border-0`}
+                  style={{ whiteSpace: "nowrap" }}
+                  onClick={() => router.push(flowSplitterHref)}
+                >
+                  Flow Splitter
+                </Button>
+                <Button
+                  variant="link"
+                  href={FLOW_QF_DOCS_URL}
+                  target="_blank"
+                  className={`${isSmallScreen ? "px-6" : "px-10"} py-4 fs-lg fw-bold border-0 text-decoration-none`}
+                  style={{ whiteSpace: "nowrap" }}
+                >
+                  Flow QF
+                </Button>
+              </Stack>
               <Stack direction="horizontal" gap={isSmallScreen ? 4 : 6}>
-                {pathname === "/" && !isSmallScreen && (
+                {isHome && !isSmallScreen && (
                   <Stack
                     direction="horizontal"
                     gap={6}
@@ -154,7 +133,7 @@ export default function Header() {
                   </Stack>
                 )}
                 <Suspense>
-                  {pathname === "/" ? (
+                  {isHome ? (
                     <Link href="/explore">
                       <Button
                         className={`${isSmallScreen ? "px-6" : "px-10"} py-4 rounded-3 text-white fs-lg fw-bold`}
@@ -200,71 +179,34 @@ export default function Header() {
           </Button>
         </Offcanvas.Header>
         <Offcanvas.Body className="d-flex flex-column align-items-center gap-10 mt-20 px-8">
-          {pathname === "/" ? (
-            <>
-              <Button
-                variant="transparent"
-                className="px-10 py-4 fs-lg fw-bold border-0"
-                onClick={() => {
-                  router.push("/?for-funders=true");
-                  setShowMobileMenu(false);
-                }}
-              >
-                For funders
-              </Button>
-              <Button
-                variant="transparent"
-                className="px-10 py-4 fs-lg fw-bold border-0"
-                onClick={() => {
-                  router.push("/?for-builders=true");
-                  setShowMobileMenu(false);
-                }}
-              >
-                For builders
-              </Button>
-              <Button
-                variant="transparent"
-                className="px-10 py-4 fs-lg fw-bold border-0"
-                onClick={() => {
-                  router.push("/?for-everyone=true");
-                  setShowMobileMenu(false);
-                }}
-              >
-                For everyone
-              </Button>
-            </>
-          ) : (
-            <>
-              <Button
-                variant="transparent"
-                className="px-10 py-4 fs-lg fw-bold border-0"
-                onClick={() => {
-                  router.push("/flow-councils");
-                  setShowMobileMenu(false);
-                }}
-              >
-                Flow Council
-              </Button>
-              <Button
-                variant="transparent"
-                className="px-10 py-4 fs-lg fw-bold border-0"
-                onClick={() => {
-                  router.push("/flow-splitters");
-                  setShowMobileMenu(false);
-                }}
-              >
-                Flow Splitter
-              </Button>
-              <Button
-                variant="link"
-                href="https://farcaster.xyz/miniapps/0EyeQpCD0lSP/flowcaster"
-                target="_blank"
-                className="px-10 py-4 fs-lg fw-bold border-0 text-decoration-none"
-              >
-                Flow Caster
-              </Button>
-            </>
-          )}
+          <Button
+            variant="transparent"
+            className="px-10 py-4 fs-lg fw-bold border-0"
+            onClick={() => {
+              router.push(flowCouncilHref);
+              setShowMobileMenu(false);
+            }}
+          >
+            Flow Council
+          </Button>
+          <Button
+            variant="transparent"
+            className="px-10 py-4 fs-lg fw-bold border-0"
+            onClick={() => {
+              router.push(flowSplitterHref);
+              setShowMobileMenu(false);
+            }}
+          >
+            Flow Splitter
+          </Button>
+          <Button
+            variant="link"
+            href={FLOW_QF_DOCS_URL}
+            target="_blank"
+            className="px-10 py-4 fs-lg fw-bold border-0 text-decoration-none"
+          >
+            Flow QF
+          </Button>
           <Stack
             direction="horizontal"
             gap={6}
@@ -306,7 +248,7 @@ export default function Header() {
             </Button>
           </Stack>
           <Suspense>
-            {pathname === "/" ? (
+            {isHome ? (
               <Link
                 className="w-100"
                 href="/explore"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -11,8 +11,7 @@ import Button from "react-bootstrap/Button";
 import Image from "react-bootstrap/Image";
 import Offcanvas from "react-bootstrap/Offcanvas";
 import { useMediaQuery } from "@/hooks/mediaQuery";
-
-const FLOW_QF_DOCS_URL = "https://docs.flowstate.network/flow-qf";
+import { FLOW_QF_DOCS_URL } from "@/lib/constants";
 
 export default function Header() {
   const [showMobileMenu, setShowMobileMenu] = useState(false);

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -14,6 +14,7 @@ export const WALLET_CONNECT_PROJECT_ID =
 export const ZERO_ADDRESS =
   "0x0000000000000000000000000000000000000000" as Address;
 export const SUPERVISUAL_BASE_URL = "https://graph.flowstate.network";
+export const FLOW_QF_DOCS_URL = "https://docs.flowstate.network/flow-qf";
 export const OG_DEFAULT_IMAGE_URL = "https://flowstate.network/og_v2.png";
 // Consumed only by useEnsResolution, which reads [0] for ENS avatar CIDs.
 export const IPFS_GATEWAYS = ["https://ipfs.fleek.co"];


### PR DESCRIPTION
Replaces the audience links in the Home page header with the product links, removes Flow Caster, and gives the Flow QF docs page a real CTA (since Flow QF is the only product without a launch page, the header sends people to the docs).

## Header
- Home header: `For funders` / `For builders` / `For everyone` -> `Flow Council` (launch page), `Flow Splitter` (launch page), `Flow QF` (docs).
- App header: same three products; `Flow Council` / `Flow Splitter` keep pointing at the product pages, `Flow Caster` is replaced by `Flow QF`.
- The home/app branch for nav links collapsed into two hrefs, so both the desktop nav and the mobile offcanvas lost a duplicated block.

## Flow Caster removal
- Gone from the header (desktop + mobile), the footer, and the Home page "Learn more" buttons. Explore round cards are untouched.
- Also removed the now-unused `?for-funders` / `?for-builders` / `?for-everyone` deep links on the Home page (the audience tabs themselves stay), and the Beamr link.

## Docs
`docs/platform/flow-qf.md` gets a stronger top admonition (Telegram + email, "rounds aren't self-serve, we run them with you") and a new "Run a Flow QF round" section covering round design, applications & review, the round page, and donor/grantee support. The docs repo PR is autogenerated on merge.

## Verification
Drove the real header in a browser: home links land on `/flow-councils/launch` and `/flow-splitters/launch`, app links on `/flow-councils` and `/flow-splitters`, both mobile menus show the three products, and no `Flow Caster` string remains in the header, footer, or home page. Built the Docusaurus site with the updated page (no broken links). `pnpm typecheck`, `pnpm lint`, `pnpm prettier` pass.