### PR TITLE
feat(goodbuilders): surface the S4 SUP campaign on the explore card and voting page

### DIFF
--- a/src/app/explore/explore.tsx
+++ b/src/app/explore/explore.tsx
@@ -105,6 +105,7 @@ export default function Explore(props: ExploreProps) {
             activeStreamCount={goodBuildersS4FlowInfo.funderCount}
             tokenSymbol="G$"
             link="/goodbuilders-4"
+            showSupRewards
           />
           <RoundCard
             name="Core Contributors"

--- a/src/app/flow-councils/[chainId]/[councilId]/flow-council.tsx
+++ b/src/app/flow-councils/[chainId]/[councilId]/flow-council.tsx
@@ -16,6 +16,7 @@ import GranteeCardSkeleton from "@/app/flow-councils/components/GranteeCardSkele
 import FeedTab from "@/app/flow-councils/components/FeedTab";
 import RoundBanner from "@/app/flow-councils/components/RoundBanner";
 import RoundBannerSkeleton from "@/app/flow-councils/components/RoundBannerSkeleton";
+import SupCampaignBanner from "@/app/flow-councils/components/SupCampaignBanner";
 import GranteeDetails from "@/app/flow-councils/components/GranteeDetails";
 import Ballot from "@/app/flow-councils/components/Ballot";
 import DistributionPoolFunding from "@/app/flow-councils/components/DistributionPoolFunding";
@@ -26,6 +27,10 @@ import { useMediaQuery } from "@/hooks/mediaQuery";
 import useFlowCouncil from "../../hooks/flowCouncil";
 import useAnimateVoteBubble from "../../hooks/animateVoteBubble";
 import { networks } from "@/lib/networks";
+import {
+  CELO_CHAIN_ID,
+  GOODBUILDERS_S4_COUNCIL_ADDRESS,
+} from "@/app/flow-councils/lib/constants";
 import { shuffle, getPlaceholderImageSrc, generateColor } from "@/lib/utils";
 
 const SKELETON_COUNT = 4;
@@ -88,6 +93,9 @@ export default function FlowCouncil({
   const granteeSkeletons = Array.from({ length: SKELETON_COUNT }, (_, i) => (
     <GranteeCardSkeleton key={i} />
   ));
+  const isGoodBuildersS4 =
+    chainId === CELO_CHAIN_ID &&
+    councilId.toLowerCase() === GOODBUILDERS_S4_COUNCIL_ADDRESS;
 
   const getGrantee = useCallback(
     (recipient: {
@@ -320,6 +328,7 @@ export default function FlowCouncil({
         onMouseUp={clearZeroVotes}
         onTouchEnd={clearZeroVotes}
       >
+        {isGoodBuildersS4 && <SupCampaignBanner />}
         {isRoundLoading ? (
           <RoundBannerSkeleton />
         ) : (

--- a/src/app/flow-councils/components/SupCampaignBanner.tsx
+++ b/src/app/flow-councils/components/SupCampaignBanner.tsx
@@ -23,7 +23,11 @@ export default function SupCampaignBanner() {
       />
       <Card.Text className="m-0 fs-lg">
         Stream G$ to the GoodBuilders S4 Flow Council to earn $SUP:{" "}
-        <Card.Link href={LEARN_MORE_URL} target="_blank">
+        <Card.Link
+          href={LEARN_MORE_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           Learn more
         </Card.Link>
         .

--- a/src/app/flow-councils/components/SupCampaignBanner.tsx
+++ b/src/app/flow-councils/components/SupCampaignBanner.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import Stack from "react-bootstrap/Stack";
+import Card from "react-bootstrap/Card";
+import Image from "react-bootstrap/Image";
+
+const LEARN_MORE_URL =
+  "https://x.com/gooddollarorg/status/2086874244156362929?s=20";
+
+export default function SupCampaignBanner() {
+  return (
+    <Stack
+      direction="horizontal"
+      gap={3}
+      className="align-items-center mb-4 px-4 py-3 bg-light border border-2 border-dark rounded-4 lh-sm"
+    >
+      <Image
+        src="/sup.svg"
+        alt="SUP"
+        width={36}
+        height={36}
+        className="flex-shrink-0"
+      />
+      <Card.Text className="m-0 fs-lg">
+        Stream G$ to the GoodBuilders S4 Flow Council to earn $SUP:{" "}
+        <Card.Link href={LEARN_MORE_URL} target="_blank">
+          Learn more
+        </Card.Link>
+        .
+      </Card.Text>
+    </Stack>
+  );
+}

--- a/src/app/flow-councils/lib/constants.ts
+++ b/src/app/flow-councils/lib/constants.ts
@@ -37,6 +37,9 @@ export const GOODBUILDERS_COUNCIL_ADDRESSES: `0x${string}`[] = [
   "0xfabef1abae4998146e8a8422813eb787caa26ec2",
 ];
 
+export const GOODBUILDERS_S4_COUNCIL_ADDRESS: `0x${string}` =
+  "0x582e3314d4ef56c18930acb10bb64313525e7820";
+
 export const GOODDOLLAR_IDENTITY_ADDRESS: `0x${string}` =
   "0xC361A6E67822a0EDc17D899227dd9FC50BD62F42";
 


### PR DESCRIPTION
Surfaces the SUP campaign on GoodBuilders S4 in two places.

**Explore card.** `RoundCard` already had a `showSupRewards` prop that renders `/sup.svg` in the footer, unused since #303 removed the badges from the old cards. Turned back on for the S4 card.

**Voting page banner.** New `SupCampaignBanner` at the top of the council page, above the round banner, following the SUP copy pattern `OpenFlow` used to carry. The "Learn more" link opens the X post in a new tab.

`/flow-councils/[chainId]/[councilId]` is shared by every council, so the banner is gated to S4. That address wasn't referenced anywhere in `src` (only in a `next.config.mjs` redirect; `GOODBUILDERS_COUNCIL_ADDRESSES` holds the test and S3 addresses), so it's added as `GOODBUILDERS_S4_COUNCIL_ADDRESS`.

Verified locally: banner shows on S4 and not on S3, SUP icon on the S4 card only, banner wraps cleanly at 390px with the icon holding its size.
